### PR TITLE
fix(pool-pump): fix three bugs preventing automatic pump start

### DIFF
--- a/internal/myhome/shelly/script/pool.go
+++ b/internal/myhome/shelly/script/pool.go
@@ -166,11 +166,25 @@ func (s *PoolService) setupDevice(ctx context.Context, via types.Channel, sd *sh
 	defer cancel()
 
 	minify := !opts.NoMinify
-	scriptResult, err := UploadWithVersion(uploadCtx, s.log, via, sd, scriptName, buf, minify, opts.ForceUpload)
+	uploadedID, err := UploadWithVersion(uploadCtx, s.log, via, sd, scriptName, buf, minify, opts.ForceUpload)
 	if err != nil {
 		return fmt.Errorf("failed to upload/start %s: %w", scriptName, err)
 	}
-	fmt.Printf("  → Script uploaded and started on %s (id:%d)\n", sd.Name(), scriptResult)
+
+	// UploadWithVersion returns 0 when the version matched and no upload was performed.
+	// Fetch the real script ID in that case — schedules reference it by ID, so using 0
+	// would create broken schedules that silently fail to call any handler at fire time.
+	scriptID := int(uploadedID)
+	if scriptID == 0 {
+		status, err := pkgscript.ScriptStatus(ctx, sd, via, scriptName)
+		if err != nil || status == nil {
+			return fmt.Errorf("script version unchanged but failed to get script ID for %s: %w", scriptName, err)
+		}
+		scriptID = int(status.Id)
+		fmt.Printf("  → Script unchanged on %s (id:%d)\n", sd.Name(), scriptID)
+	} else {
+		fmt.Printf("  → Script uploaded and started on %s (id:%d)\n", sd.Name(), scriptID)
+	}
 
 	// Pause to let script initialize and device settle
 	time.Sleep(2 * time.Second)
@@ -196,7 +210,7 @@ func (s *PoolService) setupDevice(ctx context.Context, via types.Channel, sd *sh
 
 	// Reconcile schedules on every device in the mesh — each device's script
 	// self-selects via isMyTurnToRun() so only the preferred device activates.
-	if err := s.reconcileSchedules(ctx, via, sd, int(scriptResult)); err != nil {
+	if err := s.reconcileSchedules(ctx, via, sd, scriptID); err != nil {
 		return fmt.Errorf("failed to reconcile schedules: %w", err)
 	}
 
@@ -603,8 +617,9 @@ func (s *PoolService) Start(ctx context.Context, deviceID string, speed Speed) e
 		return fmt.Errorf("invalid speed: %s", speed)
 	}
 
-	// Call doStart() in the script to use unified logic
-	code := fmt.Sprintf("doStart(%d, 'Manual start via ctl pool start %s')", switchID, speed)
+	// Call doStart() in the script to use unified logic.
+	// doStart() expects a speed string ('eco'/'mid'/'high'), not a switch ID integer.
+	code := fmt.Sprintf("doStart('%s', 'Manual start via ctl pool start %s')", speed, speed)
 
 	result, err := pkgscript.EvalInDevice(ctx, via, sd, "pool-pump.js", code)
 	if err != nil {

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -304,15 +304,18 @@ function loadConfig(callback) {
 }
 
 
-// Script.storage keys for continuously evolving values (survives reboots)
+// Script.storage keys for continuously evolving values (survives reboots, synchronous)
 var STORAGE_KEYS = {
-  forecastUrl: "forecast-url"       // Open-Meteo forecast URL built from device location
+  forecastUrl:   "forecast-url",    // Open-Meteo forecast URL built from device location
+  scheduleMode:  "schedule-mode"    // "summer" or "winter" — moved here from KVS because
+                                    // Script.storage.getItem() is synchronous; KVS.Get is
+                                    // async-only, so Shelly.call without a callback always
+                                    // returns null and schedule mode was lost on every reboot
 };
 
-// State keys for KVS persistence
+// State keys for KVS persistence (fire-and-forget writes only; reads use Script.storage)
 var STATE_KEYS = {
-  activeOutput: "active-output",    // -1 (all off), 0, 1, 2 for pro3; 0 for pro1
-  scheduleMode: "schedule-mode"     // "summer" or "winter" mode (Pro3 only)
+  activeOutput: "active-output"     // -1 (all off), 0, 1, 2 for pro3; 0 for pro1
 };
 
 // === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
@@ -764,15 +767,15 @@ function applyComponentNames(callback) {
 function loadState() {
   log("Loading persisted state...");
 
-  var savedActiveOutput = loadValue(STATE_KEYS.activeOutput);
-  if (savedActiveOutput !== null) {
-    STATE.activeOutput = savedActiveOutput;
-    log("Restored active output:", STATE.activeOutput);
-  }
+  // activeOutput: KVS fire-and-forget write; read is skipped here because
+  // enforceOutputState() reads the actual hardware switch state right after
+  // this call — hardware truth overrides any stale KVS value.
 
-  var savedScheduleMode = loadValue(STATE_KEYS.scheduleMode);
-  if (savedScheduleMode !== null) {
-    STATE.scheduleMode = savedScheduleMode;
+  // scheduleMode: use Script.storage (synchronous getItem/setItem) so that
+  // the correct mode survives a reboot without needing an async callback chain.
+  var savedMode = loadStorageValue(STORAGE_KEYS.scheduleMode);
+  if (savedMode !== null && (savedMode === "summer" || savedMode === "winter")) {
+    STATE.scheduleMode = savedMode;
     log("Restored schedule mode:", STATE.scheduleMode);
   } else {
     STATE.scheduleMode = "winter";
@@ -781,19 +784,22 @@ function loadState() {
 }
 
 function saveState() {
-  // Skip KVS writes during initialization to avoid callback depth issues
+  // Skip writes during initialization to avoid callback depth issues
   if (STATE.initializing) {
     return;
   }
 
-  // Queue KVS writes to avoid callback depth issues and ensure sequential execution
+  // activeOutput → KVS (fire-and-forget, read by CLI status command)
   queueTask(function() {
     storeValue(STATE_KEYS.activeOutput, STATE.activeOutput);
   });
 
+  // scheduleMode → Script.storage (synchronous read in loadState on next boot)
+  //              → KVS as well (CLI status command reads it there)
   if (STATE.scheduleMode !== null) {
+    storeStorageValue(STORAGE_KEYS.scheduleMode, STATE.scheduleMode);
     queueTask(function() {
-      storeValue(STATE_KEYS.scheduleMode, STATE.scheduleMode);
+      storeValue("schedule-mode", STATE.scheduleMode);
     });
   }
 }


### PR DESCRIPTION
## Summary

- **Root cause of pump never starting automatically**: schedules were created with script ID 0 when `UploadWithVersion` returned 0 (version unchanged) — every scheduled handler silently failed at fire time
- **CLI `ctl pool start` always turned pump off**: `doStart()` received a switch-ID integer instead of the expected speed string
- **Schedule mode lost on every reboot**: `loadState()` used synchronous `Shelly.call` which always returns null in Shelly's async runtime — moved `scheduleMode` persistence to `Script.storage` which has synchronous `getItem`/`setItem`

## Details

**Bug 1 — schedules target wrong script ID** (`pool.go:setupDevice`)

`UploadWithVersion` returns `0` when the script version is unchanged (normal case on 2nd+ `ctl pool add`). That `0` flowed directly into `Schedule.Create` as the script ID. Shelly can't find "script 0", so `handleNightStart()`, `handleMorningStart()` etc. were silently never called. Fixed by fetching the real running script ID via `ScriptStatus` when `uploadedID == 0`.

**Bug 2 — CLI start turns pump off** (`pool.go:Start`)

`doStart(%d, ...)` passed the switch-ID integer (e.g. `2`). `doStart(speed, reason)` expects a speed string — `mapSpeedToSwitch(2)` matched nothing and returned `-1`, turning the pump off. Fixed by passing the speed string: `doStart('%s', ...)`.

**Bug 3 — schedule mode resets to "winter" on every boot** (`pool-pump.js:loadState`)

`loadState()` called `Shelly.call("KVS.Get")` without a callback, which always returns `null` in Shelly's async-only runtime. `STATE.scheduleMode` defaulted to `"winter"` on every restart. If yesterday was `"summer"` (night schedules disabled), today's daily check calling `updateScheduleMode("winter")` was a no-op (`STATE.scheduleMode` was already `"winter"`), permanently disabling night schedules. Fixed by storing `scheduleMode` in `Script.storage` (synchronous) alongside KVS (for the CLI status command).

## Test plan

- [ ] `make test` passes (all existing tests green, including `TestPoolPump_Pro1ToggleAndWaterSupply` and `TestPoolPump_InitVerifiesSchedules`)
- [ ] Run `ctl pool add <device>` twice in a row — second run should print `Script unchanged on <device> (id:N)` with a valid non-zero ID and create schedules referencing that ID
- [ ] Run `ctl pool start <device> eco` — pump should start at eco speed, not stop
- [ ] Verify device logs show correct schedule mode restored on reboot (not always "winter")

Closes #230 (algorithm — future work)
Closes #231 (water-supply events — future work)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): fix three bugs preventing automatic pump start ([bf72197](https://github.com/asnowfix/home-automation/commit/bf7219796efef8f653e13dab033715fb8990510e))
<!-- END-AUTO-GENERATED-COMMITS -->