### PR TITLE
Merge main into v0.9.x

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,7 +22,7 @@ builds:
     dir: .
     main: ./myhome
     ldflags:
-      - -X version.Program=myhome
-      - -X version.Repo={{.GitURL}}
-      - -X version.Version={{if .IsSnapshot}}{{.Summary}}{{else}}{{.Version}}{{end}}
-      - -X version.Commit={{.FullCommit}}
+      - -X github.com/asnowfix/home-automation/pkg/version.Program=myhome
+      - -X github.com/asnowfix/home-automation/pkg/version.Repo={{.GitURL}}
+      - -X github.com/asnowfix/home-automation/pkg/version.Version={{if .IsSnapshot}}{{.Summary}}{{else}}{{.Version}}{{end}}
+      - -X github.com/asnowfix/home-automation/pkg/version.Commit={{.FullCommit}}


### PR DESCRIPTION
## Summary

- Heater JS memory optimizations: drop dead code, null state after use, remove hot-path allocations
- Fix watchdog FirmwareUpdater bind leak (use `var self` closure instead)
- Fix blu-listener recursive KVS callback chains via Timer.set deferral
- Go toolchain upgrade to 1.25.3
- Pool pump: software fuse, `pool update` subcommand, temperature-based schedule mode, purge command, task queue pattern
- MCP server for Shelly device management
- Go module rename to fully-qualified `github.com` paths
- Script: device state snapshot command, KVS/Schedule/Switch/Input RPC methods for testing

## Test plan

- [ ] CI passes on all Go packages
- [ ] Shelly JS heater script deploys cleanly with `--no-minify`
- [ ] Pool pump schedules reconcile correctly on target devices<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(build): use full import path in goreleaser ldflags for version injection ([1529867](https://github.com/asnowfix/home-automation/commit/1529867f257ba1f8ec80be9f8b08058eee0834ad))
- Merge pull request #218 from asnowfix/worktree-bugfix+unknown-version ([218ae9a](https://github.com/asnowfix/home-automation/commit/218ae9a43926193bab4804a6abb0945828456b9c))
<!-- END-AUTO-GENERATED-COMMITS -->