### PR TITLE
fix(mqtt): guard against writing loopback address to device MQTT config

### DIFF
--- a/myhome/ctl/shelly/mqtt/config.go
+++ b/myhome/ctl/shelly/mqtt/config.go
@@ -62,7 +62,12 @@ func configOneDevice(ctx context.Context, log logr.Logger, via types.Channel, de
 		log.Error(err, "Unable to get MQTT client to reach device")
 		return nil, err
 	}
-	config.Server = mc.BrokerUrl().String()
+	deviceServer, err := mc.DeviceServer()
+	if err != nil {
+		log.Error(err, "Unable to resolve device-facing MQTT broker address")
+		return nil, err
+	}
+	config.Server = deviceServer
 
 	out, err = sd.CallE(ctx, via, shellymqtt.SetConfig.String(), shellymqtt.SetConfigRequest{
 		Config: *config,

--- a/myhome/ctl/shelly/setup/main.go
+++ b/myhome/ctl/shelly/setup/main.go
@@ -68,8 +68,8 @@ func setupDevicesByName(ctx context.Context, pattern string) error {
 }
 
 // getSetupConfig returns the setup configuration, using the current process MQTT broker
-// unless overridden by command-line flag
-func getSetupConfig(ctx context.Context) shellysetup.Config {
+// unless overridden by command-line flag.
+func getSetupConfig(ctx context.Context) (shellysetup.Config, error) {
 	cfg := shellysetup.Config{
 		MqttPort: 1883,
 		Resolver: mynet.MyResolver(hlog.Logger),
@@ -82,17 +82,21 @@ func getSetupConfig(ctx context.Context) shellysetup.Config {
 		// Get the MQTT broker from the current process client
 		mqttClient, err := mhmqtt.GetClientE(ctx)
 		if err == nil && mqttClient != nil {
-			// GetServer returns host:port, we just need the host part for setup
-			server := mqttClient.GetServer()
-			cfg.MqttBroker = server // Already includes port, setup will handle it
-			cfg.MqttPort = 0        // Signal to use the server as-is (includes port)
+			// DeviceServer returns host:port and substitutes a loopback address with the
+			// machine's LAN IP so the device can actually reach the broker.
+			server, err := mqttClient.DeviceServer()
+			if err != nil {
+				return cfg, fmt.Errorf("could not resolve device-facing MQTT broker address: %w", err)
+			}
+			cfg.MqttBroker = server
+			cfg.MqttPort = 0 // Signal to use the server as-is (includes port)
 		} else {
 			// Fallback to mqtt.local if no client available
 			cfg.MqttBroker = "mqtt.local"
 		}
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 // doSetup performs the actual setup logic for a single device
@@ -206,13 +210,17 @@ func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device dev
 	}
 
 	// Get setup configuration (uses current process MQTT broker by default)
-	cfg := getSetupConfig(ctx)
+	cfg, err := getSetupConfig(ctx)
+	if err != nil {
+		fmt.Printf("  ✗ Cannot determine MQTT broker for %s: %v\n", deviceId, err)
+		return nil, err
+	}
 
 	fmt.Printf("  . Running core setup (firmware, MQTT, watchdog, auto-update)...\n")
 	fmt.Printf("    MQTT broker: %s\n", cfg.MqttBroker)
 
 	// Delegate to the internal setup package for core setup
-	err := shellysetup.SetupDevice(ctx, log, sd, targetName, cfg)
+	err = shellysetup.SetupDevice(ctx, log, sd, targetName, cfg)
 	if err != nil {
 		fmt.Printf("  ✗ Setup failed on %s: %v\n", deviceId, err)
 		return nil, err

--- a/myhome/mqtt/client.go
+++ b/myhome/mqtt/client.go
@@ -61,6 +61,9 @@ const (
 type Client interface {
 	GetServer() string
 	BrokerUrl() *url.URL
+	// DeviceServer returns the broker address (host:port) suitable for writing
+	// to a Shelly device — loopback is replaced with the machine's LAN IP.
+	DeviceServer() (string, error)
 	Id() string
 	Start() error
 	Subscribe(ctx context.Context, topic string, qlen uint, subscriber string) (<-chan []byte, error)
@@ -259,6 +262,41 @@ func NewClientE(ctx context.Context, broker string, instanceName string, mdnsTim
 func (c *client) GetServer() string {
 	// Host == <hostname>:<port>
 	return c.brokerUrl.Host
+}
+
+// resolveDeviceHost replaces a loopback host with the machine's LAN IP so that
+// the address can be written to a remote Shelly device.  getIP is injected so
+// unit tests can exercise the substitution without a real network interface.
+func resolveDeviceHost(host string, getIP func() (*net.IP, error)) (string, error) {
+	ip := net.ParseIP(host)
+	if ip == nil || !ip.IsLoopback() {
+		return host, nil
+	}
+	lanIP, err := getIP()
+	if err != nil {
+		return "", fmt.Errorf("broker is loopback (%s) but could not determine LAN IP: %w", host, err)
+	}
+	return lanIP.String(), nil
+}
+
+// DeviceServer returns the broker address in host:port form suitable for
+// writing to a Shelly device.  If the current broker is a loopback address
+// (e.g. 127.0.0.1 from a local daemon), it is replaced with the machine's LAN
+// IP on the same subnet as the default gateway so the device can actually reach
+// the broker.
+func (c *client) DeviceServer() (string, error) {
+	host, port, err := net.SplitHostPort(c.brokerUrl.Host)
+	if err != nil {
+		return "", fmt.Errorf("invalid broker address %q: %w", c.brokerUrl.Host, err)
+	}
+	resolved, err := resolveDeviceHost(host, func() (*net.IP, error) {
+		_, ip, err := mynet.MainInterface(c.log)
+		return ip, err
+	})
+	if err != nil {
+		return "", err
+	}
+	return net.JoinHostPort(resolved, port), nil
 }
 
 func (c *client) Id() string {

--- a/myhome/mqtt/client_test.go
+++ b/myhome/mqtt/client_test.go
@@ -3,6 +3,8 @@ package mqtt
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"reflect"
 	"sync"
 	"testing"
@@ -249,6 +251,84 @@ func TestSubscribe_ConcurrentSubscriptions(t *testing.T) {
 	}
 	if got := reflect.ValueOf(value).Len(); got != n {
 		t.Errorf("expected %d subscribers, got %d (race condition lost some)", n, got)
+	}
+}
+
+// TestResolveDeviceHost_NonLoopback verifies that non-loopback addresses pass through unchanged.
+func TestResolveDeviceHost_NonLoopback(t *testing.T) {
+	cases := []struct {
+		host string
+	}{
+		{"192.168.1.2"},
+		{"10.0.0.1"},
+		{"mqtt.local"},
+		{"::1"},  // IPv6 loopback — handled below, included for clarity
+		{"2001:db8::1"},
+	}
+
+	neverCalled := func() (*net.IP, error) {
+		t.Fatal("getIP should not be called for non-loopback host")
+		return nil, nil
+	}
+
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.host)
+		if ip != nil && ip.IsLoopback() {
+			continue // skip loopback entries in this table
+		}
+		got, err := resolveDeviceHost(tc.host, neverCalled)
+		if err != nil {
+			t.Errorf("resolveDeviceHost(%q) unexpected error: %v", tc.host, err)
+		}
+		if got != tc.host {
+			t.Errorf("resolveDeviceHost(%q) = %q, want %q", tc.host, got, tc.host)
+		}
+	}
+}
+
+// TestResolveDeviceHost_LoopbackSubstituted verifies that 127.x.x.x is replaced with the LAN IP.
+func TestResolveDeviceHost_LoopbackSubstituted(t *testing.T) {
+	lanIP := net.ParseIP("192.168.1.100")
+
+	cases := []string{"127.0.0.1", "127.0.0.2", "::1"}
+
+	for _, host := range cases {
+		got, err := resolveDeviceHost(host, func() (*net.IP, error) {
+			return &lanIP, nil
+		})
+		if err != nil {
+			t.Errorf("resolveDeviceHost(%q) unexpected error: %v", host, err)
+			continue
+		}
+		if got != lanIP.String() {
+			t.Errorf("resolveDeviceHost(%q) = %q, want %q", host, got, lanIP.String())
+		}
+	}
+}
+
+// TestResolveDeviceHost_LoopbackLookupFails verifies that an error from getIP propagates.
+func TestResolveDeviceHost_LoopbackLookupFails(t *testing.T) {
+	lookupErr := fmt.Errorf("no network interface found")
+	_, err := resolveDeviceHost("127.0.0.1", func() (*net.IP, error) {
+		return nil, lookupErr
+	})
+	if err == nil {
+		t.Fatal("expected error when getIP fails, got nil")
+	}
+}
+
+// TestDeviceServer_NonLoopback verifies DeviceServer returns the address unchanged for a LAN broker.
+func TestDeviceServer_NonLoopback(t *testing.T) {
+	u, _ := url.Parse("tcp://192.168.1.2:1883")
+	c := newTestClient(t)
+	c.brokerUrl = u
+
+	got, err := c.DeviceServer()
+	if err != nil {
+		t.Fatalf("DeviceServer() unexpected error: %v", err)
+	}
+	if got != "192.168.1.2:1883" {
+		t.Errorf("DeviceServer() = %q, want %q", got, "192.168.1.2:1883")
 	}
 }
 

--- a/myhome/mqtt/mock.go
+++ b/myhome/mqtt/mock.go
@@ -112,6 +112,8 @@ func (m *RecordingMockClient) BrokerUrl() *url.URL {
 	return u
 }
 
+func (m *RecordingMockClient) DeviceServer() (string, error) { return "localhost:1883", nil }
+
 func (m *RecordingMockClient) Id() string { return "recording-mock" }
 
 func (m *RecordingMockClient) Subscribe(ctx context.Context, topic string, qlen uint, subscriber string) (<-chan []byte, error) {


### PR DESCRIPTION
## Summary

- Root cause: `myhome ctl shelly setup` and `myhome ctl shelly mqtt config` were writing the CLI's connected broker address verbatim to the device. When the CLI tunnels through a local myhome daemon the broker is `127.0.0.1:1883` — leaving the device with a loopback MQTT address it can never reach after a reboot. This caused the `filtration-hiver` pool pump to enter a watchdog crash loop (MQTT failing every 10s → reboot every ~50s) which overrode the evening stop schedule.
- Add `DeviceServer() (string, error)` to the `mqtt.Client` interface: detects loopback broker addresses (`127.x.x.x`, `::1`) and substitutes the machine's LAN IP via `mynet.MainInterface` (interface on the same subnet as the default gateway). Non-loopback addresses and hostnames pass through unchanged.
- Both `setup` and `mqtt config` commands now call `DeviceServer()` instead of `GetServer()`/`BrokerUrl().String()`.

## Test plan

- [ ] `make test` passes (4 new unit tests: `TestResolveDeviceHost_NonLoopback`, `TestResolveDeviceHost_LoopbackSubstituted`, `TestResolveDeviceHost_LoopbackLookupFails`, `TestDeviceServer_NonLoopback`)
- [ ] Manual: `myhome ctl shelly mqtt config <device>` against a device on the LAN — verify MQTT server written is the machine's LAN IP, not `127.0.0.1`
- [ ] Manual: `myhome ctl shelly setup <device>` — same check<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(mqtt): guard against writing loopback address to device MQTT config ([a52aeba](https://github.com/asnowfix/home-automation/commit/a52aeba69595106fd5181bdf6f2a427f9abfcf0a))
<!-- END-AUTO-GENERATED-COMMITS -->