### PR TITLE
fix(blu-listener): fix Too many calls crash, remove in-script illuminance tracking

### DIFF
--- a/internal/shelly/scripts/blu-listener.js
+++ b/internal/shelly/scripts/blu-listener.js
@@ -4,24 +4,20 @@
 //   Value must be a JSON string: matching documentation below
 // - On match: Switch.Set on the configured switch; if auto_off>0, turns it off after N seconds.
 //
+// Illuminance min/max are plain lux numbers. Percentage-based aggregation is
+// handled by the daemon (see issue #249).
 
 /**
  * The KVS value `follow/shelly-blu/<MAC>` must be a JSON string matching this type.
  * @typedef {Object} FollowConfig
  * @property {string} switch_id - The switch ID to be used for turning on the switch.
  * @property {number} auto_off - The number of seconds to wait before turning off the switch.
- * @property {number|string} illuminance_min - The minimum illuminance value in lux, or percentage string (e.g., "20%").
- * @property {number|string} illuminance_max - The maximum illuminance value in lux, or percentage string (e.g., "80%").
- * @property {string} next_switch - The next switch ID to be used for turning on the switch.
+ * @property {number} illuminance_min - Minimum illuminance in lux (strict >).
+ * @property {number} illuminance_max - Maximum illuminance in lux (strict <).
+ * @property {string} next_switch - Optional next switch ID to turn on after auto-off.
  * @example
- * {"switch_id":"switch:0","auto_off":500,"illuminance_min":"20%","illuminance_max":"80%"}
  * {"switch_id":"switch:0","auto_off":500,"illuminance_min":10,"illuminance_max":100}
- * 
- * Percentage values (0%-100%) are calculated from the 7-day min/max history:
- * - "0%" = minimum illuminance observed in past 7 days
- * - "100%" = maximum illuminance observed in past 7 days
- * - "20%" = 20% between min and max (min + 0.2 * (max - min))
- * 
+ *
  * topic: shelly-blu/events/e8:e0:7e:d0:f9:89
  * message: {
  *     "encryption":false,
@@ -40,25 +36,47 @@ var CONFIG = {
   eventName: "shelly-blu",
   topicPrefix: "shelly-blu/events",
   kvsPrefix: "follow/shelly-blu/",
-  statePrefix: "state/shelly-blu/",
   log: true
 };
 
 var STATE = {
   // switchIndex => timerId
   offTimers: {},
-  
-  // mac (lowercase) => { dailyData: [{ date: "YYYY-MM-DD", min: number, max: number }], currentMin: number, currentMax: number, lastSaveDate: "YYYY-MM-DD" }
-  illuminanceTracking: {},
-
-  // Timer ID for daily save
-  dailySaveTimer: null,
 
   // In-memory cache of follows loaded from KVS by loadFollowsFromKVS()
   // KVS keys are set externally via "myhome ctl follow blu" command
   // Each followed MAC has its own KVS key: follow/shelly-blu/<mac>
   follows: {}
 };
+
+// === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
+// Prevents "Too many calls in progress" by dispatching Shelly.call invocations
+// one at a time, 200 ms apart. Ported verbatim from pool-pump.js.
+var TASK_QUEUE = [];
+var TASK_INDEX = 0;
+var TASK_TIMER = null;
+
+function processTaskQueue() {
+  if (TASK_INDEX >= TASK_QUEUE.length) {
+    if (TASK_TIMER) {
+      Timer.clear(TASK_TIMER);
+      TASK_TIMER = null;
+    }
+    TASK_QUEUE = [];
+    TASK_INDEX = 0;
+    return;
+  }
+  var task = TASK_QUEUE[TASK_INDEX];
+  TASK_INDEX++;
+  task();
+}
+
+function queueTask(task) {
+  TASK_QUEUE.push(task);
+  if (!TASK_TIMER) {
+    TASK_TIMER = Timer.set(200, true, processTaskQueue);
+  }
+}
 
 function getFollows() {
   return STATE.follows;
@@ -70,15 +88,14 @@ function setFollows(map) {
 
 /**
  * In-memory follows cache populated from KVS
- * Stores a map of followed BLE MACs to local action and bounds info.
  *
  * @typedef {Object.<string, FollowEntry>} FollowsMap
  * @typedef {Object} FollowEntry
  * @property {string} switchIdStr        // e.g. "switch:0"
  * @property {number} switchIndex        // numeric index parsed from switchIdStr
  * @property {number} autoOff            // seconds to auto-off; 0 to disable
- * @property {number|string|null} illuminanceMin // number in lux or percentage string (e.g., "20%")
- * @property {number|string|null} illuminanceMax // number in lux or percentage string (e.g., "80%")
+ * @property {number|null} illuminanceMin // lux threshold (strict >); null = no bound
+ * @property {number|null} illuminanceMax // lux threshold (strict <); null = no bound
  * @property {string|null} nextSwitchIdStr      // e.g. "switch:1" for optional chaining
  * @property {number|null} nextSwitchIndex      // numeric index parsed from nextSwitchIdStr
  */
