### PR TITLE
fix: incorporate `go generate` in `goreleaser`

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -30,11 +30,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.23.x'
-      - id: go-generate
-        name: Run go generate
-        run: |
-          go generate ./internal/myhome/ui/...
-          go generate ./...
       - name: Extract tag name
         id: extract-tag
         run: |
@@ -167,11 +162,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23.0
-      - id: go-generate
-        name: Run go generate
-        run: |
-          go generate ./internal/myhome/ui/...
-          go generate ./...
       - id: build
         name: Build Windows Exectutable
         run: go build -o "myhome.exe" ".\\myhome"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,9 @@
 # .goreleaser.yml
 project_name: myhome
+before:
+  hooks:
+    - go generate ./internal/myhome/ui/...
+    - go generate ./...
 builds:
   - env: [CGO_ENABLED=0]
     goos:

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ generate:
 	$(GO) generate ./internal/myhome/ui/...
 	$(GO) generate ./...
 
+goreleaser:
+	$(GO) install github.com/goreleaser/goreleaser@latest
+#	$(GO) install github.com/goreleaser/goreleaser-pro@latest
+	goreleaser build --snapshot --clean --single-target
+
 # Build Debian package for current OS/ARCH (Linux only)
 # Usage: make debpkg [VERSION=X.Y.Z]
 # If VERSION is not specified, uses git describe


### PR DESCRIPTION
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix: add go generate steps to on-tag-main and package-release workflows ([3dcd282](https://github.com/asnowfix/home-automation/commit/3dcd2824872df185bb47785c4d0e89e62270f262))
- fix: move go generate steps from workflow to goreleaser hooks ([1503471](https://github.com/asnowfix/home-automation/commit/15034713c0edaa97898353a17faf100df64609b1))
<!-- END-AUTO-GENERATED-COMMITS -->