### PR TITLE
fix(events): repair event log UI — storage, dedup, naming, BLU types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Ports: 6080 (dev web UI), 80 (systemd), 6060 (pprof), 9100 (Prometheus).
 - **Config options**: adding any new option requires updating 4 files — `options.go`, `run.go`, `docs/configuration.md`, `myhome-example.yaml`. Env var pattern: `MYHOME_<SECTION>_<KEY>`.
 - **RPC handler tests**: tests that call `myhome.RegisterMethodHandler()` must restore state in `t.Cleanup` and must not call `t.Parallel()` (shared package-level map).
 - **Database migrations**: Use `COUNT(*)` (returns int) not bool when checking SQLite column existence. See AGENTS.md "Database Patterns".
+- **SQLite database paths**: new databases use a plain relative filename (e.g. `"foo.db"`), matching `myhome.db`. Do not invent a new default directory (e.g. `~/.myhome/`, XDG paths) unless all existing databases already use it. If a flag or config key lets the user supply an absolute path, the `NewStorage` constructor must call `os.MkdirAll(filepath.Dir(path), 0o755)` before opening the file — SQLite cannot create missing parent directories.
 - **File moves**: always `git mv`, never delete-and-recreate (preserves `git log --follow` history).
 - **Non-trivial tasks**: create a plan file under `docs/` before writing code; mark each phase done before starting the next; commit plan updates alongside the implementation.
 

--- a/internal/myhome/shelly/blu/listener.go
+++ b/internal/myhome/shelly/blu/listener.go
@@ -76,6 +76,7 @@ type DeviceRegistry interface {
 	SetDevice(ctx context.Context, device *myhome.Device, overwrite bool) (bool, error)
 	GetDeviceById(ctx context.Context, id string) (*myhome.Device, error)
 	UpdateSensorValue(ctx context.Context, deviceID string, sensor string, value string) error
+	RenameDevice(ctx context.Context, oldID, newID string) error
 }
 
 // SSEBroadcaster interface for broadcasting sensor updates to UI
