### PR TITLE
fix(hlog): don't treat MYHOME_LOG=stderr as debugger signal

### DIFF
--- a/hlog/hlog.go
+++ b/hlog/hlog.go
@@ -115,21 +115,12 @@ func parseLogLevel(verbose bool, debug bool, defaultLevel zerolog.Level) zerolog
 
 // isRunningUnderDebugger detects if the process is running under a debugger (like VSCode)
 func isRunningUnderDebugger() bool {
-	// Check for common debugger environment variables
 	if os.Getenv("DELVE_DEBUGGER") != "" {
 		return true
 	}
-
-	// Check if MYHOME_LOG is set to stderr (common in VSCode launch configs)
-	if LogToStderr() {
-		return true
-	}
-
-	// Check for VSCode-specific environment variables
 	if os.Getenv("VSCODE_PID") != "" || os.Getenv("VSCODE_IPC_HOOK") != "" {
 		return true
 	}
-
 	return false
 }
 
@@ -170,9 +161,8 @@ func isColorTerminal() bool {
 }
 
 func logWriter() (io.Writer, error) {
-	// When running under VSCode debugger, use stderr
 	if LogToStderr() {
-		debugInit("VSCode debug session detected, using stderr for logging")
+		debugInit("MYHOME_LOG=stderr, using stderr for logging")
 		return os.Stderr, nil
 	}
 


### PR DESCRIPTION
## Summary

- `isRunningUnderDebugger()` was treating `MYHOME_LOG=stderr` as proof that a VSCode debugger was attached, which forced the log level to `DebugLevel`
- The production systemd unit sets `MYHOME_LOG=stderr` to route logs to journald — a legitimate setting unrelated to debugging
- Removed that check; debugger detection now relies only on `DELVE_DEBUGGER`, `VSCODE_PID`, and `VSCODE_IPC_HOOK`

## Root cause

```
# /lib/systemd/system/myhome.service
Environment=MYHOME_LOG=stderr   ← routed logs to journald
```

```go
// hlog/hlog.go — before
func isRunningUnderDebugger() bool {
    ...
    if LogToStderr() { return true }  // ← wrongly fired in production
    ...
}
```

## Test plan

- [ ] Deploy new binary to production host and confirm `journalctl -u myhome` no longer shows `"level":"debug"` lines
- [ ] Attach VSCode debugger locally and confirm debug level is still forced via `VSCODE_PID`/`VSCODE_IPC_HOOK`<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(hlog): remove MYHOME_LOG=stderr from debugger detection ([370148a](https://github.com/asnowfix/home-automation/commit/370148a7c4ca06f01ef1489830180018f0f5bbe6))
<!-- END-AUTO-GENERATED-COMMITS -->