### PR TITLE
fix(ci): remove pre-goreleaser go generate step that caused dirty-tree failure

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -32,12 +32,6 @@ jobs:
           go-version: '1.25.x'
         env:
           GOTOOLCHAIN: go1.25.3
-      - name: Run go generate
-        run: |
-          set -x
-          go generate -v ./internal/myhome/ui/...
-          go generate -v ./...
-          ls -la internal/myhome/ui/static/bulma.min.css || echo "bulma.min.css not found!"
       - name: Extract tag name
         id: extract-tag
         run: |


### PR DESCRIPTION
## Summary

- GoReleaser validates a clean working tree before running its own `before.hooks`
- The `package-deb` job was running `go generate` in a workflow step *before* goreleaser, leaving modified/untracked files that triggered the dirty-tree check and caused an immediate exit (0s, no build)
- The `.goreleaser.yml` `before.hooks` already run `go generate` at the correct point in the pipeline (after the dirty check passes), so the duplicate workflow step was redundant and harmful

## Test plan

- [ ] Delete tag `v0.10.0` locally and remotely, recreate on updated `main`, re-push
- [ ] Verify `package-deb` (amd64 + arm64) jobs reach the build step without dirty-tree error
- [ ] Verify `release` and `merge-back` jobs complete<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(ci): remove pre-goreleaser go generate step that caused dirty-tree failure ([db34bc0](https://github.com/asnowfix/home-automation/commit/db34bc00f869018bf22301ba44ef938cc40e6926))
<!-- END-AUTO-GENERATED-COMMITS -->