### PR TITLE
fix(blu-listener): break recursive KVS callback chains with Timer.set deferral

### DIFF
--- a/internal/shelly/scripts/blu-listener.js
+++ b/internal/shelly/scripts/blu-listener.js
@@ -430,24 +430,30 @@ function processKvsKey(k, newMap, onComplete) {
   Shelly.call("KVS.Get", { key: k }, onProcessKvsKeyResponse.bind(null, k, newMap, onComplete))
 }
 
+// Timer.set(0) breaks the synchronous call chain so the stack resets
+// between iterations, avoiding both stack overflow and nested-anon limits.
+
+function continueLoadIlluminance(macs, callback, index) {
+  loadIlluminanceStatesSequentially(macs, callback, index);
+}
+
+function onOneIlluminanceLoaded(macs, callback, index) {
+  Timer.set(0, false, continueLoadIlluminance.bind(null, macs, callback, index + 1));
+}
+
 function loadIlluminanceStatesSequentially(macs, callback, index) {
   if (index >= macs.length) {
-    // All states loaded
     if (callback) callback();
     return;
   }
-  
-  // Load one state at a time
-  loadIlluminanceState(macs[index], loadIlluminanceStatesSequentially.bind(null, macs, callback, index + 1));
+  loadIlluminanceState(macs[index], onOneIlluminanceLoaded.bind(null, macs, callback, index));
 }
 
 function loadAllIlluminanceStates(macs, callback) {
-  if (macs.length === 0) {
+  if (!macs || macs.length === 0) {
     if (callback) callback();
     return;
   }
-  
-  // Process sequentially to avoid "too many calls in progress"
   loadIlluminanceStatesSequentially(macs, callback, 0);
 }
 
@@ -461,15 +467,20 @@ function onAllKeysProcessed(newMap, callback) {
   loadAllIlluminanceStates(Object.keys(newMap), onAllIlluminanceStatesLoaded.bind(null, callback));
 }
 
+function continueLoadKeys(list, newMap, callback, index) {
+  processKeysSequentially(list, newMap, callback, index);
+}
+
+function onOneKeyLoaded(list, newMap, callback, index) {
+  Timer.set(0, false, continueLoadKeys.bind(null, list, newMap, callback, index + 1));
+}
+
 function processKeysSequentially(list, newMap, callback, index) {
   if (index >= list.length) {
-    // All keys processed
     onAllKeysProcessed(newMap, callback);
     return;
   }
-  
-  // Process one key at a time
-  processKvsKey(list[index], newMap, processKeysSequentially.bind(null, list, newMap, callback, index + 1));
+  processKvsKey(list[index], newMap, onOneKeyLoaded.bind(null, list, newMap, callback, index));
 }
 
 function onKvsListResponse(callback, resp, err) {
@@ -506,7 +517,6 @@ function onKvsListResponse(callback, resp, err) {
     return;
   }
 
-  // Process keys sequentially to avoid "too many calls in progress"
   processKeysSequentially(list, newMap, callback, 0);
 }
 


### PR DESCRIPTION
## Root cause

`processKeysSequentially` and `loadIlluminanceStatesSequentially` used recursive callbacks: each async result directly called the next iteration. On this Shelly firmware, `Shelly.call` fires callbacks **synchronously**, so with N follow keys + M tracked MACs the call stack grew by ~4 frames per device before `setupDailySaveTimer` → `log` were reached, overflowing Espruino's script stack.

```
Uncaught Error: Too much recursion - the stack is about to overflow
  in function "log" ← called from setupDailySaveTimer
  in function "setupDailySaveTimer" ← called from onLoadFollowsComplete
  ...
```

## What was tried

A pure-parallel replacement (fire all `KVS.Get` calls at once) immediately hit the device's **5-concurrent-RPC limit** on devices with many follow entries:

```
Uncaught Error: Too many calls in progress
  in function "loadKeysParallel"
```

## Fix

Keep the sequential pattern but insert `Timer.set(0, false, fn)` between iterations. The 0 ms timer fires on the next event-loop tick with a **fresh empty call stack**, so there is no recursion depth buildup and only one RPC is in-flight at a time. One transient timer slot is used during initialisation (released immediately when it fires), leaving the steady-state timer count unchanged.

## Verification

Deployed to all four affected devices and confirmed running clean:

| Device | Before | After |
|--------|--------|-------|
| mezzanine | crashed (recursion) | running ✓ |
| lumiere-parking | crashed (recursion) | running ✓ |
| lumiere-pool-house-mur | running (crash imminent) | running ✓ |
| lumiere-porte-entree | crashed (recursion) | running ✓ |

## Test plan

- [ ] CI passes
- [ ] `myhome ctl shelly script status <device> blu-listener.js` shows `running: true`, no `error_msg` on all four devices after reboot<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(blu-listener): break recursive KVS callback chains with Timer.set deferral ([158dd8d](https://github.com/asnowfix/home-automation/commit/158dd8d98a5a22ccb53dd30b023cb427d1b2c917))
<!-- END-AUTO-GENERATED-COMMITS -->