### PR TITLE
fix(logs): reduce high-frequency sensor update noise in syslog

### DIFF
--- a/internal/myhome/shelly/blu/listener.go
+++ b/internal/myhome/shelly/blu/listener.go
@@ -118,7 +118,7 @@ func StartBLUListener(ctx context.Context, mc mqtt.Client, registry DeviceRegist
 					log.V(1).Info("Failed to update sensor in cache", "error", cacheErr, "device_id", deviceID)
 				}
 				if sseBroadcaster != nil {
-					log.Info("Broadcasting BLU sensor update via SSE", "device_id", deviceID, "sensor", sensor, "value", value)
+					log.V(1).Info("Broadcasting BLU sensor update via SSE", "device_id", deviceID, "sensor", sensor, "value", value)
 					sseBroadcaster.BroadcastSensorUpdate(deviceID, sensor, value)
 				}
 			}

--- a/internal/myhome/ui/sse.go
+++ b/internal/myhome/ui/sse.go
@@ -115,7 +115,11 @@ func (b *SSEBroadcaster) broadcast(event string, data interface{}) {
 		delete(b.clients, ch)
 		close(ch)
 	}
-	b.log.Info("Broadcast complete", "event", event, "data", data, "sent", sentCount, "skipped", skippedCount, "evicted", len(toEvict))
+	if len(toEvict) > 0 {
+		b.log.Info("Evicted slow SSE clients", "event", event, "sent", sentCount, "skipped", skippedCount, "evicted", len(toEvict))
+	} else {
+		b.log.V(1).Info("Broadcast complete", "event", event, "sent", sentCount, "skipped", skippedCount)
+	}
 }
 
 // SensorUpdateData represents a sensor value update

--- a/linux/systemd/myhome.service
+++ b/linux/systemd/myhome.service
@@ -28,7 +28,6 @@ RuntimeMaxSec=21600
 
 # Environment variables
 Environment=HOME=/var/lib/myhome
-Environment=MYHOME_LOG=stderr
 
 [Install]
 # multi-user.target normally defines a system state where all network services


### PR DESCRIPTION
## Summary

- **Remove `MYHOME_LOG=stderr` from systemd unit** — the variable was redundant (systemd's `JOURNAL_STREAM`/`INVOCATION_ID` already cause `logWriter()` to pick stderr), but was silently tripping `isRunningUnderDebugger()` and forcing debug log level on the production daemon
- **Demote BLU listener trace log to V(1)** — "Broadcasting BLU sensor update via SSE" fires per-sensor per-reading; it's a subsystem hop, not an operational event
- **Split SSE broadcast completion log** — only logs at Info when clients are evicted (notable); the routine zero-client case goes to V(1)

## Test plan

- [ ] `make test` passes (verified locally)
- [ ] After deploying updated unit: `systemctl daemon-reload && systemctl restart myhome`, confirm the six per-sensor-reading entries no longer appear in `journalctl -u myhome -f`
- [ ] Confirm slow-client eviction still logs at Info when it occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(logs): reduce high-frequency sensor update noise in syslog ([1523a72](https://github.com/asnowfix/home-automation/commit/1523a72fd1ea3b31d28ddbe000a16ce6407a59af))
<!-- END-AUTO-GENERATED-COMMITS -->