### PR TITLE
refactor: reassign bottom-left switch from external-stairs to lampe-b…

### DIFF
--- a/internal/shelly/scripts/front-door-switch.js
+++ b/internal/shelly/scripts/front-door-switch.js
@@ -21,7 +21,7 @@ Shelly.addEventHandler(function (event) {
             //     body: JSON.stringify({ "id": 0 })
             // });
         }
-        // top-right switch - lustre
+        // top-right switch
         if (event.id === 0 && event.info.state === true) {
             print("Toggle lustre light");
             MQTT.publish("shelly1minig3-84fce63bf464/rpc", JSON.stringify({"method":"Switch.Toggle", "params":{"id":0}}), 0, false);
@@ -30,16 +30,13 @@ Shelly.addEventHandler(function (event) {
             //     body: JSON.stringify({ "id": 0 })
             // });
         }
-        // bottom-right switch - lumiere-parking
+        // bottom-right switch
         if (event.id === 3 && event.info.state === true) {
             print("Toggle lumiere-parking light");
             MQTT.publish("shellypro2-2cbcbb9fb834/rpc", JSON.stringify({"method":"Switch.Toggle", "params":{"id":1}}), 0, false);
             // Shelly.call("HTTP.GET", {
             //   url: 'http://shellypro2-2cbcbb9fb834.local/rpc/HTTP.GET?url="http://192.168.33.18/rpc/Switch.Toggle?id=1"'
             // });
-        }
-        // bottom-left switch - external-stairs
-        if (event.id === 2 && event.info.state === true) {
             print("Toggle external-stairs light");
             // Call "escalier-exterieur.local" via "old-front-door-light.local"
             // $ curl -X GET "http://shelly1minig3-543204641d24.local/rpc/HTTP.GET?url=\"http://192.168.33.18/rpc/Switch.Toggle?id=0\""
@@ -47,6 +44,17 @@ Shelly.addEventHandler(function (event) {
             MQTT.publish("shelly1minig3-543204641d24/rpc", JSON.stringify({"method":"Switch.Toggle", "params":{"id":0}}), 0, false);
             // Shelly.call("HTTP.GET", {
             //   url: 'http://shelly1minig3-543204641d24.local/rpc/HTTP.GET?url="http://192.168.33.18/rpc/Switch.Toggle?id=0"'
+            // });
+        }
+        // bottom-left switch
+        if (event.id === 2 && event.info.state === true) {
+            print("Toggle lampe-buffet-entree");
+            // Call "lampe-buffet-entree.local"
+            // $ curl -X GET "http://shellyplugsg3-e4b323382ea4.local/rpc/HTTP.GET?url=\"http://192.168.33.18/rpc/Switch.Toggle?id=0\""
+            // {"code":200, "message":"OK", "headers":{"Connection": "close","Content-Length": "15","Content-Type": "application/json","Server": "ShellyHTTP/1.0.0"}, "body":"{\"was_on\":true}"}
+            MQTT.publish("shellyplugsg3-e4b323382ea4/rpc", JSON.stringify({"method":"Switch.Toggle", "params":{"id":0}}), 0, false);
+            // Shelly.call("HTTP.GET", {
+            //   url: 'http://shellyplugsg3-e4b323382ea4.local/rpc/HTTP.GET?url="http://192.168.33.18/rpc/Switch.Toggle?id=0"'
             // });
         }
     } catch (e) {


### PR DESCRIPTION
…uffet-entree

- Moved external-stairs toggle logic from bottom-left (id=2) to bottom-right (id=3) switch
- Assigned bottom-left switch to control lampe-buffet-entree via shellyplugsg3-e4b323382ea4
- Removed device-specific names from switch comments for clarity
- Updated MQTT publish targets and commented HTTP.GET examples accordingly<!-- AUTO-GENERATED-COMMITS -->

## Commits

- refactor: reassign bottom-left switch from external-stairs to lampe-buffet-entree ([8471f3a](https://github.com/asnowfix/home-automation/commit/8471f3a61ce413f7207047bb675c6033ee2446b6))
<!-- END-AUTO-GENERATED-COMMITS -->