### PR TITLE
fix: update goreleaser version flag to use .Tag instead of .Version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,5 +18,5 @@ builds:
     ldflags:
       - -X main.Program=myhome
       - -X main.Repo={{.GitURL}}
-      - -X main.Version={{.Version}}
+      - -X main.Version={{.Tag}}
       - -X main.Commit={{.FullCommit}}


### PR DESCRIPTION
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix: update goreleaser version flag to use .Tag instead of .Version ([cf36229](https://github.com/asnowfix/home-automation/commit/cf362297ba03dd08a4c75e081da0fec422524cbc))
<!-- END-AUTO-GENERATED-COMMITS -->