@@ -110,7 +127,6 @@ function normalizeMac(mac) {
 }
 
 function parseSwitchIndex(switchIdStr) {
-  // Expecting format "switch:<number>"
   if (typeof switchIdStr !== "string") return null;
   var parts = switchIdStr.split(":");
   if (parts.length !== 2) return null;
@@ -120,262 +136,6 @@ function parseSwitchIndex(switchIdStr) {
   return n;
 }
 
-function getCurrentDate() {
-  var now = new Date();
-  var year = now.getFullYear();
-  var month = now.getMonth() + 1;
-  var day = now.getDate();
-  return year + "-" + (month < 10 ? "0" : "") + month + "-" + (day < 10 ? "0" : "") + day;
-}
-
-function onLoadIlluminanceStateResponse(mac, callback, resp, err) {
-  if (err || !resp || !resp.value) {
-    // Initialize new tracking state
-    STATE.illuminanceTracking[mac] = {
-      dailyData: [],
-      currentMin: null,
-      currentMax: null,
-      lastSaveDate: getCurrentDate()
-    };
-    if (callback) callback();
-    return;
-  }
-  
-  try {
-    var data = JSON.parse(resp.value);
-    STATE.illuminanceTracking[mac] = {
-      dailyData: data.dailyData || [],
-      currentMin: data.currentMin || null,
-      currentMax: data.currentMax || null,
-      lastSaveDate: data.lastSaveDate || getCurrentDate()
-    };
-    log("Loaded illuminance state for", mac, ":", STATE.illuminanceTracking[mac]);
-  } catch (e) {
-    log("Error parsing illuminance state for", mac, ":", e);
-    STATE.illuminanceTracking[mac] = {
-      dailyData: [],
-      currentMin: null,
-      currentMax: null,
-      lastSaveDate: getCurrentDate()
-    };
-  }
-  if (callback) callback();
-}
-
-function loadIlluminanceState(mac, callback) {
-  var key = CONFIG.statePrefix + mac;
-  Shelly.call("KVS.Get", { key: key }, onLoadIlluminanceStateResponse.bind(null, mac, callback));
-}
-
-function onSaveIlluminanceStateResponse(mac, callback, resp, err) {
-  if (err) {
-    log("Error saving illuminance state for", mac, ":", err);
-  } else {
-    log("Saved illuminance state for", mac);
-  }
-  if (callback) callback();
-}
-
-function saveIlluminanceState(mac, callback) {
-  var tracking = STATE.illuminanceTracking[mac];
-  if (!tracking) {
-    if (callback) callback();
-    return;
-  }
-  
-  var key = CONFIG.statePrefix + mac;
-  var value = JSON.stringify({
-    dailyData: tracking.dailyData,
-    currentMin: tracking.currentMin,
-    currentMax: tracking.currentMax,
-    lastSaveDate: tracking.lastSaveDate
-  });
-  
-  Shelly.call("KVS.Set", { key: key, value: value }, onSaveIlluminanceStateResponse.bind(null, mac, callback));
-}
-
-function updateIlluminanceTracking(mac, illuminance) {
-  if (typeof illuminance !== "number") return;
-  
-  var tracking = STATE.illuminanceTracking[mac];
-  if (!tracking) {
-    tracking = STATE.illuminanceTracking[mac] = {
-      dailyData: [],
-      currentMin: null,
-      currentMax: null,
-      lastSaveDate: getCurrentDate()
-    };
-  }
-  
-  var currentDate = getCurrentDate();
-  
-  // Check if we need to save yesterday's data and start a new day
-  if (tracking.lastSaveDate !== currentDate) {
-    // Save previous day's min/max if we have data
-    if (tracking.currentMin !== null && tracking.currentMax !== null) {
-      tracking.dailyData.push({
-        date: tracking.lastSaveDate,
-        min: tracking.currentMin,
-        max: tracking.currentMax
-      });
-      
-      // Keep only last 7 days (remove oldest entries from beginning)
-      while (tracking.dailyData.length > 7) {
-        // Manual shift: remove first element (shift() not supported, pop() removes from end)
-        var newArray = [];
-        for (var i = 1; i < tracking.dailyData.length; i++) {
-          newArray.push(tracking.dailyData[i]);
-        }
-        tracking.dailyData = newArray;
-      }
-      
-      log("Saved daily illuminance for", mac, "date:", tracking.lastSaveDate, "min:", tracking.currentMin, "max:", tracking.currentMax);
-    }
-    
-    // Reset for new day - initialize to null so first value sets both min and max
-    tracking.currentMin = null;
-    tracking.currentMax = null;
-    tracking.lastSaveDate = currentDate;
-  }
-  
-  // Update current day's min/max (handles both new day and same day updates)
-  if (tracking.currentMin === null || illuminance < tracking.currentMin) {
-    tracking.currentMin = illuminance;
-  }
-  if (tracking.currentMax === null || illuminance > tracking.currentMax) {
-    tracking.currentMax = illuminance;
-  }
-}
-
-function getSevenDayMinMax(mac) {
-  var tracking = STATE.illuminanceTracking[mac];
-  if (!tracking || !tracking.dailyData || tracking.dailyData.length === 0) {
-    return { min: null, max: null };
-  }
-  
-  var overallMin = null;
-  var overallMax = null;
-  
-  // Check historical data
-  for (var i = 0; i < tracking.dailyData.length; i++) {
-    var day = tracking.dailyData[i];
-    if (typeof day.min === "number") {
-      if (overallMin === null || day.min < overallMin) {
-        overallMin = day.min;
-      }
-    }
-    if (typeof day.max === "number") {
-      if (overallMax === null || day.max > overallMax) {
-        overallMax = day.max;
-      }
-    }
-  }
-  
-  // Include current day's data
-  if (tracking.currentMin !== null) {
-    if (overallMin === null || tracking.currentMin < overallMin) {
-      overallMin = tracking.currentMin;
-    }
-  }
-  if (tracking.currentMax !== null) {
-    if (overallMax === null || tracking.currentMax > overallMax) {
-      overallMax = tracking.currentMax;
-    }
-  }
-  
-  return { min: overallMin, max: overallMax };
-}
-
-function parseIlluminanceValue(value, mac) {
-  if (typeof value === "number") {
-    return value;
-  }
-  
-  if (typeof value === "string" && value.length > 1 && value.charAt(value.length - 1) === "%") {
-    var percentStr = value.substring(0, value.length - 1);
-    var percent = Number(percentStr);
-    
-    if (isNaN(percent) || percent < 0 || percent > 100) {
-      log("Invalid percentage value:", value, "for", mac);
-      return null;
-    }
-    
-    var sevenDayRange = getSevenDayMinMax(mac);
-    if (sevenDayRange.min === null || sevenDayRange.max === null) {
-      log("No historical data available for percentage calculation:", mac);
-      return null;
-    }
-    
-    // Calculate the actual value based on percentage
-    var range = sevenDayRange.max - sevenDayRange.min;
-    var actualValue = sevenDayRange.min + (range * percent / 100);
-    
-    log("Converted", value, "to", actualValue, "for", mac, "(range:", sevenDayRange.min, "-", sevenDayRange.max, ")");
-    return actualValue;
-  }
-  
-  return null;
-}
-
-function saveAllIlluminanceStates(callback) {
-  var macs = Object.keys(STATE.illuminanceTracking);
-  if (macs.length === 0) {
-    if (callback) callback();
-    return;
-  }
-  
-  var pending = macs.length;
-  function onStateSaved() {
-    pending--;
-    if (pending === 0 && callback) callback();
-  }
-  
-  for (var i = 0; i < macs.length; i++) {
-    saveIlluminanceState(macs[i], onStateSaved);
-  }
-}
-
-function onDailySaveRecurring() {
-  log("Daily save timer triggered (recurring)");
-  saveAllIlluminanceStates();
-}
-
-function onDailySaveFirstTime() {
-  log("Daily save timer triggered");
-  saveAllIlluminanceStates();
-  // Set up next day's timer (24 hours)
-  STATE.dailySaveTimer = Timer.set(24 * 60 * 60 * 1000, true, onDailySaveRecurring);
-}
-
-function setupDailySaveTimer() {
-  // Clear existing timer
-  if (STATE.dailySaveTimer) {
-    Timer.clear(STATE.dailySaveTimer);
-  }
-  
-  // Calculate milliseconds until next midnight using basic Date methods
-  var now = new Date();
-  var currentTime = now.getTime();
-  var currentHour = now.getHours();
-  var currentMinute = now.getMinutes();
-  var currentSecond = now.getSeconds();
-  var currentMs = now.getMilliseconds();
-  
-  // Calculate milliseconds from now until midnight
-  var msUntilMidnight = (23 - currentHour) * 60 * 60 * 1000 + // remaining hours
-                        (59 - currentMinute) * 60 * 1000 +     // remaining minutes  
-                        (59 - currentSecond) * 1000 +          // remaining seconds
-                        (1000 - currentMs);                    // remaining milliseconds
-  
-  // Add 1 second to ensure we're past midnight
-  msUntilMidnight += 1000;
-  
-  // Set timer for midnight, then repeat every 24 hours
-  STATE.dailySaveTimer = Timer.set(msUntilMidnight, false, onDailySaveFirstTime);
-  
-  log("Set up daily save timer, next save in", Math.round(msUntilMidnight / 1000), "seconds");
-}
-
 function onProcessKvsKeyResponse(k, newMap, onComplete, gresp, gerr) {
   if (gerr) {
     log("KVS.Get error for", k, ":", gerr);
@@ -383,30 +143,29 @@ function onProcessKvsKeyResponse(k, newMap, onComplete, gresp, gerr) {
     return;
   }
   if (!gresp || typeof gresp.value !== "string") {
-    log("KVS.Get error for", k, gerr);
+    log("KVS.Get empty for", k);
     onComplete();
     return;
   }
-  
-  // Skip keys that don't start with our prefix
+
   if (k.indexOf(CONFIG.kvsPrefix) !== 0) {
     log("Skipping non-follow key:", k);
     onComplete();
     return;
   }
-  
+
   try {
     var value = JSON.parse(gresp.value);
     var switchIdStr = value && value.switch_id ? String(value.switch_id) : null;
     var autoOff = value && typeof value.auto_off === "number" ? value.auto_off : 0;
-    var illumMin = value && ("illuminance_min" in value) ? value.illuminance_min : null;
-    var illumMax = value && ("illuminance_max" in value) ? value.illuminance_max : null;
+    var illumMin = value && typeof value.illuminance_min === "number" ? value.illuminance_min : null;
+    var illumMax = value && typeof value.illuminance_max === "number" ? value.illuminance_max : null;
     var nextSwitchStr = value && value.next_switch ? String(value.next_switch) : null;
     var nextIdx = parseSwitchIndex(nextSwitchStr);
     var mac = k.substr(CONFIG.kvsPrefix.length);
     mac = normalizeMac(mac);
     var idx = parseSwitchIndex(switchIdStr);
-    
+
     if (mac && idx !== null) {
       newMap[mac] = {
         switchIdStr: switchIdStr,
@@ -427,52 +186,13 @@ function onProcessKvsKeyResponse(k, newMap, onComplete, gresp, gerr) {
 }
 
 function processKvsKey(k, newMap, onComplete) {
-  Shelly.call("KVS.Get", { key: k }, onProcessKvsKeyResponse.bind(null, k, newMap, onComplete))
-}
-
-// Timer.set(0) breaks the synchronous call chain so the stack resets
-// between iterations, avoiding both stack overflow and nested-anon limits.
-
-function continueLoadIlluminance(macs, callback, index) {
-  loadIlluminanceStatesSequentially(macs, callback, index);
-}
-
-function onOneIlluminanceLoaded(macs, callback, index) {
-  Timer.set(0, false, continueLoadIlluminance.bind(null, macs, callback, index + 1));
-}
-
-function loadIlluminanceStatesSequentially(macs, callback, index) {
-  if (index >= macs.length) {
-    if (callback) callback();
-    return;
-  }
-  loadIlluminanceState(macs[index], onOneIlluminanceLoaded.bind(null, macs, callback, index));
-}
-
-function loadAllIlluminanceStates(macs, callback) {
-  if (!macs || macs.length === 0) {
-    if (callback) callback();
-    return;
-  }
-  loadIlluminanceStatesSequentially(macs, callback, 0);
-}
-
-function onAllIlluminanceStatesLoaded(callback) {
-  if (callback) callback(true);
+  Shelly.call("KVS.Get", { key: k }, onProcessKvsKeyResponse.bind(null, k, newMap, onComplete));
 }
 
 function onAllKeysProcessed(newMap, callback) {
   setFollows(newMap);
   log("Loaded follows:", newMap);
-  loadAllIlluminanceStates(Object.keys(newMap), onAllIlluminanceStatesLoaded.bind(null, callback));
-}
-
-function continueLoadKeys(list, newMap, callback, index) {
-  processKeysSequentially(list, newMap, callback, index);
-}
-
-function onOneKeyLoaded(list, newMap, callback, index) {
-  Timer.set(0, false, continueLoadKeys.bind(null, list, newMap, callback, index + 1));
+  if (callback) callback(true);
 }
 
 function processKeysSequentially(list, newMap, callback, index) {
@@ -480,7 +200,11 @@ function processKeysSequentially(list, newMap, callback, index) {
     onAllKeysProcessed(newMap, callback);
     return;
   }
-  processKvsKey(list[index], newMap, onOneKeyLoaded.bind(null, list, newMap, callback, index));
+  processKvsKey(list[index], newMap, function() {
+    queueTask(function() {
+      processKeysSequentially(list, newMap, callback, index + 1);
+    });
+  });
 }
 
 function onKvsListResponse(callback, resp, err) {
@@ -489,8 +213,7 @@ function onKvsListResponse(callback, resp, err) {
     if (callback) callback(false);
     return;
   }
-  
-  // Normalize possible response shapes
+
   var list = [];
   if (resp) {
     if (resp.keys) {
@@ -506,10 +229,10 @@ function onKvsListResponse(callback, resp, err) {
       }
     }
   }
-  
+
   log("KVS.List keys:", list.length);
   var newMap = {};
-  
+
   if (!list || !list.length) {
     setFollows(newMap);
     log("No followed MACs.");
@@ -534,18 +257,20 @@ function onAutoOffSwitchSetResponse(switchIndex, follow, r, e) {
   else log("Auto-off switch", switchIndex);
   var hasNext = follow && typeof follow.nextSwitchIndex === "number";
   if (hasNext) {
-    Shelly.call("Switch.Set", { id: follow.nextSwitchIndex, on: true }, onNextSwitchSetResponse.bind(null, follow));
+    queueTask(function() {
+      Shelly.call("Switch.Set", { id: follow.nextSwitchIndex, on: true }, onNextSwitchSetResponse.bind(null, follow));
+    });
   }
 }
 
 function onAutoOffTimerFired(switchIndex, follow) {
-  // Always switch OFF current first
-  Shelly.call("Switch.Set", { id: switchIndex, on: false }, onAutoOffSwitchSetResponse.bind(null, switchIndex, follow));
   STATE.offTimers[switchIndex] = 0;
+  queueTask(function() {
+    Shelly.call("Switch.Set", { id: switchIndex, on: false }, onAutoOffSwitchSetResponse.bind(null, switchIndex, follow));
+  });
 }
 
 function ensureAutoOffTimer(switchIndex, seconds, follow) {
-  // Cancel previous timer, set new one if seconds>0
   var prev = STATE.offTimers[switchIndex];
   if (prev) {
     Timer.clear(prev);
@@ -558,66 +283,48 @@ function ensureAutoOffTimer(switchIndex, seconds, follow) {
 }
 
 function handleBluEvent(topic, message) {
-  // message is expected to be JSON with at least { address: ".." }
   var data = null;
   try {
     data = JSON.parse(message);
   } catch (e) {
-    // Reference 'e' so minifier keeps the parameter (prevents `catch {}`)
     log("Invalid JSON on", topic, "payload:", message, "err:", e);
     return;
   }
   var mac = normalizeMac(data && data.address);
-  if (!mac) return; // not a BLU payload we care about
+  if (!mac) return;
 
   var follows = getFollows();
   var follow = follows[mac];
-  if (!follow) return; // not followed
-
-  // Track illuminance data for all followed devices (regardless of motion)
-  var illuminance = (data && typeof data.illuminance === "number") ? data.illuminance : null;
-  if (illuminance !== null) {
-    updateIlluminanceTracking(mac, illuminance);
-  }
+  if (!follow) return;
 
   // Only act on motion == 1 events
   var motion = data && data.motion;
-  if (!(motion === 1 || motion === "1")) {
-    // Ignore events without motion or with motion 0
-    return;
-  }
+  if (!(motion === 1 || motion === "1")) return;
 
   log("Motion detected for", mac, "illuminance", data.illuminance, "min", follow.illuminanceMin, "max", follow.illuminanceMax);
 
-  // If illuminance bounds are configured, enforce them
-  var parsedMin = follow.illuminanceMin !== null ? parseIlluminanceValue(follow.illuminanceMin, mac) : null;
-  var parsedMax = follow.illuminanceMax !== null ? parseIlluminanceValue(follow.illuminanceMax, mac) : null;
-  var hasMin = parsedMin !== null;
-  var hasMax = parsedMax !== null;
-  
-  if (hasMin || hasMax) {
-    var illum = (data && typeof data.illuminance === "number") ? data.illuminance : null;
+  // Enforce illuminance bounds (plain lux numbers; percentages are resolved by the daemon)
+  var illum = (data && typeof data.illuminance === "number") ? data.illuminance : null;
+  if (follow.illuminanceMin !== null || follow.illuminanceMax !== null) {
     if (illum === null) {
-      // No illuminance provided in event; cannot evaluate bounds -> ignore
-      log("Ignoring due to missing illuminance for bounds", mac, { min: follow.illuminanceMin, max: follow.illuminanceMax });
+      log("Ignoring: no illuminance in event for bounds check", mac);
       return;
     }
-    // Strictly greater than illuminance_min
-    if (hasMin && illum <= parsedMin) {
-      log("Illuminance", illum, "too low (<=", parsedMin, "from", follow.illuminanceMin, ") for", mac);
+    if (follow.illuminanceMin !== null && illum <= follow.illuminanceMin) {
+      log("Illuminance", illum, "too low (<=", follow.illuminanceMin, ") for", mac);
       return;
     }
-    // Strictly less than illuminance_max
-    if (hasMax && illum >= parsedMax) {
-      log("Illuminance", illum, "too high (>=", parsedMax, "from", follow.illuminanceMax, ") for", mac);
+    if (follow.illuminanceMax !== null && illum >= follow.illuminanceMax) {
+      log("Illuminance", illum, "too high (>=", follow.illuminanceMax, ") for", mac);
       return;
     }
   }
-  log("Illuminance bounds ok for", mac, "illuminance", data.illuminance, "parsed min:", parsedMin, "parsed max:", parsedMax);
+  log("Illuminance ok for", mac, "illuminance", illum);
 
-  // Act: turn on configured switch, then setup auto-off
   var idx = follow.switchIndex;
-  Shelly.call("Switch.Set", { id: idx, on: true }, onSwitchSetOnResponse.bind(null, idx, follow, mac));
+  queueTask(function() {
+    Shelly.call("Switch.Set", { id: idx, on: true }, onSwitchSetOnResponse.bind(null, idx, follow, mac));
+  });
   ensureAutoOffTimer(idx, follow.autoOff, follow);
 }
 
@@ -637,7 +344,6 @@ function subscribeMqtt() {
 }
 
 function cancelAllTimers() {
-  // Cancel all ongoing auto-off timers when manual operation is detected
   for (var switchIndex in STATE.offTimers) {
     var timerId = STATE.offTimers[switchIndex];
     if (timerId) {
@@ -658,7 +364,7 @@ function onEventData(eventData) {
         var kvsEvent = eventData.info;
         if (kvsEvent.key && kvsEvent.key.indexOf(CONFIG.kvsPrefix) === 0) {
           log("KVS change detected for key:", kvsEvent.key, "action:", kvsEvent.action);
-          loadFollowsFromKVS();
+          queueTask(function() { loadFollowsFromKVS(); });
         }
       } else if (eventData.info.event === "remote-input-event") {
         log("Remote input event detected (cancelAllTimers)");
@@ -666,12 +372,6 @@ function onEventData(eventData) {
       } else if (eventData.info.component && eventData.info.component.indexOf("input:") === 0) {
         log("Local input event detected (cancelAllTimers)");
         cancelAllTimers();
-      } else if (eventData.info.event === "reboot") {
-        log("Device reboot detected, saving illuminance data");
-        saveAllIlluminanceStates();
-      } else if (eventData.info.event === "script_stop") {
-        log("Script stopping, saving illuminance data");
-        saveAllIlluminanceStates();
       }
     }
   } catch (e) {
@@ -683,18 +383,8 @@ function subscribeEvent() {
   Shelly.addEventHandler(onEventData);
 }
 
-function onHourlyBackupTimer() {
-  log("Hourly backup save triggered");
-  saveAllIlluminanceStates();
-}
-
 function onLoadFollowsComplete(success) {
   if (success) {
-    setupDailySaveTimer();
-    
-    // Set up periodic save every hour as backup
-    Timer.set(60 * 60 * 1000, true, onHourlyBackupTimer);
-    
     log("Script initialization complete");
   } else {
     log("Script initialization failed");

--- a/internal/shelly/scripts/blu_listener_test.go
+++ b/internal/shelly/scripts/blu_listener_test.go
@@ -1,0 +1,364 @@
+package scripts
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+	"github.com/asnowfix/home-automation/pkg/shelly/script"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+const bluListenerScriptPath = "blu-listener.js"
+
+func readBluListenerScript(t *testing.T) []byte {
+	t.Helper()
+	buf, err := os.ReadFile(bluListenerScriptPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", bluListenerScriptPath, err)
+	}
+	return buf
+}
+
+func bluFollowKVS(mac, switchID string, autoOff float64) map[string]interface{} {
+	v, _ := json.Marshal(map[string]interface{}{
+		"switch_id": switchID,
+		"auto_off":  autoOff,
+	})
+	return map[string]interface{}{
+		"follow/shelly-blu/" + mac: string(v),
+	}
+}
+
+func bluFollowKVSWithBounds(mac, switchID string, autoOff float64, illumMin, illumMax interface{}) map[string]interface{} {
+	cfg := map[string]interface{}{
+		"switch_id": switchID,
+		"auto_off":  autoOff,
+	}
+	if illumMin != nil {
+		cfg["illuminance_min"] = illumMin
+	}
+	if illumMax != nil {
+		cfg["illuminance_max"] = illumMax
+	}
+	v, _ := json.Marshal(cfg)
+	return map[string]interface{}{
+		"follow/shelly-blu/" + mac: string(v),
+	}
+}
+
+// injectBluEvent sends a shelly-blu event via the EventInjector channel.
+// The script's onEventData handler routes these to handleBluEvent.
+func injectBluEvent(t *testing.T, injector chan []byte, mac string, illuminance int, motion int) {
+	t.Helper()
+	payload, _ := json.Marshal(map[string]interface{}{
+		"address":     mac,
+		"illuminance": illuminance,
+		"motion":      motion,
+		"battery":     90,
+	})
+	event, _ := json.Marshal(map[string]interface{}{
+		"info": map[string]interface{}{
+			"event":   "shelly-blu",
+			"address": "shelly-blu/events/" + mac,
+			"data":    string(payload),
+		},
+	})
+	injector <- event
+}
+
+func switchIsOn(deviceState *script.DeviceState, switchKey string) bool {
+	if deviceState.ComponentStatus == nil {
+		return false
+	}
+	v, ok := deviceState.ComponentStatus[switchKey]
+	if !ok {
+		return false
+	}
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	on, ok := m["output"].(bool)
+	return ok && on
+}
+
+func newBluListenerState(kvs map[string]interface{}) *script.DeviceState {
+	return &script.DeviceState{
+		KVS:     kvs,
+		Storage: make(map[string]interface{}),
+		ComponentStatus: map[string]interface{}{
+			"switch:0": map[string]interface{}{"id": 0, "output": false},
+			"switch:1": map[string]interface{}{"id": 1, "output": false},
+		},
+		EventInjector: make(chan []byte, 8),
+	}
+}
+
+func runBluListener(ctx context.Context, t *testing.T, buf []byte, state *script.DeviceState) chan error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, bluListenerScriptPath, buf, false, state)
+	}()
+	// Allow script to initialize: KVS.List + KVS.Get chain + onLoadFollowsComplete
+	time.Sleep(300 * time.Millisecond)
+	return done
+}
+
+// TestBluListener_MotionTurnsOnSwitch verifies that a BLU motion event from a
+// followed MAC turns on the configured switch.
+func TestBluListener_MotionTurnsOnSwitch(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	mac := "aa:bb:cc:dd:ee:ff"
+	state := newBluListenerState(bluFollowKVS(mac, "switch:0", 0))
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		10*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	injectBluEvent(t, state.EventInjector, mac, 50, 1)
+
+	ok := waitFor(5*time.Second, 50*time.Millisecond, func() bool {
+		return switchIsOn(state, "switch:0")
+	})
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatal("switch:0 was not turned on after BLU motion event")
+	}
+}
+
+// TestBluListener_NoMotionNoAction verifies that a BLU event with motion=0
+// does not turn on the switch.
+func TestBluListener_NoMotionNoAction(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	mac := "aa:bb:cc:dd:ee:01"
+	state := newBluListenerState(bluFollowKVS(mac, "switch:0", 0))
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		5*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	injectBluEvent(t, state.EventInjector, mac, 50, 0) // motion=0
+
+	time.Sleep(400 * time.Millisecond)
+	cancel()
+	<-done
+
+	if switchIsOn(state, "switch:0") {
+		t.Fatal("switch:0 was turned on despite motion=0")
+	}
+}
+
+// TestBluListener_AutoOffTurnsOffSwitch verifies that the auto-off timer fires
+// and turns the switch off after the configured duration.
+func TestBluListener_AutoOffTurnsOffSwitch(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	mac := "11:22:33:44:55:66"
+	// 0.3 s auto-off to keep the test fast
+	state := newBluListenerState(bluFollowKVS(mac, "switch:0", 0.3))
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		10*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	injectBluEvent(t, state.EventInjector, mac, 50, 1)
+
+	onOk := waitFor(5*time.Second, 50*time.Millisecond, func() bool {
+		return switchIsOn(state, "switch:0")
+	})
+	if !onOk {
+		cancel()
+		<-done
+		t.Fatal("switch:0 was not turned on")
+	}
+
+	offOk := waitFor(5*time.Second, 50*time.Millisecond, func() bool {
+		return !switchIsOn(state, "switch:0")
+	})
+	cancel()
+	<-done
+
+	if !offOk {
+		t.Fatal("switch:0 was not turned off by auto-off timer")
+	}
+}
+
+// TestBluListener_IlluminanceTooHigh verifies that when illuminance >= max,
+// the switch is NOT turned on.
+func TestBluListener_IlluminanceTooHigh(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	mac := "aa:11:bb:22:cc:33"
+	state := newBluListenerState(bluFollowKVSWithBounds(mac, "switch:0", 0, nil, 100))
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		5*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	// illuminance == max (100) → blocked by strict < check
+	injectBluEvent(t, state.EventInjector, mac, 100, 1)
+
+	time.Sleep(400 * time.Millisecond)
+	cancel()
+	<-done
+
+	if switchIsOn(state, "switch:0") {
+		t.Fatal("switch:0 was turned on despite illuminance >= illuminance_max")
+	}
+}
+
+// TestBluListener_IlluminanceTooLow verifies that when illuminance <= min,
+// the switch is NOT turned on.
+func TestBluListener_IlluminanceTooLow(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	mac := "aa:11:bb:22:cc:44"
+	state := newBluListenerState(bluFollowKVSWithBounds(mac, "switch:0", 0, 50, nil))
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		5*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	// illuminance == min (50) → blocked by strict > check
+	injectBluEvent(t, state.EventInjector, mac, 50, 1)
+
+	time.Sleep(400 * time.Millisecond)
+	cancel()
+	<-done
+
+	if switchIsOn(state, "switch:0") {
+		t.Fatal("switch:0 was turned on despite illuminance <= illuminance_min")
+	}
+}
+
+// TestBluListener_IlluminanceWithinBoundsTurnsOn verifies that an event within
+// configured lux bounds does trigger the switch.
+func TestBluListener_IlluminanceWithinBoundsTurnsOn(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	mac := "aa:11:bb:22:cc:55"
+	// min=20, max=100 → illuminance=60 should pass
+	state := newBluListenerState(bluFollowKVSWithBounds(mac, "switch:0", 0, 20, 100))
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		10*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	injectBluEvent(t, state.EventInjector, mac, 60, 1)
+
+	ok := waitFor(5*time.Second, 50*time.Millisecond, func() bool {
+		return switchIsOn(state, "switch:0")
+	})
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatal("switch:0 was not turned on for illuminance within bounds")
+	}
+}
+
+// TestBluListener_KVSReloadPicksUpNewFollow verifies that after a KVS change
+// event, a newly configured follow MAC becomes active.
+func TestBluListener_KVSReloadPicksUpNewFollow(t *testing.T) {
+	buf := readBluListenerScript(t)
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	// Start with no follows
+	state := newBluListenerState(map[string]interface{}{})
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		10*time.Second,
+	)
+	defer cancel()
+
+	done := runBluListener(ctx, t, buf, state)
+
+	// Add follow config to KVS while script is running
+	mac := "ff:ee:dd:cc:bb:aa"
+	v, _ := json.Marshal(map[string]interface{}{
+		"switch_id": "switch:0",
+		"auto_off":  0,
+	})
+	state.KVS["follow/shelly-blu/"+mac] = string(v)
+
+	// Inject KVS change event to trigger reload
+	kvsEvent, _ := json.Marshal(map[string]interface{}{
+		"info": map[string]interface{}{
+			"event":  "kvs",
+			"key":    "follow/shelly-blu/" + mac,
+			"action": "set",
+		},
+	})
+	state.EventInjector <- kvsEvent
+
+	// Allow reload chain to complete
+	time.Sleep(400 * time.Millisecond)
+
+	injectBluEvent(t, state.EventInjector, mac, 50, 1)
+
+	ok := waitFor(5*time.Second, 50*time.Millisecond, func() bool {
+		return switchIsOn(state, "switch:0")
+	})
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatal("switch:0 not turned on after KVS reload added new follow")
+	}
+}

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -777,6 +777,37 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			}
 			return nil, nil
 		},
+		// KVS.List — enumerate keys matching an optional prefix
+		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/KVS#kvslist
+		"kvs.list": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
+			prefix := ""
+			if !goja.IsUndefined(params) && !goja.IsNull(params) {
+				paramsObj := params.ToObject(vm)
+				if p := paramsObj.Get("prefix"); p != nil && !goja.IsUndefined(p) && !goja.IsNull(p) {
+					prefix = p.String()
+				}
+			}
+
+			kvs := deviceState.GetKVS()
+			keys := make([]string, 0)
+			for k := range kvs {
+				if strings.HasPrefix(k, prefix) {
+					keys = append(keys, k)
+				}
+			}
+
+			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
+				if callable, ok := goja.AssertFunction(callback); ok {
+					result := map[string]interface{}{"keys": keys}
+					ret, err := callable(goja.Undefined(), vm.ToValue(result), vm.ToValue(0), goja.Null(), userdata)
+					if err != nil {
+						return nil, err
+					}
+					return ret.Export(), nil
+				}
+			}
+			return map[string]interface{}{"keys": keys}, nil
+		},
 		"kvs.get": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
 			// emulate https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/KVS#kvsget
 			paramsObj := params.ToObject(vm)


### PR DESCRIPTION
## Summary

- **Root cause**: `saveAllIlluminanceStates` fired N concurrent `Shelly.call("KVS.Set")` in a synchronous `for` loop, exhausting the device's 5-concurrent-RPC budget. A BLU motion event arriving simultaneously pushed the count over the limit, crashing with `Uncaught Error: Too many calls in progress`.
- **Fix**: Remove the entire in-script 7-day illuminance min/max aggregation feature. Illuminance percentage bounds (`"20%"`) will be resolved by the daemon instead (tracked in #249). All remaining `Shelly.call` sites now go through a task queue (ported from `pool-pump.js`) that dispatches at most one call per 200 ms tick.
- **KVS cleanup**: stale `state/shelly-blu/<mac>` keys removed from `lumiere-parking`, `lumiere-porte-entree`, and `lumiere-pool-house-mur` on deploy.

## Changes

### `internal/shelly/scripts/blu-listener.js` (708 → 323 lines)
- Remove `STATE.illuminanceTracking` and all related functions (`updateIlluminanceTracking`, `getSevenDayMinMax`, `parseIlluminanceValue`, `loadIlluminanceState`, `saveIlluminanceState`, `saveAllIlluminanceStates`, sequential load chain, etc.)
- Remove daily save timer, hourly backup timer, and `statePrefix` from `CONFIG`
- Remove `reboot` / `script_stop` event handlers (only called `saveAllIlluminanceStates`)
- `illuminance_min` / `illuminance_max` now accept plain lux numbers only; the daemon resolves percentages before writing to device KVS (#249)
- Port task queue (`TASK_QUEUE` / `processTaskQueue` / `queueTask`) from `pool-pump.js`
- All `Shelly.call` sites go through `queueTask`; KVS reload on change event also queued
- `onLoadFollowsComplete` simplified: no timer setup (timers were only for illuminance)

### `pkg/shelly/script/run.go`
- Add `kvs.list` to the emulated runtime (was missing; scripts calling `KVS.List` silently got an empty result in tests)

### `internal/shelly/scripts/blu_listener_test.go` (new)
- 7 tests: motion→on, motion=0 no-op, auto-off timer, illuminance high/low/within bounds, KVS reload picks up new follow

## Deployed to
- `lumiere-parking` ✓
- `lumiere-porte-entree` ✓
- `mezzanine` ✓
- `lumiere-pool-house-mur` ✓
- `lumiere-pool-house-pilier` — old script deleted (device was at 3-script limit; blu-listener not re-uploaded)

## Related
- Daemon illuminance aggregation follow-up: #249
- Emulator device-limit enforcement follow-up: #250<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(blu-listener): fix Too many calls crash, remove illuminance tracking ([05c481d](https://github.com/asnowfix/home-automation/commit/05c481d0f6303adf0555730f87307798878034a7))
<!-- END-AUTO-GENERATED-COMMITS -->