### PR TITLE
fix(scripts): reduce heater.js and watchdog.js memory usage

### DIFF
--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -187,7 +187,6 @@ var STATE = {
   // Forecast cache
   forecastUrl: null,
   cachedForecast: null,
-  cachedForecastTimes: null,
   lastForecastFetchDate: null,
 
   // Heater state
@@ -1099,9 +1098,8 @@ function onForecast(result, error_code, error_message, cb) {
     return;
   }
 
-  // Cache only the arrays we need, let GC clean up the rest
+  // Cache only the array we need, let GC clean up the rest
   STATE.cachedForecast = data.hourly.temperature_2m;
-  STATE.cachedForecastTimes = data.hourly.time;
   data = null; // Help GC
 
   var now = new Date();

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -29,63 +29,53 @@ const DEFAULT_COOLING_RATE = 1.0;
 // Any changes here must be reflected in the Go code and validated by TestHeaterKVSKeysMatchJSSchema
 var CONFIG_SCHEMA = {
   enableLogging: {
-    description: "Enable logging when true",
     key: "enable-logging",
     default: true,
     type: "boolean"
   },
   roomId: {
-    description: "Room identifier for temperature API",
     key: "room-id",
     default: null,
     type: "string",
     unprefixed: true
   },
   cheapStartHour: {
-    description: "Start hour of cheap electricity window",
     key: "cheap-start-hour",
     default: 23,
     type: "number"
   },
   cheapEndHour: {
-    description: "End hour of cheap electricity window",
     key: "cheap-end-hour",
     default: 7,
     type: "number"
   },
   pollIntervalMs: {
-    description: "Polling interval in milliseconds",
     key: "poll-interval-ms",
-    default: 5 * 60 * 1000, // 5 minutes
+    default: 5 * 60 * 1000,
     type: "number"
   },
   preheatHours: {
-    description: "Hours before cheap window end to start preheating",
     key: "preheat-hours",
     default: 2,
     type: "number"
   },
   normallyClosed: {
-    description: "Whether the switch is normally closed",
     key: "normally-closed",
     default: true,
     type: "boolean",
     unprefixed: true
   },
   internalTemperatureTopic: {
-    description: "MQTT topic for internal temperature sensor",
     key: "internal-temperature-topic",
     default: null,
     type: "string"
   },
   externalTemperatureTopic: {
-    description: "MQTT topic for external temperature sensor",
     key: "external-temperature-topic",
     default: null,
     type: "string"
   },
   doorSensorTopics: {
-    description: "Comma-separated list of MQTT topics for door/window sensors",
     key: "door-sensor-topics",
     default: "",
     type: "string"

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -248,21 +248,6 @@ var STATE = {
   subscribedDoorSensorTopics: []
 };
 
-function onDeviceLocation(result, error_code, error_message, cb) {
-  log('onDeviceLocation')
-  if (error_code === 0 && result) {
-    if (result.lat !== null && result.lon !== null) {
-      log('Auto-detected location: lat=' + result.lat + ', lon=' + result.lon + ', tz=' + result.tz);
-      setForecastURL(result.lat, result.lon);
-      if (typeof cb === 'function') cb();
-    } else {
-      log('Location detection returned null coordinates');
-    }
-  } else {
-    log('Failed to detect location (error ' + error_code + '): ' + error_message);
-  }
-}
-
 function onForecastUrlReady(cb) {
   log('onForecastUrlReady')
   fetchAndCacheForecast(loadConfig.bind(null, cb));

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -29,53 +29,63 @@ const DEFAULT_COOLING_RATE = 1.0;
 // Any changes here must be reflected in the Go code and validated by TestHeaterKVSKeysMatchJSSchema
 var CONFIG_SCHEMA = {
   enableLogging: {
+    description: "Enable logging when true",
     key: "enable-logging",
     default: true,
     type: "boolean"
   },
   roomId: {
+    description: "Room identifier for temperature API",
     key: "room-id",
     default: null,
     type: "string",
     unprefixed: true
   },
   cheapStartHour: {
+    description: "Start hour of cheap electricity window",
     key: "cheap-start-hour",
     default: 23,
     type: "number"
   },
   cheapEndHour: {
+    description: "End hour of cheap electricity window",
     key: "cheap-end-hour",
     default: 7,
     type: "number"
   },
   pollIntervalMs: {
+    description: "Polling interval in milliseconds",
     key: "poll-interval-ms",
     default: 5 * 60 * 1000,
     type: "number"
   },
   preheatHours: {
+    description: "Hours before cheap window end to start preheating",
     key: "preheat-hours",
     default: 2,
     type: "number"
   },
   normallyClosed: {
+    description: "Whether the switch is normally closed",
     key: "normally-closed",
     default: true,
     type: "boolean",
     unprefixed: true
   },
   internalTemperatureTopic: {
+    description: "MQTT topic for internal temperature sensor",
     key: "internal-temperature-topic",
     default: null,
     type: "string"
   },
   externalTemperatureTopic: {
+    description: "MQTT topic for external temperature sensor",
     key: "external-temperature-topic",
     default: null,
     type: "string"
   },
   doorSensorTopics: {
+    description: "Comma-separated list of MQTT topics for door/window sensors",
     key: "door-sensor-topics",
     default: "",
     type: "string"
@@ -405,6 +415,11 @@ function onKvsLoaded(result, error_code, error_message, userdata) {
   } else {
     log('Failed to load KVS config (error ' + error_code + '): ' + error_message);
   }
+  // Drop description strings now that config is loaded — only needed at parse/load time
+  for (var name in CONFIG_SCHEMA) {
+    CONFIG_SCHEMA[name].description = null;
+  }
+
   if (typeof userdata === 'function') {
     userdata(updated);
   } else {

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -618,7 +618,7 @@ function fetchControlInputsWithCachedForecast(cb) {
   };
   // Store last external temp for fallback in shouldPreheat
   if (results.external !== null) lastExternalTemp = results.external;
-  log('Fetched all control inputs:', JSON.stringify(results));
+  // log('Fetched all control inputs:', JSON.stringify(results)); // hot path — serialises full results every 5 min
 
   // Clear guard before calling callback
   _fetchingControlInputs = false;
@@ -674,7 +674,7 @@ var kalman = new KalmanFilter();
  */
 function parseTemperatureFromMqtt(topic, message) {
   var temp = null;
-  log("parseTemperatureFromMqtt", topic, message);
+  // log("parseTemperatureFromMqtt", topic, message); // hot path — logs full payload every MQTT event
   try {
     // H&T Gen1 format, via gen1 HTTP-to-MQTT proxy
     // topic: shellies/<id>/sensor/temperature
@@ -754,11 +754,11 @@ function onExternalTemperature(topic, message) {
 function onTemperatureRanges(topic, message) {
   log('Received temperature ranges update from MQTT:', topic);
   try {
-    log('Received temperature ranges update from MQTT:', message);
+    // log('Received temperature ranges update from MQTT:', message); // duplicates topic log above, logs full payload
     var data = JSON.parse(message);
     if (data && data.ranges) {
       STATE.cachedTemperatureRanges = data
-      log('Updated temperature ranges:', JSON.stringify(STATE.cachedTemperatureRanges));
+      // log('Updated temperature ranges:', JSON.stringify(STATE.cachedTemperatureRanges)); // serialises full object
 
       // Schedule control loop check
       scheduleControlLoopCheck();
@@ -1309,9 +1309,8 @@ if (typeof Shelly !== "undefined") {
     if (status && status.component === "sys" && status.delta && ("kvs_rev" in status.delta)) {
       log('KVS updated (rev ' + status.delta.kvs_rev + '), reloading configuration and re-fetching temperatures');
       loadConfig(onConfigLoaded);
-    } else {
-      log('Script status:', JSON.stringify(status));
     }
+    // else { log('Script status:', JSON.stringify(status)); } // hot path — fires on every switch/temp event
   });
 
   // Subscribe to all heater commands using wildcard

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -171,7 +171,6 @@ var STATE = {
 
   // Heater state
   lastHeaterState: false,
-  normallyClosed: true,
 
   // Temperature values (in-memory cache from MQTT)
   temperature: {
@@ -210,16 +209,12 @@ var STATE = {
 
   // Temperature ranges subscription topics (for dynamic config change)
   temperatureRangesTopic: null,
-  subscribedTemperatureRangesTopic: null,
 
   // Control loop timer handle
   controlLoopTimerId: null,
 
   // Pending control loop check timer handle (for deferred checks)
   controlLoopCheckTimerId: null,
-
-  // Last successful temperature ranges from RPC
-  lastSuccessfulRanges: null,
 
   // Door/window sensor states: { topic: { open: boolean, lastUpdate: timestamp } }
   doorSensors: {},

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -536,6 +536,7 @@ function initDeviceInfo() {
   STATE.deviceId = STATE.deviceInfo.id || 'unknown';
 
   log('Device ID:', STATE.deviceId, 'Device Name:', STATE.deviceName);
+  STATE.deviceInfo = null; // release — id and name already extracted above
 }
 
 // === PRE-HEATING LOGIC ===

--- a/internal/shelly/scripts/heater.js
+++ b/internal/shelly/scripts/heater.js
@@ -167,16 +167,6 @@ function logMemory(label) {
   }
 }
 
-// Generate a simple random ID
-function randomId(n) {
-  var chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-  var id = '';
-  for (var i = 0; i < n; i++) {
-    id += chars[Math.floor(Math.random() * chars.length)];
-  }
-  return id;
-}
-
 // === STATE (DYNAMIC RUNTIME VALUES) ===
 var STATE = {
   // Device info (cached at startup)
@@ -969,16 +959,6 @@ function subscribeToDoorSensors() {
   }
 }
 
-// Extract device name from MQTT topic (e.g., "shellies/device-name/sensor/temperature" -> "device-name")
-function extractDeviceNameFromTopic(topic) {
-  if (!topic) return null;
-  var parts = topic.split('/');
-  if (parts.length >= 2) {
-    return parts[1];
-  }
-  return null;
-}
-
 function subscribeMqttTemperature(location, topic) {
   log('Subscribing to MQTT topic for', location, 'temperature...');
 
@@ -1008,21 +988,6 @@ function subscribeMqttTemperature(location, topic) {
       MQTT.subscribe(newTopic, onExternalTemperature);
     }
     STATE.subscribedTemperatureTopic[location] = newTopic;
-  }
-}
-
-// === DATA FETCHING FUNCTIONS ===
-// Read temperature from STATE (in-memory cache)
-function getShellyTemperature(location, cb) {
-  log('getShellyTemperature', location);
-  var temp = STATE.temperature[location];
-
-  if (!temp) {
-    log('Read', location, 'temperature:', temp);
-    cb(temp);
-  } else {
-    log('No', location, 'temperature available yet');
-    cb(null);
   }
 }
 

--- a/internal/shelly/scripts/watchdog.js
+++ b/internal/shelly/scripts/watchdog.js
@@ -145,33 +145,34 @@ var FirmwareUpdater = {
         this.lastCheckTimestamp = Date.now();
         
         // Call the Shelly API to check for updates
+        var self = this;
         Shelly.call("Shelly.CheckForUpdate", {}, function(result, error_code, error_message) {
             if (error_code) {
-                this.log("Error checking for updates: " + error_message);
+                self.log("Error checking for updates: " + error_message);
                 return;
             }
-            
+
             // If result is empty, no update is available
             if (!result || (Object.keys(result).length === 0)) {
-                this.log("No firmware updates available");
+                self.log("No firmware updates available");
                 return;
             }
-            
+
             // Determine which update to use based on configuration
             var updateInfo = null;
             if (CONFIG.firmwareUpdate.updateChannel === "beta" && result.beta) {
                 updateInfo = result.beta;
-                this.log("Beta update available: " + updateInfo.version + " (" + updateInfo.build_id + ")");
+                self.log("Beta update available: " + updateInfo.version + " (" + updateInfo.build_id + ")");
             } else if (result.stable) {
                 updateInfo = result.stable;
-                this.log("Stable update available: " + updateInfo.version + " (" + updateInfo.build_id + ")");
+                self.log("Stable update available: " + updateInfo.version + " (" + updateInfo.build_id + ")");
             }
-            
+
             // If update is available and auto-update is enabled, apply it
             if (updateInfo && CONFIG.firmwareUpdate.autoUpdate) {
-                this.applyUpdate();
+                self.applyUpdate();
             }
-        }.bind(this));
+        });
     },
     
     // Apply the firmware update
@@ -184,14 +185,15 @@ var FirmwareUpdater = {
         this.log("Reboot lock enabled: " + SHARED_STATE.rebootLockReason);
         
         // Call the Shelly API to apply the update
+        var self = this;
         Shelly.call("Shelly.Update", { stage: CONFIG.firmwareUpdate.updateChannel }, function(result, error_code, error_message) {
             if (error_code) {
-                this.log("Error applying update: " + error_message);
+                self.log("Error applying update: " + error_message);
                 return;
             }
-            
-            this.log("Update initiated successfully. Device will reboot.");
-        }.bind(this));
+
+            self.log("Update initiated successfully. Device will reboot.");
+        });
     },
     
     // Schedule the next update check


### PR DESCRIPTION
## Summary

- Drop `STATE.cachedForecastTimes` in `heater.js` — 24 time strings (~1.1 KB) stored but never read
- Remove duplicate `onDeviceLocation` definition (first silently shadowed by second)
- Remove three dead functions: `randomId`, `extractDeviceNameFromTopic`, `getShellyTemperature`
- Remove unused `STATE` fields: `normallyClosed`, `subscribedTemperatureRangesTopic`, `lastSuccessfulRanges`
- Null `STATE.deviceInfo` after startup (full device object held forever; only `id`/`name` needed)
- Restore `CONFIG_SCHEMA` `description` fields for readability but null them out after `onKvsLoaded` returns
- Comment out hot-path `JSON.stringify` log calls (fire on every MQTT event / every 5-min poll cycle)
- Replace `.bind(this)` with `var self` closure in `watchdog.js` `FirmwareUpdater` (bind allocates a new function object per call)

Motivated by `heater.js` crashing with `out_of_memory` on `radiateur-cuisine` — see issue #216 for full diagnosis and remaining proposals.

## Test plan

- [ ] Verify `heater.js` starts and runs on devices that previously had it stopped (`radiateur-bureau`, `radiateur-chambre-enfants`, etc.)
- [ ] Verify `radiateur-cuisine` behaviour (tracked in #216 — likely needs `blu-publisher.js` removed from that device)
- [ ] Confirm `watchdog.js` firmware-update check still fires correctly (`.bind` → `self` refactor)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(heater): drop cachedForecastTimes — 24 time strings stored but never read (~1.1 KB) ([3ed9763](https://github.com/asnowfix/home-automation/commit/3ed976344c02e4a7cd6fb7980cd95758e4a43e13))
- fix(heater): remove duplicate onDeviceLocation — first definition silently shadowed by second ([686756f](https://github.com/asnowfix/home-automation/commit/686756fb2f5f46e185b4c0db4ee1d716e1657c00))
- fix(heater): remove dead functions randomId, extractDeviceNameFromTopic, getShellyTemperature ([8cf3085](https://github.com/asnowfix/home-automation/commit/8cf3085b4f18fd1ee64a3c9831e3b935aaed4fc2))
- fix(heater): drop description fields from CONFIG_SCHEMA — never read at runtime (~300 B string table) ([682add6](https://github.com/asnowfix/home-automation/commit/682add6de69e77dfcbbf644a358af1ef6b466801))
- fix(heater): remove unused STATE fields normallyClosed, subscribedTemperatureRangesTopic, lastSuccessfulRanges ([1283500](https://github.com/asnowfix/home-automation/commit/128350049ada0d1fbba53dcc18a79b86e6da77f8))
- fix(heater): null STATE.deviceInfo after startup — full device object held forever, only id/name needed ([146f347](https://github.com/asnowfix/home-automation/commit/146f3477640c4ad77169f6fb4fb885e5d57d6e2b))
- fix(heater): comment out hot-path JSON.stringify log calls to reduce per-event allocations ([4a1687b](https://github.com/asnowfix/home-automation/commit/4a1687bf80ff9d0d9628c8e9cdc846f824bb87ea))
- fix(watchdog): replace .bind(this) with var self closure in FirmwareUpdater — bind allocates a new function object per call ([242a39d](https://github.com/asnowfix/home-automation/commit/242a39d910de2cbd26e785722b5241986b444931))
- fix(heater): restore CONFIG_SCHEMA description fields but null them out after config load ([6db18ec](https://github.com/asnowfix/home-automation/commit/6db18ecd4ce17f8743e3418d6405d7d1de193ccc))
<!-- END-AUTO-GENERATED-COMMITS -->