### PR TITLE
fix(build): use full import path in goreleaser ldflags for version injection

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
     dir: .
     main: ./myhome
     ldflags:
-      - -X version.Program=myhome
-      - -X version.Repo={{.GitURL}}
-      - -X version.Version={{if .IsSnapshot}}{{.Summary}}{{else}}{{.Version}}{{end}}
-      - -X version.Commit={{.FullCommit}}
+      - -X github.com/asnowfix/home-automation/pkg/version.Program=myhome
+      - -X github.com/asnowfix/home-automation/pkg/version.Repo={{.GitURL}}
+      - -X github.com/asnowfix/home-automation/pkg/version.Version={{if .IsSnapshot}}{{.Summary}}{{else}}{{.Version}}{{end}}
+      - -X github.com/asnowfix/home-automation/pkg/version.Commit={{.FullCommit}}


### PR DESCRIPTION
## Summary

- Go's `-X pkgpath.Var=value` linker flag silently no-ops when the package path doesn't match
- The ldflags used bare `version.*` but the package lives at `github.com/asnowfix/home-automation/pkg/version`
- At runtime `Version == ""`, so `GetVersion()` fell through to `git describe` (unavailable in prod), then returned `"unknown"` — causing the UI title to show `MyHome N devices / unknown`

## Test plan

- [ ] Build a snapshot with `make build` / `goreleaser build --snapshot --clean --single-target`
- [ ] Run `./dist/.../myhome version` — should print the git tag/summary, not `"unknown"`
- [ ] Start the daemon and confirm the UI title shows the correct version<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(build): use full import path in goreleaser ldflags for version injection ([1529867](https://github.com/asnowfix/home-automation/commit/1529867f257ba1f8ec80be9f8b08058eee0834ad))
<!-- END-AUTO-GENERATED-COMMITS -->