### PR TITLE
feat: add broker readiness check to prevent client connection race co…

### DIFF
--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -93,6 +93,11 @@ func (d *daemon) Run() error {
 			log.Error(err, "Failed to initialize MyHome")
 			return err
 		}
+		// Wait for broker to be ready to accept connections
+		if err := mqttserver.WaitForBrokerReady(d.ctx, log.WithName("mqtt.Broker"), 5*time.Second); err != nil {
+			log.Error(err, "MQTT broker failed to become ready")
+			return err
+		}
 		// Connect to localhost when using embedded broker
 		mqttBrokerAddr = "localhost"
 	} else {


### PR DESCRIPTION
…ndition

- Implemented WaitForBrokerReady function to poll TCP connection with 10ms intervals
- Added 5-second timeout with attempt counting for broker availability
- Integrated readiness check in daemon.Run() before setting mqttBrokerAddr to localhost
- Added context cancellation support during wait loop
- Returns error if broker doesn't become ready within timeout period
- Replaces previous 500ms fixed delay with active connection<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat: add broker readiness check to prevent client connection race condition ([f91cc17](https://github.com/asnowfix/home-automation/commit/f91cc170fe1df3fec96887c41c6062b0af1626c2))
<!-- END-AUTO-GENERATED-COMMITS -->