### PR TITLE
fix: disable Windows and Darwin builds in goreleaser (packaging not y…

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,8 +9,9 @@ builds:
   - env: [CGO_ENABLED=0]
     goos:
       - linux
-      - windows
-      - darwin
+      # FIXME: goreleaser can build for windows and darwin but they are not supported in packaging
+      # - windows
+      # - darwin
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
…et supported)

- Commented out Windows and Darwin in .goreleaser.yml goos list
- Added FIXME comment noting goreleaser can build but packaging doesn't support these platforms yet
- Keeps only Linux builds enabled for now<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix: disable Windows and Darwin builds in goreleaser (packaging not yet supported) ([c50473b](https://github.com/asnowfix/home-automation/commit/c50473bf3e355945bac907c67f4e28e158056060))
<!-- END-AUTO-GENERATED-COMMITS -->