### PR TITLE
fix: ensure MQTT client connects to localhost when using embedded broker

### DIFF
--- a/myhome/mqtt/server.go
+++ b/myhome/mqtt/server.go
@@ -112,6 +112,10 @@ func Broker(ctx context.Context, log logr.Logger, resolver mynet.Resolver, progr
 		}
 
 		log.Info("Started new MQTT broker", "mdns_server", mdnsServer, "mdns_service", ZEROCONF_SERVICE)
+
+		// Give mDNS a moment to propagate before clients try to connect
+		time.Sleep(500 * time.Millisecond)
+		log.Info("MQTT broker ready for client connections")
 	} else {
 		log.Info("Started new MQTT broker (mDNS disabled)")
 	}


### PR DESCRIPTION
- Added mqttBrokerAddr variable to conditionally set broker address
- Set mqttBrokerAddr to "localhost" when embedded broker is enabled
- Use options.Flags.MqttBroker when embedded broker is disabled
- Added 500ms delay after mDNS propagation to prevent client connection race condition
- Added log message indicating broker is ready for client connections<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix: ensure MQTT client connects to localhost when using embedded broker ([3082ebe](https://github.com/asnowfix/home-automation/commit/3082ebe40b57cc414ff106103bf6e4e1485847c7))
<!-- END-AUTO-GENERATED-COMMITS -->