### PR TITLE
bugfix: create zeroconf resolver on-demand in BrowseService instead of storing as struct field (stability)

### DIFF
--- a/internal/myhome/net/resolver.go
+++ b/internal/myhome/net/resolver.go
@@ -45,7 +45,6 @@ type resolver struct {
 	log         logr.Logger
 	started     bool
 	mdns        *mdns.Conn
-	zeroconf    *zeroconf.Resolver
 	mdnsTimeout time.Duration
 }
 
@@ -76,19 +75,11 @@ func (r *resolver) start(ctx context.Context) Resolver {
 		return r
 	}
 
-	iface, ip, err := MainInterface(r.log)
+	_, ip, err := MainInterface(r.log)
 	if err != nil {
 		r.log.Error(err, "Unable to find main interface")
 		return nil
 	}
-
-	zc, err := zeroconf.NewResolver(zeroconf.SelectIPTraffic(zeroconf.IPv4AndIPv6), zeroconf.SelectIfaces([]net.Interface{*iface}))
-	if err != nil {
-		r.log.Error(err, "Failed to initialize ZeroConf resolver")
-		return nil
-	}
-
-	r.zeroconf = zc
 
 	addr4, err := net.ResolveUDPAddr("udp4", mdns.DefaultAddressIPv4)
 	if err != nil {
@@ -237,7 +228,18 @@ func (r *resolver) LookupService(ctx context.Context, service string) (*url.URL,
 func (r *resolver) BrowseService(ctx context.Context, service, domain string, entries chan<- *zeroconf.ServiceEntry) error {
 	r.start(ctx)
 	r.waitForStart(ctx)
-	return r.zeroconf.Browse(ctx, service, domain, entries)
+
+	iface, _, err := MainInterface(r.log)
+	if err != nil {
+		return err
+	}
+
+	resolver, err := zeroconf.NewResolver(zeroconf.SelectIPTraffic(zeroconf.IPv4AndIPv6), zeroconf.SelectIfaces([]net.Interface{*iface}))
+	if err != nil {
+		return err
+	}
+
+	return resolver.Browse(ctx, service, domain, entries)
 }
 
 // PublishService registers a Zeroconf/DNS-SD service and ensures the resolver is started.


### PR DESCRIPTION


- Removed zeroconf field from resolver struct
- Modified BrowseService to create new zeroconf.Resolver instance when called
- Changed MainInterface call in start() to use blank identifier for unused iface parameter
- Moved MainInterface call and zeroconf.NewResolver creation into BrowseService method<!-- AUTO-GENERATED-COMMITS -->

## Commits

- refactor: create zeroconf resolver on-demand in BrowseService instead of storing as struct field ([69d274e](https://github.com/asnowfix/home-automation/commit/69d274ee0d7374848871040dda087f665dc96dc0))
<!-- END-AUTO-GENERATED-COMMITS -->