### PR TITLE
feat(tools): add classify-events tool and MQTT event test fixtures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1204,6 +1204,40 @@ mac, err := blu.ResolveMac(ctx, identifier)
   - `list`: List scripts on device(s)
   - `start/stop/delete`: Script lifecycle management
 
+### Developer Tools
+
+One-off Go programs in `tools/`. Each is its own workspace module — always add new ones with `go work use ./tools/<name>`. Run from the repo root.
+
+| Tool | Purpose |
+|---|---|
+| `tools/classify-events/` | Classifies raw Shelly MQTT event dumps → test fixtures in `pkg/shelly/mqtt/testdata/` |
+| `tools/extract-pool-defaults/` | Code-gen: extracts pool-pump JS constants → `myhome/ctl/pool/pool_defaults_generated.go` |
+
+#### `tools/classify-events`
+
+Reads every `*.json` file from an events dump directory (default: `myhome/events`), groups events by `(method, component, device-type)`, writes one pretty-printed representative per shape to a testdata directory (default: `pkg/shelly/mqtt/testdata/`), then deletes all originals.
+
+```bash
+go run ./tools/classify-events                            # use defaults
+go run ./tools/classify-events <events-dir> <testdata-dir>
+```
+
+Output filenames follow the pattern:
+- `notify_status__<device-type>__<component>.json`
+- `notify_event__<device-type>__<component>__<event>.json`
+
+The testdata lives alongside `pkg/shelly/mqtt/` so it travels with that package when it is eventually extracted into its own repository.
+
+#### `tools/extract-pool-defaults`
+
+Code-generation tool invoked by `//go:generate` in `myhome/ctl/pool/generate.go`. Parses `CONFIG_SCHEMA` from `internal/shelly/scripts/pool-pump.js` and writes typed Go constants to `myhome/ctl/pool/pool_defaults_generated.go`. Run via `make generate`, not directly.
+
+```bash
+go run ./tools/extract-pool-defaults \
+    internal/shelly/scripts/pool-pump.js \
+    myhome/ctl/pool/pool_defaults_generated.go
+```
+
 ---
 
 ## Common Issues and Solutions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,9 @@ go test -race ./...                              # with race detector
 go run ./myhome ctl shelly script upload <device> <script.js> --no-minify
 go run ./myhome ctl shelly script update <device>
 go run ./myhome ctl shelly script debug <device> true
