### PR TITLE
Fix binary path to test the released version string

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -67,12 +67,13 @@ jobs:
         run: |
           set -euo pipefail
           EXPECTED_VERSION="${{ steps.extract-tag.outputs.tag }}"
+          BINARY_PATH="./${{ steps.shape-artifacts.outputs.binary }}"
           
           # Make binary executable
-          chmod +x ${{ steps.shape-artifacts.outputs.binary }}
+          chmod +x "$BINARY_PATH"
           
           # Get version from binary
-          VERSION=$(${{ steps.shape-artifacts.outputs.binary }} version)
+          VERSION=$("$BINARY_PATH" version)
           
           echo "Expected version: $EXPECTED_VERSION"
           echo "Actual version: $VERSION"


### PR DESCRIPTION
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix: properly quote binary path in version check script ([d1ddc83](https://github.com/asnowfix/home-automation/commit/d1ddc8319dc78d463c1b1d32246df4f3be07ba1e))
<!-- END-AUTO-GENERATED-COMMITS -->