### PR TITLE
fix(blu): prevent RPC calls to BLU devices that lack an RPC interface

### DIFF
--- a/pkg/shelly/device.go
+++ b/pkg/shelly/device.go
@@ -136,7 +136,7 @@ func (d *Device) Refresh(ctx context.Context, via types.Channel) (bool, error) {
 	}
 
 	// BLU devices (Generation 0) cannot be refreshed via RPC - they are updated via MQTT events only
-	if strings.HasPrefix(d.Id(), "shellyblu-") {
+	if IsBluDevice(d.Id()) {
 		d.log.V(1).Info("Skipping refresh for BLU device (updated via MQTT events)", "device_id", d.Id())
 		return false, nil
 	}
@@ -482,10 +482,15 @@ func IsGen1Device(deviceId string) bool {
 	return false
 }
 
-// BLU device ID prefixes that identify BLU devices
+// BLU device ID prefixes that identify BLU devices.
+// Must stay in sync with deviceIDFromCapabilities() in internal/myhome/shelly/blu/listener.go.
 var bluPrefixes = []string{
-	"shellyblu-", // Shelly BLU (generic, if unknown)
-	"sbht-",      // Shelly BLU H&T (Humidity & Temperature)
+	"shellyblu-",            // generic BLU fallback
+	"shellybluht3-",         // BLU H&T v3
+	"shellybludoorwindow2-", // BLU door/window v2
+	"shellyblumotion1-",     // BLU motion v1
+	"shellyblubutton1-",     // BLU button v1
+	"sbht-",                 // alternate H&T naming
 }
 
 func IsBluDevice(deviceId string) bool {
@@ -694,6 +699,9 @@ func (d *Device) initDeviceInfo(ctx context.Context, via types.Channel) error {
 	if d == nil {
 		panic("device is nil")
 	}
+	if IsBluDevice(d.Id()) {
+		return nil
+	}
 	if d.Id() == "" || d.Mac() == nil {
 		info, err := shelly.GetDeviceInfo(ctx, d, via)
 		if err != nil {
@@ -781,7 +789,7 @@ func Foreach(ctx context.Context, log logr.Logger, deviceList []devices.Device, 
 			}
 
 			// Skip BLU devices (Generation 0) - they cannot receive commands or run scripts
-			if strings.HasPrefix(devSummary.Id(), "shellyblu-") {
+			if IsBluDevice(devSummary.Id()) {
 				log.V(1).Info("Skipping BLU device (no command/script support)", "device_id", devSummary.Id())
 				results <- DeviceResult{Device: devSummary, Error: nil}
 				return


### PR DESCRIPTION
## Summary

- `bluPrefixes` only contained `shellyblu-` and `sbht-`, so specific BLU variants like `shellybluht3-` were not recognised as BLU devices by `IsBluDevice()`
- Guards in `Refresh()` and `Foreach()` used a hardcoded `strings.HasPrefix(d.Id(), "shellyblu-")` that also missed these variants
- `initDeviceInfo()` had no BLU guard at all, causing `Shelly.GetDeviceInfo` to be called unconditionally and time out

## Changes

- Expand `bluPrefixes` to cover all prefixes emitted by `deviceIDFromCapabilities()` (`shellybluht3-`, `shellybludoorwindow2-`, `shellyblumotion1-`, `shellyblubutton1-`)
- Replace hardcoded `HasPrefix` checks in `Refresh()` and `Foreach()` with `IsBluDevice()`
- Add `IsBluDevice()` early-return to `initDeviceInfo()`

## Test plan

- [ ] Run daemon with a BLU H&T device (`shellybluht3-*`) and confirm no timeout errors in the log
- [ ] Confirm BLU sensor events still arrive and are processed by the BLU listener
- [ ] `go test ./internal/myhome/shelly/blu/...` passes<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(blu): prevent RPC calls to BLU devices that lack an RPC interface ([524964d](https://github.com/asnowfix/home-automation/commit/524964de1f7edead40bbb1aff11b5c2b8e4c77d8))
<!-- END-AUTO-GENERATED-COMMITS -->