@@ -86,6 +87,28 @@ type SSEBroadcaster interface {
 // StartBLUListener starts listening to BLU device MQTT events and registers them
 func StartBLUListener(ctx context.Context, mc mqtt.Client, registry DeviceRegistry, sseBroadcaster SSEBroadcaster) error {
 	return StartBLUListenerWithEvents(ctx, mc, registry, sseBroadcaster, nil, nil)
+}
+
+// deviceIDFromCapabilities infers the Shelly BLU device-type prefix from the
+// sensor fields present in a BLU event, then appends the normalised MAC suffix.
+// Precedence follows field exclusivity: window sensors never carry motion data,
+// H&T sensors never carry motion/window data, etc.
+func deviceIDFromCapabilities(mac string, data BLUEventData) string {
+	suffix := strings.ToLower(strings.ReplaceAll(mac, ":", ""))
+	var prefix string
+	switch {
+	case data.Window != nil:
+		prefix = "shellybludoorwindow2"
+	case data.Temperature != nil || data.Humidity != nil:
+		prefix = "shellybluht3"
+	case data.Motion != nil:
+		prefix = "shellyblumotion1"
+	case data.Button != nil:
+		prefix = "shellyblubutton1"
+	default:
+		prefix = "shellyblu"
+	}
+	return prefix + "-" + suffix
 }
 
 // StartBLUListenerWithEvents is like StartBLUListener but also records events and sensor observations.
@@ -101,26 +124,12 @@ func StartBLUListenerWithEvents(ctx context.Context, mc mqtt.Client, registry De
 	err := mc.SubscribeWithHandler(ctx, topic, 16, "shelly/blu", func(topic string, payload []byte, subscriber string) error {
 		log.Info("event received", "topic", topic, "payload", string(payload))
 
-		// Parse BLU event topic first: shelly-blu/events/<MAC>
-		parts := strings.Split(topic, "/")
-		if len(parts) != 3 {
-			err := fmt.Errorf("invalid BLU event topic: %s", topic)
-			log.Error(err, "invalid BLU event topic", "topic", topic)
-			return err
-		}
-		mac := parts[2] // MAC address with colons
-		deviceID := "shellyblu-" + strings.ToLower(strings.ReplaceAll(mac, ":", ""))
-
-		log.V(1).Info("event emitter", "device_id", deviceID, "mac", mac)
-
-		// Handle device registration
-		sensors, err := handleBLUEvent(ctx, log, topic, payload, registry)
+		// Handle device registration; returns the resolved device ID.
+		deviceID, sensors, err := handleBLUEvent(ctx, log, topic, payload, registry)
 
 		// Update cache and broadcast sensor updates via SSE
-		// Both happen regardless of registration success, similar to Gen1 pattern
 		if sensors != nil {
 			for sensor, value := range *sensors {
-				// Update device cache so values survive page reloads
 				if cacheErr := registry.UpdateSensorValue(ctx, deviceID, sensor, value); cacheErr != nil {
 					log.V(1).Info("Failed to update sensor in cache", "error", cacheErr, "device_id", deviceID)
 				}
@@ -129,15 +138,14 @@ func StartBLUListenerWithEvents(ctx context.Context, mc mqtt.Client, registry De
 					sseBroadcaster.BroadcastSensorUpdate(deviceID, sensor, value)
 				}
 			}
-		}
-		if sensors == nil {
+		} else {
 			log.V(1).Info("No sensors in event", "topic", topic, "device_id", deviceID)
 		}
 
 		// Feed event log and sensor tracker from the raw payload (nil-safe)
 		handleBLUEventBridge(ctx, log, payload, eventSvc, tracker)
 
-		log.V(1).Info("event processing completed", "device_id", deviceID, "mac", mac)
+		log.V(1).Info("event processing completed", "device_id", deviceID)
 
 		return err
 	})
@@ -241,26 +249,27 @@ func handleBLUEventBridge(ctx context.Context, log logr.Logger, payload []byte, 
 	}
 }
 
-func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload []byte, registry DeviceRegistry) (*map[string]string, error) {
+// handleBLUEvent returns (deviceID, sensors, error).
+func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload []byte, registry DeviceRegistry) (string, *map[string]string, error) {
 	log.V(1).Info("Handling BLU event", "topic", topic, "payload", string(payload))
 
 	// Parse the event data
 	var eventData BLUEventData
 	if err := json.Unmarshal(payload, &eventData); err != nil {
 		log.V(1).Info("Failed to parse event", "topic", topic, "error", err)
-		return nil, err
+		return "", nil, err
 	}
 
 	// Validate MAC address
 	if eventData.Address == "" {
 		err := fmt.Errorf("event missing MAC address")
 		log.Error(err, "Event missing MAC address", "event", eventData)
-		return nil, err
+		return "", nil, err
 	}
 
-	// Normalize MAC address: lowercase, remove colons
-	mac := strings.ToLower(strings.ReplaceAll(eventData.Address, ":", ""))
-	deviceID := "shellyblu-" + mac
+	deviceID := deviceIDFromCapabilities(eventData.Address, eventData)
+	// Fallback: look up by old generic ID for devices stored before type inference.
+	legacyID := "shellyblu-" + strings.ToLower(strings.ReplaceAll(eventData.Address, ":", ""))
 
 	// Determine sensor capabilities from the event data
 	capabilities := []string{}
@@ -389,11 +398,22 @@ func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload 
 	macAddr, parseErr := net.ParseMAC(eventData.Address)
 	if parseErr != nil {
 		log.Error(parseErr, "Failed to parse MAC address", "device_id", deviceID, "mac", eventData.Address)
-		return nil, parseErr
+		return deviceID, nil, parseErr
 	}
 
-	// Try to get existing device from DB
+	// Try to get existing device from DB; fall back to legacy generic ID.
 	existingDevice, err := registry.GetDeviceById(ctx, deviceID)
+	if err != nil && legacyID != deviceID {
+		existingDevice, err = registry.GetDeviceById(ctx, legacyID)
+		if err == nil && existingDevice != nil {
+			log.Info("Upgrading BLU device ID", "old_id", legacyID, "new_id", deviceID)
+			if renameErr := registry.RenameDevice(ctx, legacyID, deviceID); renameErr != nil {
+				log.Error(renameErr, "Failed to rename BLU device", "old_id", legacyID, "new_id", deviceID)
+			} else {
+				existingDevice.Id_ = deviceID
+			}
+		}
+	}
 	if err == nil && existingDevice != nil {
 		// Device exists - check if anything changed
 		changed := false
@@ -429,7 +449,7 @@ func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload 
 			modified, err := registry.SetDevice(ctx, existingDevice, true)
 			if err != nil {
 				log.Error(err, "Failed to update BLU device", "device_id", deviceID)
-				return nil, err
+				return deviceID, nil, err
 			}
 			if modified {
 				log.V(1).Info("Updated BLU device", "device_id", deviceID, "capabilities", capabilities)
@@ -437,7 +457,7 @@ func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload 
 				log.V(2).Info("BLU device unchanged in database", "device_id", deviceID)
 			}
 		}
-		return &sensors, nil
+		return deviceID, &sensors, nil
 	}
 
 	// Device doesn't exist - create new entry
