### PR TITLE
fix(pool): create schedules on all devices and add software fuse

### DIFF
--- a/docs/pool-pump.md
+++ b/docs/pool-pump.md
@@ -106,9 +106,35 @@ The `in_mode: detached` switch config prevents the *physical input* from directl
 
 ---
 
+## Software Fuse (Anti-Cycling Protection)
+
+Prevents rapid relay cycling that generates repeated motor inrush currents and trips circuit breakers. The fuse monitors output state changes regardless of their source (schedules, buttons, MQTT, water supply).
+
+### Parameters
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `FUSE_WINDOW_MS` | 120 000 ms (2 min) | Sliding window for counting state changes |
+| `FUSE_MAX_CHANGES` | 4 | Max transitions allowed per window |
+| `FUSE_COOLDOWN_MS` | 300 000 ms (5 min) | Lockout duration after the fuse trips |
+
+### Behaviour
+1. Every call to `activateOutput()` that actually changes the relay state (on→off or off→on) records a timestamp.
+2. Before any **ON** activation, `fuseAllowOn()` prunes stale entries, then checks the count.
+3. If the count reaches `FUSE_MAX_CHANGES`, the fuse **trips**: all switches are turned off and all ON activations are refused.
+4. After `FUSE_COOLDOWN_MS` elapses, the fuse resets automatically and normal operation resumes.
+5. **OFF activations (`outputId = -1`) always pass** — safety takes precedence over the fuse.
+
+### Normal operation budget
+A start/stop cycle produces 2 state changes (on + off). The threshold of 4 allows two full cycles plus margin — well above the one cycle per scheduled period (night run or day run).
+
+### No extra timers
+The fuse uses only in-memory variables (`FUSE_CHANGES` array, `FUSE_TRIPPED` flag, `FUSE_TRIP_TIME` timestamp). It does not allocate timers; the cooldown is checked lazily on the next activation attempt.
+
+---
+
 ## Schedules
 
-Schedules are created on Pro3 devices only (detected by switch count). Managed via `ctl pool add` using a **delete-and-recreate** strategy (no incremental reconciliation).
+Schedules are created on **all devices** in the mesh. Each device's script self-selects via `isMyTurnToRun()` — only the preferred device activates on schedule events, others ignore them. Managed via `ctl pool setup` using a **delete-and-recreate** strategy (no incremental reconciliation).
 
 | Schedule | Timespec | Handler | Default state |
 |----------|----------|---------|---------------|

--- a/internal/myhome/shelly/script/pool.go
+++ b/internal/myhome/shelly/script/pool.go
@@ -194,12 +194,10 @@ func (s *PoolService) setupDevice(ctx context.Context, via types.Channel, sd *sh
 	}
 	time.Sleep(500 * time.Millisecond)
 
-	// Only reconcile schedules on Pro3 (detected by having 3+ switches)
-	// For now, we assume first device is Pro3 - schedules are created there
-	if deviceID == pro3ID {
-		if err := s.reconcileSchedules(ctx, via, sd, int(scriptResult)); err != nil {
-			return fmt.Errorf("failed to reconcile schedules: %w", err)
-		}
+	// Reconcile schedules on every device in the mesh — each device's script
+	// self-selects via isMyTurnToRun() so only the preferred device activates.
+	if err := s.reconcileSchedules(ctx, via, sd, int(scriptResult)); err != nil {
+		return fmt.Errorf("failed to reconcile schedules: %w", err)
 	}
 
 	s.log.Info("Device setup complete", "device", sd.Name())

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -869,8 +869,75 @@ function setOutput(outputId, on, callback) {
   Shelly.call("Switch.Set", {id: outputId, on: on}, callback);
 }
 
+// === SOFTWARE FUSE (ANTI-CYCLING PROTECTION) ===
+// Prevents rapid relay cycling that generates repeated motor inrush currents
+// and trips circuit breakers. Tracks output state changes in a sliding window;
+// if too many transitions occur, the fuse "trips": all switches are turned off
+// and ON activations are refused for a cooldown period.
+// OFF activations (-1) always pass — safety trumps the fuse.
+var FUSE_WINDOW_MS = 120000;      // 2-minute sliding window
+var FUSE_MAX_CHANGES = 4;         // max state changes per window
+var FUSE_COOLDOWN_MS = 300000;    // 5-minute cooldown after trip
+var FUSE_CHANGES = [];            // timestamps of recent state changes
+var FUSE_TRIPPED = false;
+var FUSE_TRIP_TIME = 0;
+
+function fuseRecord() {
+  FUSE_CHANGES.push(Date.now());
+}
+
+function fuseAllowOn() {
+  var now = Date.now();
+
+  // If tripped, check cooldown
+  if (FUSE_TRIPPED) {
+    if (now - FUSE_TRIP_TIME >= FUSE_COOLDOWN_MS) {
+      log("FUSE: cooldown expired, resetting");
+      FUSE_TRIPPED = false;
+      FUSE_CHANGES = [];
+      return true;
+    }
+    log("FUSE: tripped, refusing activation (cooldown remaining:",
+        Math.round((FUSE_COOLDOWN_MS - (now - FUSE_TRIP_TIME)) / 1000), "s)");
+    return false;
+  }
+
+  // Prune entries outside the window (no shift — manual loop per Shelly constraint)
+  var recent = [];
+  for (var i = 0; i < FUSE_CHANGES.length; i++) {
+    if (now - FUSE_CHANGES[i] < FUSE_WINDOW_MS) {
+      recent.push(FUSE_CHANGES[i]);
+    }
+  }
+  FUSE_CHANGES = recent;
+
+  // Check threshold
+  if (FUSE_CHANGES.length >= FUSE_MAX_CHANGES) {
+    log("FUSE: TRIPPED — " + FUSE_CHANGES.length + " state changes in " +
+        (FUSE_WINDOW_MS / 1000) + "s window. Blocking ON activations for " +
+        (FUSE_COOLDOWN_MS / 1000) + "s");
+    FUSE_TRIPPED = true;
+    FUSE_TRIP_TIME = now;
+    turnOffAllSwitches();
+    return false;
+  }
+
+  return true;
+}
+
 function activateOutput(outputId, callback) {
   log("Activating output:", outputId);
+
+  // Software fuse: always allow OFF (-1), check fuse for ON activations
+  if (outputId !== -1 && !fuseAllowOn()) {
+    log("FUSE: activation refused, forcing off");
+    outputId = -1;
+  }
+
+  // Record actual state changes for fuse tracking
+  if (outputId !== STATE.activeOutput) {
+    fuseRecord();
+  }
 
   if (STATE.deviceType === "pro3") {
     safeActivatePro3(outputId, function() {


### PR DESCRIPTION
Schedules were only created on Pro3, so when preferred was set to Pro1 the night pump run never activated. Now all mesh devices get schedules and each self-selects via isMyTurnToRun().

Add anti-cycling software fuse in activateOutput(): tracks relay state changes in a 2-minute sliding window and trips (all off + 5-min lockout) after 4 transitions, preventing repeated motor inrush from tripping circuit breakers.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool): create schedules on all devices and add software fuse ([d979d92](https://github.com/asnowfix/home-automation/commit/d979d92528f5dccd4d8a2964ffcfbb940803855e))
<!-- END-AUTO-GENERATED-COMMITS -->