### PR TITLE
Fix version validation condition

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -78,11 +78,15 @@ jobs:
           echo "Expected version: $EXPECTED_VERSION"
           echo "Actual version: $VERSION"
           
-          # Check if version matches the expected tag
-          if [[ "$VERSION" == "$EXPECTED_VERSION" ]]; then
+          # Normalize versions for comparison (strip 'v' prefix if present)
+          EXPECTED_NORMALIZED="${EXPECTED_VERSION#v}"
+          VERSION_NORMALIZED="${VERSION#v}"
+          
+          # Check if versions match (with or without 'v' prefix)
+          if [[ "$VERSION_NORMALIZED" == "$EXPECTED_NORMALIZED" ]]; then
             echo "✓ Binary version validation passed"
           else
-            echo "✗ Binary version validation failed: expected $EXPECTED_VERSION but got $VERSION" >&2
+            echo "✗ Binary version validation failed: expected $EXPECTED_NORMALIZED but got $VERSION_NORMALIZED" >&2
             exit 1
           fi
       - id: prepare-deb


### PR DESCRIPTION
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix: normalize version strings to handle optional 'v' prefix in version validation ([c717f92](https://github.com/asnowfix/home-automation/commit/c717f922e3eb1fc1b01ca5a433563b4b05d7894d))
<!-- END-AUTO-GENERATED-COMMITS -->