### PR TITLE
fix(pool-pump): fix OOM crash and pump-never-starts on Pro1

### DIFF
--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -295,6 +295,8 @@ function loadConfig(callback) {
       }
 
       log("Configuration loaded successfully");
+      // Free schema object — only needed during KVS loading, not at runtime
+      CONFIG_SCHEMA = null;
       callback(true);
       return;
     }
@@ -487,8 +489,13 @@ function loadStorageValue(key) {
   if (v === "null" || v === "undefined") return null;
   if (v === "true") return true;
   if (v === "false") return false;
-  var num = Number(v);
-  if (!isNaN(num)) return num;
+  try {
+    var num = Number(v);
+    if (!isNaN(num)) return num;
+  } catch (e) {
+    // Espruino throws "String too big to convert to float" on long strings
+    if (e && false) {}
+  }
   try {
     return JSON.parse(v);
   } catch (e) {
@@ -794,6 +801,8 @@ function applyComponentNames(callback) {
   function processNext() {
     if (index >= componentsToConfig.length) {
       log("All component names applied");
+      // Free static data — only needed during component setup
+      COMPONENT_NAMES = null;
       if (callback) callback();
       return;
     }


### PR DESCRIPTION
## Summary

- **Pump never starts**: `script/pool-pump/preferred` was set to the device *name* (`filtration-hiver`) but `isMyTurnToRun()` compares against the device *ID* (`shellypro1-ec62608c0230`). Always `false` → every `doStart()` was a silent no-op. Fixed in KVS (not in this diff).
- **OOM crash on startup**: `CONFIG_SCHEMA` and `COMPONENT_NAMES` were large static objects kept alive for the script lifetime. Both are now freed to `null` immediately after use. Peak JS heap drops from exhausted (~28 KB used, crash) to stable 18 KB.
- **`String too big to convert to float`**: `loadStorageValue()` called `Number(v)` bare; Espruino throws on long strings (e.g. the stored forecast URL) instead of returning `NaN`. Wrapped in try/catch so it falls through to `JSON.parse` and returns the string as-is.

Also fixed in KVS (not in this diff): `script/pool-pump/pro3-id` was pointing at the Pro1's own device ID — a leftover from when the Pro3 also ran the script. Cleared so `subscribePro3Status()` is a no-op.

## Test plan

- [x] Script starts and stays `running: true` on filtration-hiver (previously crashed immediately with `out_of_memory`)
- [x] `isMyTurnToRun()` returns `true` after KVS fix
- [x] `scheduleMode` resolved to `summer` after daily check ran successfully
- [x] `mem_peak: 17920`, `mem_free: 10360` — well within JS heap limits<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): fix OOM crash and pump-never-starts on Pro1 ([9eb4a69](https://github.com/asnowfix/home-automation/commit/9eb4a6956d6f509f1bd9c2ba38b7b723856a46fd))
<!-- END-AUTO-GENERATED-COMMITS -->