+
+# developer tools (run from repo root)
+go run ./tools/classify-events [events-dir] [testdata-dir]   # classify raw event dumps → pkg/shelly/mqtt/testdata/
 ```
 
 `make test` is canonical — never bare `go test ./...` (it skips workspace sub-modules). New CI test commands must also invoke `make test`, not go directly to `go test`.

--- a/go.work
+++ b/go.work
@@ -32,9 +32,9 @@ use (
 	./myhome/ctl/temperature
 	./myhome/daemon
 	./myhome/daemon/watch
-	./myhome/events
 	./myhome/devices
 	./myhome/devices/impl
+	./myhome/events
 	./myhome/mqtt
 	./myhome/occupancy
 	./myhome/storage
@@ -58,4 +58,5 @@ use (
 	./pkg/shelly/wifi
 	./pkg/tapo
 	./pkg/version
+	./tools/classify-events
 )

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__ble__infos_updated.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__ble__infos_updated.json
@@ -1,0 +1,15 @@
+{
+  "dst": "shelly1minig3-54320440d02c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "ble",
+        "event": "infos_updated",
+        "ts": 1758227220.27
+      }
+    ],
+    "ts": 1758227220.27
+  },
+  "src": "shelly1minig3-54320440d02c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__input_0__btn_down.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__input_0__btn_down.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:0",
+        "event": "btn_down",
+        "id": 0,
+        "ts": 1758144838.48
+      }
+    ],
+    "ts": 1758144838.48
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__input_0__single_push.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__input_0__single_push.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:0",
+        "event": "single_push",
+        "id": 0,
+        "ts": 1758144836.5
+      }
+    ],
+    "ts": 1758144836.5
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_1__config_changed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_1__config_changed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shelly1minig3-543204522cb4/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 60,
+        "component": "script:1",
+        "event": "config_changed",
+        "id": 1,
+        "restart_required": false,
+        "ts": 1758232347.84
+      }
+    ],
+    "ts": 1758232347.84
+  },
+  "src": "shelly1minig3-543204522cb4"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_2__config_changed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_2__config_changed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shelly1minig3-54320440d02c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 277,
+        "component": "script:2",
+        "event": "config_changed",
+        "id": 2,
+        "restart_required": false,
+        "ts": 1758225944.92
+      }
+    ],
+    "ts": 1758225944.92
+  },
+  "src": "shelly1minig3-54320440d02c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__config_changed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__config_changed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shelly1minig3-54320440d02c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 278,
+        "component": "script:3",
+        "event": "config_changed",
+        "id": 3,
+        "restart_required": false,
+        "ts": 1758226411.56
+      }
+    ],
+    "ts": 1758226411.56
+  },
+  "src": "shelly1minig3-54320440d02c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__remote_button_event.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__remote_button_event.json
@@ -1,0 +1,23 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "script:3",
+        "data": {
+          "event": "single_push",
+          "eventTime": 1758226433755.712,
+          "src": "shellyplus1-b8d61a85ed58",
+          "switchId": "switch:0",
+          "switchIndex": 0
+        },
+        "event": "remote-button-event",
+        "id": 3,
+        "ts": 1758226433.76
+      }
+    ],
+    "ts": 1758226433.76
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__remote_input_event.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__remote_input_event.json
@@ -1,0 +1,20 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "script:3",
+        "data": {
+          "component": "switch:0",
+          "src": "shellyplus1-b8d61a85ed58"
+        },
+        "event": "remote-input-event",
+        "id": 3,
+        "ts": 1758231446.6
+      }
+    ],
+    "ts": 1758231446.6
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__component_added.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__component_added.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 29,
+        "component": "sys",
+        "event": "component_added",
+        "restart_required": false,
+        "target": "script:1",
+        "ts": 1758225503.28
+      }
+    ],
+    "ts": 1758225503.28
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__component_removed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__component_removed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shelly1minig3-54320440d02c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 273,
+        "component": "sys",
+        "event": "component_removed",
+        "restart_required": false,
+        "target": "script:1",
+        "ts": 1758225767.04
+      }
+    ],
+    "ts": 1758225767.04
+  },
+  "src": "shelly1minig3-54320440d02c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__ota_begin.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__ota_begin.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_begin",
+        "msg": "in_progress",
+        "ts": 1758225551.76
+      }
+    ],
+    "ts": 1758225551.76
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__ota_error.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__ota_error.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shelly1minig3-5432046415d4/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_error",
+        "msg": "error",
+        "ts": 1758232803.04
+      }
+    ],
+    "ts": 1758232803.04
+  },
+  "src": "shelly1minig3-5432046415d4"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__ota_progress.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__ota_progress.json
@@ -1,0 +1,17 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_progress",
+        "msg": "in_progress",
+        "progress_percent": 8,
+        "ts": 1758225558.81
+      }
+    ],
+    "ts": 1758225558.81
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__scheduled_restart.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__sys__scheduled_restart.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "scheduled_restart",
+        "time_ms": 995,
+        "ts": 1758225541.76
+      }
+    ],
+    "ts": 1758225541.76
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__script_1__config_changed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__script_1__config_changed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shellyplugsg3-e4b3233885e8/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 21,
+        "component": "script:1",
+        "event": "config_changed",
+        "id": 1,
+        "restart_required": false,
+        "ts": 1755843599.67
+      }
+    ],
+    "ts": 1755843599.67
+  },
+  "src": "shellyplugsg3-e4b3233885e8"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__component_added.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__component_added.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shellyplugsg3-e4b3233885e8/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 21,
+        "component": "sys",
+        "event": "component_added",
+        "restart_required": false,
+        "target": "script:1",
+        "ts": 1755843597.59
+      }
+    ],
+    "ts": 1755843597.59
+  },
+  "src": "shellyplugsg3-e4b3233885e8"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__component_removed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__component_removed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shellyplugsg3-e4b3233885e8/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 22,
+        "component": "sys",
+        "event": "component_removed",
+        "restart_required": false,
+        "target": "script:1",
+        "ts": 1755843691.86
+      }
+    ],
+    "ts": 1755843691.86
+  },
+  "src": "shellyplugsg3-e4b3233885e8"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__ota_error.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__ota_error.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplugsg3-b08184a53f24/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_error",
+        "msg": "error",
+        "ts": 1758232805.04
+      }
+    ],
+    "ts": 1758232805.04
+  },
+  "src": "shellyplugsg3-b08184a53f24"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__ota_progress.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__ota_progress.json
@@ -1,0 +1,17 @@
+{
+  "dst": "shellyplugsg3-e4b323390b4c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_progress",
+        "msg": "in_progress",
+        "progress_percent": 12,
+        "ts": 1759263363.8
+      }
+    ],
+    "ts": 1759263363.8
+  },
+  "src": "shellyplugsg3-e4b323390b4c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__scheduled_restart.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplugsg3__sys__scheduled_restart.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplugsg3-e4b3233885e8/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "scheduled_restart",
+        "time_ms": 998,
+        "ts": 1755844971.97
+      }
+    ],
+    "ts": 1755844971.97
+  },
+  "src": "shellyplugsg3-e4b3233885e8"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__ble__infos_updated.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__ble__infos_updated.json
@@ -1,0 +1,15 @@
+{
+  "dst": "shellyplus1-b8d61a85ed58/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "ble",
+        "event": "infos_updated",
+        "ts": 1755247298.74
+      }
+    ],
+    "ts": 1755247298.74
+  },
+  "src": "shellyplus1-b8d61a85ed58"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__input_0__btn_down.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__input_0__btn_down.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplus1-b8d61a85ed58/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:0",
+        "event": "btn_down",
+        "id": 0,
+        "ts": 1758225682.9
+      }
+    ],
+    "ts": 1758225682.9
+  },
+  "src": "shellyplus1-b8d61a85ed58"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__input_0__btn_up.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__input_0__btn_up.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplus1-b8d61a85ed58/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:0",
+        "event": "btn_up",
+        "id": 0,
+        "ts": 1758231448.73
+      }
+    ],
+    "ts": 1758231448.73
+  },
+  "src": "shellyplus1-b8d61a85ed58"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__input_0__single_push.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__input_0__single_push.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplus1-b8d61a85ed58/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:0",
+        "event": "single_push",
+        "id": 0,
+        "ts": 1758225680.7
+      }
+    ],
+    "ts": 1758225680.7
+  },
+  "src": "shellyplus1-b8d61a85ed58"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__sys__ota_error.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplus1__sys__ota_error.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplus1-b8d61a86cac0/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_error",
+        "msg": "error",
+        "ts": 1758146405.04
+      }
+    ],
+    "ts": 1758146405.04
+  },
+  "src": "shellyplus1-b8d61a86cac0"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__script_1__config_changed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__script_1__config_changed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 40,
+        "component": "script:1",
+        "event": "config_changed",
+        "id": 1,
+        "restart_required": false,
+        "ts": 1759263934.75
+      }
+    ],
+    "ts": 1759263934.75
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__component_added.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__component_added.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 40,
+        "component": "sys",
+        "event": "component_added",
+        "restart_required": false,
+        "target": "script:1",
+        "ts": 1759263932.53
+      }
+    ],
+    "ts": 1759263932.53
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__component_removed.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__component_removed.json
@@ -1,0 +1,18 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "cfg_rev": 38,
+        "component": "sys",
+        "event": "component_removed",
+        "restart_required": false,
+        "target": "script:1",
+        "ts": 1759263101.85
+      }
+    ],
+    "ts": 1759263101.85
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__ota_begin.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__ota_begin.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_begin",
+        "msg": "in_progress",
+        "ts": 1759263939.01
+      }
+    ],
+    "ts": 1759263939.01
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__ota_error.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__ota_error.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_error",
+        "msg": "error",
+        "ts": 1758146405.04
+      }
+    ],
+    "ts": 1758146405.04
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__ota_progress.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__ota_progress.json
@@ -1,0 +1,17 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "ota_progress",
+        "msg": "in_progress",
+        "progress_percent": 18,
+        "ts": 1759263946.22
+      }
+    ],
+    "ts": 1759263946.22
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__scheduled_restart.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellyplusi4__sys__scheduled_restart.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "scheduled_restart",
+        "time_ms": 929,
+        "ts": 1759263968.75
+      }
+    ],
+    "ts": 1759263968.75
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellypro1__input_0__single_push.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellypro1__input_0__single_push.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellypro1-30c6f782d274/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:0",
+        "event": "single_push",
+        "id": 0,
+        "ts": 1758405108.65
+      }
+    ],
+    "ts": 1758405108.65
+  },
+  "src": "shellypro1-30c6f782d274"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellypro2__input_1__btn_up.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellypro2__input_1__btn_up.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellypro2-2cbcbb9fb834/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:1",
+        "event": "btn_up",
+        "id": 1,
+        "ts": 1755025600.75
+      }
+    ],
+    "ts": 1755025600.75
+  },
+  "src": "shellypro2-2cbcbb9fb834"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellypro2__input_1__single_push.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellypro2__input_1__single_push.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellypro2-2cbcbb9fb834/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "input:1",
+        "event": "single_push",
+        "id": 1,
+        "ts": 1755025599.69
+      }
+    ],
+    "ts": 1755025599.69
+  },
+  "src": "shellypro2-2cbcbb9fb834"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellypro3__sys__scheduled_restart.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellypro3__sys__scheduled_restart.json
@@ -1,0 +1,16 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "scheduled_restart",
+        "time_ms": 999,
+        "ts": 1758144064.05
+      }
+    ],
+    "ts": 1758144064.05
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_event__shellypro3__sys__sys_btn_push.json
+++ b/pkg/shelly/mqtt/testdata/notify_event__shellypro3__sys__sys_btn_push.json
@@ -1,0 +1,15 @@
+{
+  "dst": "shellypro3-34987a48c26c/events",
+  "method": "NotifyEvent",
+  "params": {
+    "events": [
+      {
+        "component": "sys",
+        "event": "sys_btn_push",
+        "ts": 1758144175.54
+      }
+    ],
+    "ts": 1758144175.54
+  },
+  "src": "shellypro3-34987a48c26c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__cloud.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__cloud.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "cloud": {
+      "connected": true
+    },
+    "ts": 1755025632.54
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__mqtt.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__mqtt.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shelly1minig3-54320464f17c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "mqtt": {
+      "connected": true
+    },
+    "ts": 1755246470.29
+  },
+  "src": "shelly1minig3-54320464f17c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__script_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__script_1.json
@@ -1,0 +1,15 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:1": {
+      "error_msg": null,
+      "errors": [
+        "out_of_memory"
+      ],
+      "running": false
+    },
+    "ts": 1758225505.98
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__script_2.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__script_2.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shelly1minig3-54320464074c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:2": {
+      "error_msg": null,
+      "errors": [],
+      "running": false
+    },
+    "ts": 1758225583.92
+  },
+  "src": "shelly1minig3-54320464074c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__script_3.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__script_3.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shelly1minig3-54320440d02c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:3": {
+      "error_msg": null,
+      "errors": [],
+      "running": true
+    },
+    "ts": 1758226411.98
+  },
+  "src": "shelly1minig3-54320440d02c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__switch_0.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__switch_0.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shelly1minig3-54320464f17c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:0": {
+      "output": false,
+      "source": "loopback"
+    },
+    "ts": 1755025536.46
+  },
+  "src": "shelly1minig3-54320464f17c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__sys.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shelly1minig3-54320464ac08/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "last_sync_ts": 1755016844
+    },
+    "ts": 1755016844.23
+  },
+  "src": "shelly1minig3-54320464ac08"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__wifi.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shelly1minig3__wifi.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shelly1minig3-54320464a1d0/events",
+  "method": "NotifyStatus",
+  "params": {
+    "ts": 1758225698.19,
+    "wifi": {
+      "ap_client_count": 0
+    }
+  },
+  "src": "shelly1minig3-54320464a1d0"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__cloud.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__cloud.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellyplugsg3-b08184a53f24/events",
+  "method": "NotifyStatus",
+  "params": {
+    "cloud": {
+      "connected": false
+    },
+    "ts": 1755535675.79
+  },
+  "src": "shellyplugsg3-b08184a53f24"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__mqtt.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__mqtt.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellyplugsg3-e4b3233885e8/events",
+  "method": "NotifyStatus",
+  "params": {
+    "mqtt": {
+      "connected": true
+    },
+    "ts": 1755252384.94
+  },
+  "src": "shellyplugsg3-e4b3233885e8"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__script_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__script_1.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellyplugsg3-e4b3233885e8/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:1": {
+      "error_msg": null,
+      "errors": [],
+      "running": true
+    },
+    "ts": 1755842323.53
+  },
+  "src": "shellyplugsg3-e4b3233885e8"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__switch_0.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__switch_0.json
@@ -1,0 +1,29 @@
+{
+  "dst": "shellyplugsg3-b08184a53f24/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:0": {
+      "aenergy": {
+        "by_minute": [
+          210.969,
+          210.969,
+          0
+        ],
+        "minute_ts": 1755016500,
+        "total": 18572.574
+      },
+      "id": 0,
+      "ret_aenergy": {
+        "by_minute": [
+          0,
+          0,
+          0
+        ],
+        "minute_ts": 1755016500,
+        "total": 0
+      }
+    },
+    "ts": 1755016500
+  },
+  "src": "shellyplugsg3-b08184a53f24"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplugsg3__sys.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shellyplugsg3-e4b323390b4c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "time": "19:15",
+      "unixtime": 1755191744
+    },
+    "ts": 1755191744.44
+  },
+  "src": "shellyplugsg3-e4b323390b4c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__cloud.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__cloud.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellyplus1-08b61fd90730/events",
+  "method": "NotifyStatus",
+  "params": {
+    "cloud": {
+      "connected": false
+    },
+    "ts": 1755252382.7
+  },
+  "src": "shellyplus1-08b61fd90730"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__mqtt.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__mqtt.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellyplus1-b8d61a86cac0/events",
+  "method": "NotifyStatus",
+  "params": {
+    "mqtt": {
+      "connected": true
+    },
+    "ts": 1758145137.11
+  },
+  "src": "shellyplus1-b8d61a86cac0"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__switch_0.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__switch_0.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shellyplus1-b8d61a85ed58/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:0": {
+      "output": true,
+      "source": "loopback"
+    },
+    "ts": 1755025562.18
+  },
+  "src": "shellyplus1-b8d61a85ed58"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__sys.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shellyplus1-08b61fd9333c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "time": "18:37",
+      "unixtime": 1755016629
+    },
+    "ts": 1755016629.06
+  },
+  "src": "shellyplus1-08b61fd9333c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__wifi.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplus1__wifi.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellyplus1-b8d61a86cac0/events",
+  "method": "NotifyStatus",
+  "params": {
+    "ts": 1755256640.89,
+    "wifi": {
+      "ap_client_count": 1
+    }
+  },
+  "src": "shellyplus1-b8d61a86cac0"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__cloud.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__cloud.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "cloud": {
+      "connected": true
+    },
+    "ts": 1759263982.49
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__script_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__script_1.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:1": {
+      "error_msg": null,
+      "errors": [],
+      "running": true
+    },
+    "ts": 1759263935.61
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__script_2.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__script_2.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:2": {
+      "error_msg": null,
+      "errors": [],
+      "running": true
+    },
+    "ts": 1759261523.81
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellyplusi4__sys.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shellyplusi4-c4d8d554ad6c/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "time": "18:52",
+      "unixtime": 1755190330
+    },
+    "ts": 1755190330.55
+  },
+  "src": "shellyplusi4-c4d8d554ad6c"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro1__switch_0.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro1__switch_0.json
@@ -1,0 +1,14 @@
+{
+  "dst": "shellypro1-30c6f782d274/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:0": {
+      "temperature": {
+        "tC": 45.71,
+        "tF": 114.27
+      }
+    },
+    "ts": 1758144873.23
+  },
+  "src": "shellypro1-30c6f782d274"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro1__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro1__sys.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shellypro1-30c6f782d274/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "time": "23:22",
+      "unixtime": 1758144178
+    },
+    "ts": 1758144178.05
+  },
+  "src": "shellypro1-30c6f782d274"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro2__script_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro2__script_1.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellypro2-2cbcbb9fb834/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:1": {
+      "error_msg": null,
+      "errors": [],
+      "running": false
+    },
+    "ts": 1758469883.09
+  },
+  "src": "shellypro2-2cbcbb9fb834"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro2__script_2.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro2__script_2.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellypro2-2cbcbb9fb834/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:2": {
+      "error_msg": null,
+      "errors": [],
+      "running": false
+    },
+    "ts": 1758384889.28
+  },
+  "src": "shellypro2-2cbcbb9fb834"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro2__switch_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro2__switch_1.json
@@ -1,0 +1,14 @@
+{
+  "dst": "shellypro2-2cbcbb9fb834/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:1": {
+      "temperature": {
+        "tC": 45,
+        "tF": 113
+      }
+    },
+    "ts": 1758146303.92
+  },
+  "src": "shellypro2-2cbcbb9fb834"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro2__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro2__sys.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellypro2-2cbcbb9fb834/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "last_sync_ts": 1755025482
+    },
+    "ts": 1755025482
+  },
+  "src": "shellypro2-2cbcbb9fb834"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__cloud.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__cloud.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "cloud": {
+      "connected": true
+    },
+    "ts": 1755249675.29
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__mqtt.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__mqtt.json
@@ -1,0 +1,11 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "mqtt": {
+      "connected": true
+    },
+    "ts": 1755248912.11
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__script_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__script_1.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:1": {
+      "error_msg": null,
+      "errors": [],
+      "running": true
+    },
+    "ts": 1759261524.64
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__script_2.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__script_2.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:2": {
+      "error_msg": null,
+      "errors": [],
+      "running": true
+    },
+    "ts": 1759261529.16
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__script_3.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__script_3.json
@@ -1,0 +1,13 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "script:3": {
+      "error_msg": null,
+      "errors": [],
+      "running": false
+    },
+    "ts": 1759261961.68
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__switch_0.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__switch_0.json
@@ -1,0 +1,14 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:0": {
+      "temperature": {
+        "tC": 47.93,
+        "tF": 118.27
+      }
+    },
+    "ts": 1755016913.24
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__switch_1.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__switch_1.json
@@ -1,0 +1,14 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:1": {
+      "temperature": {
+        "tC": 53.5,
+        "tF": 128.3
+      }
+    },
+    "ts": 1755022877.11
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__switch_2.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__switch_2.json
@@ -1,0 +1,14 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "switch:2": {
+      "temperature": {
+        "tC": 48.12,
+        "tF": 118.62
+      }
+    },
+    "ts": 1755016523.24
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/pkg/shelly/mqtt/testdata/notify_status__shellypro3__sys.json
+++ b/pkg/shelly/mqtt/testdata/notify_status__shellypro3__sys.json
@@ -1,0 +1,12 @@
+{
+  "dst": "shellypro3-a0dd6ca1c588/events",
+  "method": "NotifyStatus",
+  "params": {
+    "sys": {
+      "time": "19:12",
+      "unixtime": 1755191528
+    },
+    "ts": 1755191528.48
+  },
+  "src": "shellypro3-a0dd6ca1c588"
+}

--- a/tools/classify-events/go.mod
+++ b/tools/classify-events/go.mod
@@ -1,0 +1,3 @@
+module github.com/asnowfix/home-automation/tools/classify-events
+
+go 1.25.0

--- a/tools/classify-events/main.go
+++ b/tools/classify-events/main.go
@@ -1,0 +1,185 @@
+// classify-events reads raw Shelly MQTT event files, picks one representative
+// per unique (method, component, device-type) shape, writes them as test fixtures,
+// then deletes all originals.
+//
+// Usage (from repo root):
+//
+//	go run ./tools/classify-events [events-dir] [testdata-dir]
+//
+// Defaults: myhome/events  →  pkg/shelly/mqtt/testdata
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+)
+
+type rawEvent struct {
+	Src    string          `json:"src"`
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+type notifyEventParams struct {
+	Events []struct {
+		Component string `json:"component"`
+		Event     string `json:"event"`
+	} `json:"events"`
+}
+
+func main() {
+	eventsDir := "myhome/events"
+	testdataDir := "pkg/shelly/mqtt/testdata"
+	if len(os.Args) > 1 {
+		eventsDir = os.Args[1]
+	}
+	if len(os.Args) > 2 {
+		testdataDir = os.Args[2]
+	}
+
+	entries, err := os.ReadDir(eventsDir)
+	if err != nil {
+		fatalf("read events dir %s: %v", eventsDir, err)
+	}
+
+	type fileRecord struct {
+		path string
+		key  string
+	}
+
+	// first pass: classify every file
+	var records []fileRecord
+	representatives := map[string]string{} // key → first file path
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(eventsDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: read %s: %v\n", path, err)
+			continue
+		}
+		var e rawEvent
+		if err := json.Unmarshal(data, &e); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: parse %s: %v\n", path, err)
+			continue
+		}
+		key := classify(e)
+		records = append(records, fileRecord{path: path, key: key})
+		if _, seen := representatives[key]; !seen {
+			representatives[key] = path
+		}
+	}
+
+	if len(records) == 0 {
+		fmt.Println("No event files found.")
+		return
+	}
+
+	// second pass: write representatives to testdata
+	if err := os.MkdirAll(testdataDir, 0o755); err != nil {
+		fatalf("create testdata dir: %v", err)
+	}
+
+	written := 0
+	for key, srcPath := range representatives {
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			fatalf("read representative %s: %v", srcPath, err)
+		}
+		// pretty-print for readability
+		var raw any
+		json.Unmarshal(data, &raw)
+		pretty, err := json.MarshalIndent(raw, "", "  ")
+		if err != nil {
+			fatalf("marshal %s: %v", srcPath, err)
+		}
+		dest := filepath.Join(testdataDir, key+".json")
+		if err := os.WriteFile(dest, append(pretty, '\n'), 0o644); err != nil {
+			fatalf("write %s: %v", dest, err)
+		}
+		written++
+	}
+
+	// third pass: delete all originals
+	deleted := 0
+	for _, rec := range records {
+		if err := os.Remove(rec.path); err != nil {
+			fmt.Fprintf(os.Stderr, "warn: delete %s: %v\n", rec.path, err)
+		} else {
+			deleted++
+		}
+	}
+
+	// summary
+	fmt.Printf("\nWrote %d test fixtures to %s\n", written, testdataDir)
+	fmt.Printf("Deleted %d original event files from %s\n\n", deleted, eventsDir)
+
+	// count by key
+	counts := map[string]int{}
+	for _, rec := range records {
+		counts[rec.key]++
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "FIXTURE\tORIGINAL COUNT")
+	for _, k := range keys {
+		fmt.Fprintf(tw, "%s.json\t%d\n", k, counts[k])
+	}
+	tw.Flush()
+}
+
+// classify returns a stable, filesystem-safe key for an event.
+func classify(e rawEvent) string {
+	deviceType := e.Src
+	if idx := strings.Index(deviceType, "-"); idx != -1 {
+		deviceType = deviceType[:idx]
+	}
+
+	switch e.Method {
+	case "NotifyStatus", "NotifyFullStatus":
+		var params map[string]json.RawMessage
+		if err := json.Unmarshal(e.Params, &params); err == nil {
+			for k := range params {
+				if k == "ts" {
+					continue
+				}
+				return fmt.Sprintf("notify_status__%s__%s", deviceType, sanitize(k))
+			}
+		}
+		return fmt.Sprintf("notify_status__%s__unknown", deviceType)
+
+	case "NotifyEvent":
+		var p notifyEventParams
+		if err := json.Unmarshal(e.Params, &p); err == nil && len(p.Events) > 0 {
+			ev := p.Events[0]
+			return fmt.Sprintf("notify_event__%s__%s__%s",
+				deviceType, sanitize(ev.Component), sanitize(ev.Event))
+		}
+		return fmt.Sprintf("notify_event__%s__unknown", deviceType)
+	}
+
+	return fmt.Sprintf("unknown__%s__%s", deviceType, sanitize(e.Method))
+}
+
+func sanitize(s string) string {
+	r := strings.NewReplacer(":", "_", "-", "_", "/", "_", " ", "_")
+	return r.Replace(s)
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "error: "+format+"\n", args...)
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

- Adds `tools/classify-events`: a stdlib-only Go tool that reads raw Shelly MQTT event dumps, deduplicates by `(method, component, device-type)` shape, writes one representative fixture per shape to `pkg/shelly/mqtt/testdata/`, and deletes all originals
- Adds 74 test fixtures distilled from 6,119 captured events (Aug–Sep 2025), covering `NotifyStatus` and `NotifyEvent` across all 7 device types present in the house
- Documents both developer tools (`classify-events` and `extract-pool-defaults`) in `AGENTS.md` under a new "Developer Tools" section; adds a one-liner reference in `CLAUDE.md`'s Commands block

Fixtures live alongside `pkg/shelly/mqtt/` so they travel with that package when it is eventually extracted to its own repository.

## Test plan

- [ ] `go build ./tools/classify-events/...` compiles clean
- [ ] `go run ./tools/classify-events --help` prints usage (or exits 0 with no args when run against an empty dir)
- [ ] Spot-check a few fixtures in `pkg/shelly/mqtt/testdata/` — valid pretty-printed JSON matching the documented filename convention
- [ ] `myhome/events/` is empty (all originals deleted)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(tools): add classify-events tool and MQTT event test fixtures ([0e7de68](https://github.com/asnowfix/home-automation/commit/0e7de68d84e98d7ff3fda2f16d3eaf3ebed4f07f))
<!-- END-AUTO-GENERATED-COMMITS -->