@@ -459,7 +479,7 @@ func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload 
 	modified, err := registry.SetDevice(ctx, device, true)
 	if err != nil {
 		log.Error(err, "Failed to register BLU device", "device_id", deviceID)
-		return nil, err
+		return deviceID, nil, err
 	}
 
 	if modified {
@@ -467,7 +487,7 @@ func handleBLUEvent(ctx context.Context, log logr.Logger, topic string, payload 
 	} else {
 		log.V(1).Info("BLU device already exists (unchanged)", "device_id", deviceID)
 	}
-	return &sensors, nil
+	return deviceID, &sensors, nil
 }
 
 // btHomeInfoEqual compares two BTHomeInfo structs for equality

--- a/internal/myhome/shelly/blu/listener_test.go
+++ b/internal/myhome/shelly/blu/listener_test.go
@@ -34,6 +34,8 @@ func (f *fakeBLURegistry) UpdateSensorValue(_ context.Context, deviceID, sensor,
 	return nil
 }
 
+func (f *fakeBLURegistry) RenameDevice(_ context.Context, _, _ string) error { return nil }
+
 func buildBLUPayload(t *testing.T, data BLUEventData) []byte {
 	t.Helper()
 	b, err := json.Marshal(data)
@@ -62,7 +64,7 @@ func TestHandleBLUEvent_SensorUpdateWritesCache(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	topic := "shelly-blu/events/aa:bb:cc:dd:ee:ff"
 
-	sensors, err := handleBLUEvent(ctx, logr.Discard(), topic, payload, reg)
+	_, sensors, err := handleBLUEvent(ctx, logr.Discard(), topic, payload, reg)
 	if err != nil {
 		t.Fatalf("handleBLUEvent error: %v", err)
 	}
@@ -109,7 +111,7 @@ func TestHandleBLUEvent_NoSensorsNoCache(t *testing.T) {
 	ctx := logr.NewContext(context.Background(), logr.Discard())
 	topic := "shelly-blu/events/aa:bb:cc:dd:ee:ff"
 
-	sensors, _ := handleBLUEvent(ctx, logr.Discard(), topic, payload, reg)
+	_, sensors, _ := handleBLUEvent(ctx, logr.Discard(), topic, payload, reg)
 
 	if sensors != nil && len(*sensors) > 0 {
 		t.Errorf("expected no sensors, got %v", *sensors)

--- a/internal/myhome/shelly/gen2/listener.go
+++ b/internal/myhome/shelly/gen2/listener.go
@@ -3,6 +3,7 @@ package gen2
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"strings"
 	"time"
 
@@ -29,7 +30,7 @@ func NewListener(log logr.Logger, mqtt mqttclient.Client, svc *events.Service, t
 
 func (l *Listener) Start(ctx context.Context) error {
 	if err := l.mqtt.SubscribeWithHandler(ctx, "+/events/rpc", 16, "shelly/gen2/events", func(topic string, payload []byte, _ string) error {
-		return l.handleNotifyEvent(ctx, payload)
+		return l.handleRpc(ctx, payload)
 	}); err != nil {
 		l.log.Error(err, "Failed to subscribe to +/events/rpc")
 		return err
@@ -46,22 +47,100 @@ func (l *Listener) Start(ctx context.Context) error {
 	return nil
 }
 
+func (l *Listener) handleRpc(ctx context.Context, payload []byte) error {
+	var hdr struct {
+		Method string `json:"method"`
+	}
+	if err := json.Unmarshal(payload, &hdr); err != nil {
+		l.log.V(1).Info("Failed to parse +/events/rpc header", "error", err)
+		return nil
+	}
+	switch hdr.Method {
+	case "NotifyEvent":
+		return l.handleNotifyEvent(ctx, payload)
+	case "NotifyStatus":
+		return l.handleNotifyStatus(ctx, payload)
+	}
+	return nil
+}
+
+func (l *Listener) handleNotifyStatus(ctx context.Context, payload []byte) error {
+	var msg struct {
+		Src    string                     `json:"src"`
+		Params map[string]json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		l.log.V(1).Info("Failed to parse NotifyStatus", "error", err)
+		return nil
+	}
+
+	for key, raw := range msg.Params {
+		if key == "ts" {
+			continue
+		}
+		// Only handle switch:N components for on/off events.
+		if !strings.HasPrefix(key, "switch:") {
+			continue
+		}
+		var sw struct {
+			Output  *bool    `json:"output"`
+			Ts      float64  `json:"ts"`
+			APower  *float64 `json:"apower"`
+			Voltage *float64 `json:"voltage"`
+		}
+		if err := json.Unmarshal(raw, &sw); err != nil || sw.Output == nil {
+			continue
+		}
+		var ts float64
+		if sw.Ts != 0 {
+			ts = sw.Ts
+		} else {
+			ts = float64(time.Now().Unix())
+		}
+		eventName := "switch.off"
+		if *sw.Output {
+			eventName = "switch.on"
+		}
+		var dataPtr *string
+		if sw.APower != nil || sw.Voltage != nil {
+			m := make(map[string]float64, 2)
+			if sw.APower != nil {
+				m["apower"] = *sw.APower
+			}
+			if sw.Voltage != nil {
+				m["voltage"] = *sw.Voltage
+			}
+			b, _ := json.Marshal(m)
+			s := string(b)
+			dataPtr = &s
+		}
+		e := events.Event{
+			Ts:        ts,
+			DeviceID:  msg.Src,
+			Component: key,
+			Event:     eventName,
+			Severity:  "info",
+			Data:      dataPtr,
+		}
+		if err := l.service.Record(ctx, e); err != nil {
+			l.log.Error(err, "Failed to record switch status event", "device_id", msg.Src, "component", key)
+		}
+	}
+	return nil
+}
+
 func (l *Listener) handleNotifyEvent(ctx context.Context, payload []byte) error {
 	var msg struct {
 		Src    string `json:"src"`
 		Method string `json:"method"`
 		Params struct {
-			Ts     float64          `json:"ts"`
+			Ts     float64           `json:"ts"`
 			Events []json.RawMessage `json:"events"`
 		} `json:"params"`
 	}
 
 	if err := json.Unmarshal(payload, &msg); err != nil {
 		l.log.V(1).Info("Failed to parse +/events/rpc message", "error", err)
-		return nil
-	}
-
-	if msg.Method != "NotifyEvent" {
 		return nil
 	}
 
@@ -98,7 +177,14 @@ func (l *Listener) handleNotifyEvent(ctx context.Context, payload []byte) error 
 
 		ts := entry.Ts
 		if ts == 0 {
-			ts = msg.Params.Ts
+			if msg.Params.Ts >= 1e9 {
+				// Floor to integer seconds: multiple gateways relaying the same
+				// BLU broadcast within the same second share an identical ts and
+				// are deduplicated by the UNIQUE(device_id,component,event,ts) constraint.
+				ts = math.Floor(msg.Params.Ts)
+			} else {
+				ts = float64(time.Now().Unix())
+			}
 		}
 
 		e := events.Event{

--- a/internal/myhome/ui/events_template.go
+++ b/internal/myhome/ui/events_template.go
@@ -40,7 +40,7 @@ func eventTemplateFuncs() template.FuncMap {
 // Used both in the HTMX table and in BroadcastEvent SSE push.
 const eventRowTemplate = `<tr class="{{severityClass .Severity}}">
   <td>{{formatTime .Ts}}</td>
-  <td>{{.DeviceID}}</td>
+  <td>{{if .DeviceName}}<span title="{{.DeviceID}}">{{.DeviceName}}</span>{{else}}{{.DeviceID}}{{end}}</td>
   <td>{{.Component}}</td>
   <td>{{.Event}}</td>
   <td>{{.Severity}}</td>
@@ -71,7 +71,7 @@ const eventsTableTemplate = `<form id="events-filter-form"
       hx-swap="innerHTML">
   <div class="field is-grouped is-grouped-multiline mb-4">
     <div class="control">
-      <input class="input is-small" type="text" name="device" placeholder="Device ID"
+      <input class="input is-small" type="text" name="device" placeholder="Device name, ID or MAC"
              value="{{.Device}}">
     </div>
     <div class="control">

--- a/internal/myhome/ui/htmx.go
+++ b/internal/myhome/ui/htmx.go
@@ -13,6 +13,7 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/events"
 	"github.com/asnowfix/home-automation/myhome/storage"
+	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/go-logr/logr"
 )
 
@@ -198,18 +199,105 @@ func (h *HTMXHandler) EventsMore(w http.ResponseWriter, r *http.Request) {
 	h.renderEventsRows(w, r, offset)
 }
 
+// eventRow is the template view for a single event row.
+// Fields are copied explicitly to avoid the embedded-struct name collision:
+// events.Event has a field named Event (string), and embedding events.Event
+// creates an outer field also named Event (the struct itself), shadowing it.
+type eventRow struct {
+	Ts         float64
+	DeviceID   string
+	Component  string
+	Event      string
+	Severity   string
+	Data       *string
+	DeviceName string
+}
+
+// resolveDeviceFilter translates a free-text device filter (name, id, or MAC)
+// into the list of device_id values that may appear in the events table.
+// Both the stored id and the MAC are included because different event sources
+// (Gen2 MQTT vs BLU) store different identifiers as device_id.
+// Falls back to the raw filter string when no device record is found.
+func (h *HTMXHandler) resolveDeviceFilter(filter string) []string {
+	if filter == "" {
+		return nil
+	}
+	d, err := h.db.GetDeviceByAny(h.ctx, filter)
+	if err != nil {
+		if mac := shellyapi.MacFromShellyID(filter); mac != nil {
+			d, err = h.db.GetDeviceByAny(h.ctx, mac.String())
+		}
+	}
+	if err != nil {
+		return []string{filter}
+	}
+	ids := []string{d.Id()}
+	if mac := d.Mac(); mac != nil {
+		if s := mac.String(); s != d.Id() {
+			ids = append(ids, s)
+		}
+	}
+	return ids
+}
+
+// deviceNameMap resolves names for all unique device IDs that appear in evts.
+// It uses GetDeviceByAny so it matches across id, mac, name, and host columns.
+// For Shelly devices whose stored id differs from the MQTT src, it also tries
+// the MAC address derived from the device ID suffix as a fallback.
+// Unknown or unnamed devices are omitted; callers fall back to the raw ID.
+func (h *HTMXHandler) deviceNameMap(evts []events.Event) map[string]string {
+	seen := make(map[string]struct{}, len(evts))
+	for _, e := range evts {
+		seen[e.DeviceID] = struct{}{}
+	}
+	m := make(map[string]string, len(seen))
+	for id := range seen {
+		d, err := h.db.GetDeviceByAny(h.ctx, id)
+		if err != nil {
+			if mac := shellyapi.MacFromShellyID(id); mac != nil {
+				d, err = h.db.GetDeviceByAny(h.ctx, mac.String())
+			}
+		}
+		if err != nil {
+			continue
+		}
+		if n := d.Name(); n != "" && n != id {
+			m[id] = n
+		}
+	}
+	return m
+}
+
+// toEventRows decorates a slice of events with device names from the map.
+func toEventRows(evts []events.Event, names map[string]string) []eventRow {
+	rows := make([]eventRow, len(evts))
+	for i, e := range evts {
+		rows[i] = eventRow{
+			Ts:         e.Ts,
+			DeviceID:   e.DeviceID,
+			Component:  e.Component,
+			Event:      e.Event,
+			Severity:   e.Severity,
+			Data:       e.Data,
+			DeviceName: names[e.DeviceID],
+		}
+	}
+	return rows
+}
+
 func (h *HTMXHandler) buildQuery(r *http.Request, offset int) events.Query {
 	device := r.URL.Query().Get("device")
 	evType := r.URL.Query().Get("type")
 	severity := r.URL.Query().Get("severity")
-	return events.Query{
-		DeviceID:  device,
+	q := events.Query{
+		DeviceIDs: h.resolveDeviceFilter(device),
 		EventType: evType,
 		Severity:  severity,
 		Since:     24 * time.Hour,
 		Limit:     50,
 		Offset:    offset,
 	}
+	return q
 }
 
 func (h *HTMXHandler) renderEventsTable(w http.ResponseWriter, r *http.Request, offset int) {
@@ -228,9 +316,9 @@ func (h *HTMXHandler) renderEventsTable(w http.ResponseWriter, r *http.Request, 
 	}
 
 	data := map[string]interface{}{
-		"Events":   evts,
+		"Events":   toEventRows(evts, h.deviceNameMap(evts)),
 		"Offset":   offset + len(evts),
-		"Device":   q.DeviceID,
+		"Device":   r.URL.Query().Get("device"),
 		"Type":     q.EventType,
 		"Severity": q.Severity,
 	}
@@ -256,9 +344,9 @@ func (h *HTMXHandler) renderEventsRows(w http.ResponseWriter, r *http.Request, o
 	}
 
 	data := map[string]interface{}{
-		"Events":   evts,
+		"Events":   toEventRows(evts, h.deviceNameMap(evts)),
 		"Offset":   offset + len(evts),
-		"Device":   q.DeviceID,
+		"Device":   r.URL.Query().Get("device"),
 		"Type":     q.EventType,
 		"Severity": q.Severity,
 	}

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -1,8 +1,6 @@
 package daemon
 
 import (
-	"os"
-	"path/filepath"
 	"strconv"
 	"time"
 
@@ -13,11 +11,7 @@ import (
 )
 
 func defaultEventsDBPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "events.db"
-	}
-	return filepath.Join(home, ".myhome", "events.db")
+	return "events.db"
 }
 
 var disableGen1Proxy bool

--- a/myhome/daemon/watch/zeroconf.go
+++ b/myhome/daemon/watch/zeroconf.go
@@ -22,8 +22,11 @@ func ZeroConf(ctx context.Context, restartAfter time.Duration, dm devices.Manage
 
 	go func(log logr.Logger) error {
 		stopped := make(chan struct{}, 1)
-		scan := make(chan *zeroconf.ServiceEntry, 1)
 		for {
+			// A fresh channel is required each iteration: zeroconf closes the
+			// entries channel when Browse exits (via LookupParams.done()), so
+			// reusing a closed channel on restart causes panic: close of closed channel.
+			scan := make(chan *zeroconf.ServiceEntry, 1)
 			err := dr.BrowseService(ctx, shelly.MDNS_SHELLIES, "local.", scan)
 			if err != nil {
 				log.Error(err, "Failed to start ZeroConf browser, will retry after delay")

--- a/myhome/devices/cache.go
+++ b/myhome/devices/cache.go
@@ -205,6 +205,18 @@ func (c *Cache) ForgetDevice(ctx context.Context, id string) error {
 	return c.db.ForgetDevice(ctx, id)
 }
 
+func (c *Cache) RenameDevice(ctx context.Context, oldID, newID string) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if d, exists := c.devicesById[oldID]; exists {
+		delete(c.devicesById, oldID)
+		d.Id_ = newID
+		c.devicesById[newID] = d
+	}
+	return c.db.RenameDevice(ctx, oldID, newID)
+}
+
 func (c *Cache) SetDeviceRoom(ctx context.Context, identifier string, roomId string) (bool, error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/myhome/devices/cache_test.go
+++ b/myhome/devices/cache_test.go
@@ -165,6 +165,17 @@ func (f *fakeRegistry) ForgetDevice(_ context.Context, id string) error {
 	return nil
 }
 
+func (f *fakeRegistry) RenameDevice(_ context.Context, oldID, newID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls["RenameDevice"]++
+	if d, ok := f.devices[oldID]; ok {
+		delete(f.devices, oldID)
+		f.devices[newID] = d
+	}
+	return nil
+}
+
 func (f *fakeRegistry) SetDeviceRoom(_ context.Context, identifier string, roomId string) (bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/myhome/devices/device.go
+++ b/myhome/devices/device.go
@@ -16,6 +16,7 @@ type DeviceRegistry interface {
 	GetDeviceByMAC(ctx context.Context, mac string) (*myhome.Device, error)
 	GetDeviceByName(ctx context.Context, name string) (*myhome.Device, error)
 	ForgetDevice(ctx context.Context, id string) error
+	RenameDevice(ctx context.Context, oldID, newID string) error
 	GetAllDevices(ctx context.Context) ([]*myhome.Device, error)
 	SetDeviceRoom(ctx context.Context, identifier string, roomId string) (bool, error)
 	GetDevicesByRoom(ctx context.Context, roomId string) ([]*myhome.Device, error)

--- a/myhome/events/storage.go
+++ b/myhome/events/storage.go
@@ -3,6 +3,8 @@ package events
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -35,7 +37,8 @@ type DailyStat struct {
 }
 
 type Query struct {
-	DeviceID  string
+	DeviceIDs []string // IN match; takes precedence over DeviceID when set
+	DeviceID  string   // exact match (used when DeviceIDs is empty)
 	EventType string
 	Severity  string
 	Since     time.Duration
@@ -49,6 +52,12 @@ type Storage struct {
 }
 
 func NewStorage(log logr.Logger, dbPath string) (*Storage, error) {
+	if dir := filepath.Dir(dbPath); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			log.Error(err, "Failed to create events database directory", "dir", dir)
+			return nil, err
+		}
+	}
 	db, err := sqlx.Connect("sqlite", dbPath)
 	if err != nil {
 		log.Error(err, "Failed to connect to events database", "dbPath", dbPath)
@@ -149,7 +158,14 @@ func (s *Storage) Query(ctx context.Context, q Query) ([]Event, error) {
 	parts := []string{"1=1"}
 	args := []interface{}{}
 
-	if q.DeviceID != "" {
+	if len(q.DeviceIDs) > 0 {
+		placeholders := make([]string, len(q.DeviceIDs))
+		for i, id := range q.DeviceIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		parts = append(parts, "device_id IN ("+strings.Join(placeholders, ",")+")")
+	} else if q.DeviceID != "" {
 		parts = append(parts, "device_id = ?")
 		args = append(args, q.DeviceID)
 	}

--- a/myhome/storage/db.go
+++ b/myhome/storage/db.go
@@ -318,6 +318,14 @@ func (s *DeviceStorage) GetDeviceByHost(ctx context.Context, host string) (*myho
 }
 
 // ForgetDevice deletes a device from the database by any of its identifiers (Id, MAC address, name, host)
+func (s *DeviceStorage) RenameDevice(ctx context.Context, oldID, newID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE devices SET id = ? WHERE id = ?`, newID, oldID)
+	if err != nil {
+		s.log.Error(err, "Failed to rename device", "old_id", oldID, "new_id", newID)
+	}
+	return err
+}
+
 func (s *DeviceStorage) ForgetDevice(ctx context.Context, identifier string) error {
 	query := `DELETE FROM devices WHERE id = $1 OR mac = $1 OR name = $1 OR host = $1`
 	res, err := s.db.Exec(query, identifier)

--- a/pkg/shelly/device.go
+++ b/pkg/shelly/device.go
@@ -583,6 +583,31 @@ func NewDeviceFromIp(ctx context.Context, log logr.Logger, ip net.IP) (devices.D
 	return d, nil
 }
 
+// MacFromShellyID extracts the MAC address embedded in a Shelly device ID of
+// the form "<model>-<12hexchars>" (e.g. "shelly1minig3-54320464e730").
+// Returns nil when the ID does not follow that pattern.
+func MacFromShellyID(id string) net.HardwareAddr {
+	i := strings.LastIndex(id, "-")
+	if i < 0 {
+		return nil
+	}
+	h := id[i+1:]
+	if len(h) != 12 {
+		return nil
+	}
+	for _, c := range h {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return nil
+		}
+	}
+	mac, err := net.ParseMAC(fmt.Sprintf("%s:%s:%s:%s:%s:%s",
+		h[0:2], h[2:4], h[4:6], h[6:8], h[8:10], h[10:12]))
+	if err != nil {
+		return nil
+	}
+	return mac
+}
+
 func NewDeviceFromMqttId(ctx context.Context, log logr.Logger, id string) (devices.Device, error) {
 	if id == "" || id == "<nil>" {
 		return nil, fmt.Errorf("invalid device id: %s", id)
@@ -591,6 +616,9 @@ func NewDeviceFromMqttId(ctx context.Context, log logr.Logger, id string) (devic
 		log: log,
 	}
 	d.UpdateId(id)
+	if mac := MacFromShellyID(id); mac != nil {
+		d.UpdateMac(mac.String())
+	}
 	return d, nil
 }
 


### PR DESCRIPTION
## Summary

- **Events DB path**: default to `events.db` (relative, same dir as `myhome.db`) — eliminates `SQLITE_CANTOPEN` caused by `~/.myhome/` never being created; `os.MkdirAll` guard added for explicit absolute paths
- **Gen2 listener**: handle `NotifyStatus` for switch on/off events (previously only `NotifyEvent` was processed); populate `data` with `apower`/`voltage` for metered switches; fix BLU timestamp/deduplication by flooring gateway `ts` to integer seconds
- **Event log UI**: resolve device names via `GetDeviceByAny` + MAC-from-Shelly-ID fallback; fix embedded-struct name collision that printed raw Go structs in the Event column; device filter now resolves names/MACs to actual `device_id` values via `IN` clause
- **BLU device IDs**: infer type-specific prefix from event capabilities (`shellybludoorwindow2`, `shellybluht3`, `shellyblumotion1`, `shellyblubutton1`); opportunistic upgrade of existing `shellyblu-<mac>` entries on next event via new `DeviceRegistry.RenameDevice`
- **`pkg/shelly.MacFromShellyID`**: extract MAC from Shelly device ID suffix — used in `NewDeviceFromMqttId` (no network call needed) and in the UI resolver

## Test plan

- [ ] Start daemon with `go run ./myhome daemon run -B <broker>` — confirm `events.db` is created in the working directory alongside `myhome.db`, no `SQLITE_CANTOPEN` error
- [ ] Toggle a switch via the UI — confirm `switch.on` / `switch.off` rows appear in `/event-log` within seconds
- [ ] Check that metered switches (Shelly 1 Mini G3) show `{"apower":…,"voltage":…}` in the Data column
- [ ] Trigger a BLU motion sensor — confirm single row (not 3 duplicates), correct timestamp, device name shown
- [ ] Type a device name in the event log filter — confirm rows filter correctly
- [ ] Confirm existing `shellyblu-<mac>` devices are renamed to typed IDs on next BLU event
- [ ] `make test` passes<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(events): repair event log UI — storage, dedup, naming, BLU types ([8badbc7](https://github.com/asnowfix/home-automation/commit/8badbc7f7c2903d1452f774c399f19759eb0760e))
- fix(zeroconf): prevent panic on browser restart after network loss ([b601070](https://github.com/asnowfix/home-automation/commit/b601070d88aaeaf55a352e0d9c818ed3ba1cc0d1))
<!-- END-AUTO-GENERATED-COMMITS -->