### PR TITLE
fix: improve MQTT broker initialization with configurable readiness checks and enhanced logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,24 @@
             }
         },
         {
-            "name": "myhome daemon (w/o MQTT broker) DEBUG",
+            "name": "myhome daemon (full, no-mDNS) DEBUG",
+            "type": "go",
+            "request": "launch",
+            "program": "${workspaceFolder}/myhome",
+            "args": [
+                "daemon", "run",
+                "--debug",
+                "-P", "myhome-no-mdns.prof",
+                "--ui-port", "6081",
+                "--no-mdns-publish",
+                "-I", "myhome-local"
+            ],
+            "env": {
+                "MYHOME_LOG": "stderr"
+            }
+        },
+        {
+            "name": "myhome daemon (w/o MQTT broker & no-mDNS) DEBUG",
             "type": "go",
             "request": "launch",
             "program": "${workspaceFolder}/myhome",
@@ -56,14 +73,14 @@
             }
         },
         {
-            "name": "myhome daemon (w/o MQTT broker) VERBOSE",
+            "name": "myhome daemon (w/o MQTT broker & no-mDNS) VERBOSE",
             "type": "go",
             "request": "launch",
             "program": "${workspaceFolder}/myhome",
             "args": [
                 "daemon", "run",
                 "--verbose",
-                "-P", "myhome-wo-broker.prof",
+                "-P", "myhome-wo-broker-no-mdns.prof",
                 "-B", "192.168.1.2",
                 "--ui-port", "6081",
                 "--no-mdns-publish",
@@ -81,7 +98,7 @@
             "args": [
                 "daemon", "run",
                 "--debug",
-                "-P", "myhome-wo-broker.prof",
+                "-P", "myhome-wo-broker-no-mdns.prof",
                 "-B", "192.168.1.2",
                 "--ui-port", "6081",
                 "--enable-gen1-proxy",
@@ -111,7 +128,7 @@
             "args": ["--debug", "daemon", "run",
                 "-B", "192.168.1.2",
                 "--ui-port", "6081",
-                "-P", "myhome-wo-broker.prof",
+                "-P", "myhome-wo-broker-no-mdns.prof",
                 "-B", "192.168.1.2",
                 "-E", "events",
                 "--no-mdns-publish",
@@ -128,7 +145,7 @@
             "program": "${workspaceFolder}/myhome",
             "args": [
                 "--debug", "daemon", "run",
-                "-P", "myhome-wo-broker.prof",
+                "-P", "myhome-wo-broker-no-mdns.prof",
                 "-D"
             ],
             "env": {

--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -43,6 +43,15 @@ daemon:
   # MQTT broker address (leave empty to use embedded broker)
   # mqtt_broker: "192.168.1.2"
   
+  # Initial delay before checking if embedded MQTT broker is ready
+  # Gives the broker time to complete async initialization after Serve() returns
+  # Default: 500ms
+  # broker_readiness_initial_delay: 500ms
+  
+  # Timeout for waiting for embedded MQTT broker to be ready
+  # Default: 30s
+  # broker_readiness_timeout: 30s
+  
   # mDNS lookup timeout
   # mdns_timeout: 7s
   


### PR DESCRIPTION

- Added broker_readiness_initial_delay and broker_readiness_timeout configuration options to myhome-example.yaml
- Moved WaitForBrokerReady from mqtt/server.go to mqtt/client.go with MQTT client-based connection testing
- Implemented exponential backoff (100ms to 5s) for broker readiness checks instead of fixed 10ms polling
- Changed broker address format to include port (localhost:1883) for proper<!-- AUTO-GENERATED-COMMITS -->

## Commits

- refactor: improve MQTT broker initialization with configurable readiness checks and enhanced logging ([0926a3f](https://github.com/asnowfix/home-automation/commit/0926a3f4116d42c24baed177f6a6bc7b9f8ce148))
<!-- END-AUTO-GENERATED-COMMITS -->