### PR TITLE
feat: MyHome workflows in JavaScript on a daemon-side goja script host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ dist/metadata.json
 internal/myhome/ui/static/alpine.min.js
 internal/myhome/ui/static/htmx.min.js
 myhome/ctl/pool/pool_defaults_generated.go
+
+# Daemon script host runtime state (per-script KVS/Script.storage)
+scripts-state/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,6 +391,27 @@ The number of scripts that can run simultaneously on a single device depends on 
 
 Other models are not yet catalogued here — add entries as you hit them. Attempting to enable a script beyond the limit returns: `"Reached the maximum N of enabled scripts"` (error code -108).
 
+#### Emulator enforcement: device-test vs device-extension mode
+
+The goja-based emulator (`pkg/shelly/script`) does not yet enforce the limits above
+(tracked in issue #250) — scripts can currently pass emulated tests while exceeding
+limits that crash real hardware. When #250 lands, the emulator will support two modes:
+
+- **`DeviceTestMode`** (default for tests of device-bound scripts): mirrors real
+  hardware — any violation panics/fails the test immediately.
+- **`DeviceExtensionMode`** (used by `myhome/scripthost`, the daemon-side script host):
+  no limits enforced.
+
+These are deliberately different, not a TODO to "finish enforcing everywhere": the
+daemon hosts JS workflows (`internal/shelly/scripts/heater-myhome.js`, `occupancy.js`)
+specifically to **subcontract memory/CPU-heavy work off the device** — see
+`myhome/scripthost/service.go` package doc. A device has a ~30 KB JS heap and the
+5-timer/5-handler/10-subscription ceilings above; the daemon has neither, by design.
+Enforcing device limits on daemon-hosted scripts would defeat the purpose of having a
+daemon-side script host at all. Any code/tests built against `pkg/shelly/script` for
+device-bound scripts must use `DeviceTestMode`; `myhome/scripthost` must construct its
+engines in `DeviceExtensionMode`.
+
 ### KVS Key Naming Convention
 
 **All KVS (Key-Value Storage) keys must use only lowercase letters, digits, hyphens, and slashes: `[0-9a-z-/]`**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -833,6 +833,52 @@ func (h *MethodHandlers) RegisterHandlers() {
 }
 ```
 
+### Daemon Script Host (JS Workflows)
+
+MyHome-specific *workflows* are written in JavaScript and executed on the daemon by the
+built-in goja engine (`myhome/scripthost`); communication, persistence and infrastructure
+stay in Go. Daemon scripts use the same Shelly API as device scripts (Timer, MQTT,
+Shelly.call with KVS emulation, Script.storage — persisted under `scripts-state/<name>.json`)
+plus a `MyHome` global:
+
+| API | Purpose |
+|---|---|
+| `MyHome.instance()` | This daemon's instance name |
+| `MyHome.log(...)` | Structured daemon log |
+| `MyHome.on(name, fn)` | Handle `script.invoke` calls addressed to this script |
+| `MyHome.call(verb, params, cb)` | In-process myhome RPC verb (`cb(result, error_code, error_message)`) |
+| `MyHome.deviceCall(device, method, params, cb)` | RPC to a Shelly device (any identifier) |
+| `MyHome.uploadScript(device, scriptName, cb)` | Upload + start an embedded device script |
+| `MyHome.registerVerb(verb, fn)` | JS implementation of an existing RPC verb (opt-in workflow replacement) |
+
+Configuration: `daemon.scripts.run: [occupancy, heater-myhome]` (see docs/configuration.md).
+Scripts are resolved from `daemon.scripts.dir` first, then the embedded
+`internal/shelly/scripts` library — so **every device script can assume a script of the
+same name is also present on the daemon**. A script detects which side it runs on with
+`typeof MyHome !== "undefined"` (see `myhome-link.js` for the dual-mode pattern).
+
+#### Device → Daemon Script Invocation (script.invoke)
+
+Devices call daemon-hosted script handlers through the regular myhome RPC protocol —
+no extra MQTT subscription on the daemon side:
+
+```js
+// Request: publish on "<instance>/rpc" ("myhome/rpc" reaches the main daemon)
+{ "id": "dev-1", "src": "<own-mqtt-prefix>/myhome", "dst": "<instance>",
+  "method": "script.invoke",
+  "params": { "script": "myhome-link", "name": "ping", "params": {"any": "json"} } }
+```
+
+The daemon responds on `<src>/rpc`, i.e. `<own-mqtt-prefix>/myhome/rpc` — the `/myhome`
+suffix keeps the response topic clear of the device's own RPC prefix. Devices subscribe
+to that topic once and match responses by `id` (full ES5-safe implementation:
+`internal/shelly/scripts/myhome-link.js`).
+
+Instance names: every daemon serves `<instance>/rpc` (default instance = short OS
+hostname); the daemon running the embedded broker additionally serves the well-known
+`myhome/rpc`. Dev/test daemons use `--instance <name> --mqtt-broker <addr>` and are
+addressed explicitly (KVS `script/<name>/instance` on the device).
+
 ### Database Patterns
 
 #### SQLite Column Existence Check

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,31 @@ daemon:
 - Flag: `--remote-proxy`
 - Env: `MYHOME_DAEMON_REMOTE_PROXY`
 
+#### Workflow Scripts (daemon script host)
+
+**`scripts.enabled`** (bool, default: `false`)
+- Enable the daemon script host: MyHome workflow scripts written in JavaScript, executed on the daemon's built-in goja engine
+- Auto-enabled when `scripts.run` is non-empty
+- Flag: `--enable-scripts`
+- Env: `MYHOME_DAEMON_SCRIPTS_ENABLED`
+
+**`scripts.run`** (string list, default: empty)
+- Names of workflow scripts to run on the daemon (with or without `.js`)
+- Scripts are resolved from `scripts.dir` first, then from the embedded device-script library (`internal/shelly/scripts`)
+- Some scripts replace their Go workflow counterpart when listed (e.g. `occupancy` replaces the Go occupancy service; `heater-myhome` takes over the `heater.getconfig`/`heater.setconfig` RPC verbs)
+- Flag: `--scripts-run occupancy,heater-myhome`
+- Env: `MYHOME_DAEMON_SCRIPTS_RUN`
+
+**`scripts.dir`** (string, default: `""`)
+- Optional directory of workflow scripts overriding the embedded library (useful for development)
+- Flag: `--scripts-dir`
+- Env: `MYHOME_DAEMON_SCRIPTS_DIR`
+
+**`scripts.state_dir`** (string, default: `scripts-state`)
+- Directory holding one JSON state file per script (persisted KVS + `Script.storage`)
+- Flag: `--scripts-state-dir`
+- Env: `MYHOME_DAEMON_SCRIPTS_STATE_DIR`
+
 #### Service Enablement
 
 **`enable_gen1_proxy`** (bool, default: auto)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -126,6 +126,13 @@ daemon:
 - Flag: `--ui-port` or `-u`
 - Env: `MYHOME_DAEMON_UI_PORT`
 
+**`instance_name`** (string, default: short OS hostname)
+- Daemon instance name, used in RPC topics (`<instance>/rpc`)
+- The daemon running the embedded broker is the *main* daemon: it additionally serves the well-known `myhome/rpc` topic, so clients that do not specify an instance keep working
+- Secondary daemons (development, tests) should use a distinct instance name and an external broker (`mqtt_broker`)
+- Flag: `--instance` or `-I`
+- Env: `MYHOME_DAEMON_INSTANCE_NAME`
+
 **`remote_proxy`** (string, default: `""`)
 - Forward all `/devices/...` HTTP requests to a remote myhome daemon instead of connecting to devices directly. Useful when running a local myhome instance that reaches the home network via SSH port-forwarding and cannot dial device IPs directly.
 - Example: `http://home-pi:6080` or `http://localhost:6081` (when `ssh -L 6081:localhost:6080 home-pi`)

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -123,14 +123,14 @@ Key properties:
 - [x] Unit test via emulator.
 
 ### Phase 7 — Live validation on development.local
-- [ ] Build; run dev daemon `--instance dev-claude --mqtt-broker 192.168.1.2 …`
+- [x] Build; run dev daemon `--instance dev-claude --mqtt-broker 192.168.1.2 …`
       (no mDNS publish, no embedded broker, separate db/state files, UI port off 6080).
-- [ ] Upload `myhome-link.js` to development.local (`--no-minify`), enable script debug,
+- [x] Upload `myhome-link.js` to development.local (`--no-minify`), enable script debug,
       verify device→daemon `script.invoke` round-trip and distributed heater forecast.
-- [ ] `make test` green.
+- [x] `make test` green.
 
 ### Phase 8 — Draft PR
-- [ ] Push branch, open draft PR with summary, config examples, and migration notes
+- [x] Push branch, open draft PR with summary, config examples, and migration notes
       (main daemon: nothing to change — alias topic keeps current behaviour).
 
 ## Risks / notes

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -1,0 +1,147 @@
+# Plan: MyHome workflows in JavaScript (goja), distributed device↔daemon execution
+
+> Refactor so that MyHome-specific *workflows* are written in JavaScript and executed by
+> the daemon's built-in goja engine, while communication, persistence and infrastructure
+> stay in Go. Devices can invoke (via MQTT) scripts running on a daemon; a single logical
+> workflow can therefore span a device and a daemon. Multiple daemons coexist,
+> differentiated by their *instance name* in the RPC protocol.
+
+## Decisions (agreed with FiX, 2026-06-11)
+
+- **Scope this session**: framework + migrate **occupancy** and **heater** workflows.
+  `myhome/temperature` is being refactored in a separate worktree — do not touch it.
+- **Go workflow code stays**: JS versions are **opt-in via config**; Go implementations
+  remain the default until validated in production. Cleanup happens later.
+- **Instance names**: default = OS hostname; overridable via `--instance` /
+  `daemon.instance_name` / `MYHOME_DAEMON_INSTANCE_NAME`. The daemon that runs the
+  embedded MQTT broker is the *main* daemon and additionally serves the well-known
+  `myhome/rpc` topic, so existing CLI/devices keep working unchanged.
+- **Git**: incremental commits on `worktree-feature+my-js-home`, pushed, draft PR.
+- **Testing**: dev daemon instance `dev-claude` against broker `tcp://192.168.1.2:1883`;
+  live device `development.local` (192.168.1.31). The production daemon is not modified.
+
+## Architecture
+
+```
+┌────────────────────────── daemon (Go) ─────────────────────────┐
+│ myhome/scripthost          ← NEW: runs workflow JS in goja     │
+│   ├─ engine per script (pkg/shelly/script Engine)              │
+│   ├─ state persisted as JSON (scripts-state/<name>.json)       │
+│   ├─ Shelly-compatible APIs (Timer, MQTT, KVS, Script.storage) │
+│   └─ MyHome.* daemon APIs (call, deviceCall, on, registerVerb) │
+│ internal/myhome RPC server ← existing myhome/rpc protocol      │
+│   └─ NEW verb script.invoke → dispatches into scripthost       │
+└────────────────────────────────────────────────────────────────┘
+            ▲ MQTT <instance>/rpc (+ myhome/rpc on main daemon)
+            │ request: {id, src, dst, method:"script.invoke",
+            │           params:{script, name, params}}
+            ▼ response to <src>/rpc
+┌─────────── Shelly device (ES5 Espruino) ───────────┐
+│ device script publishes RPC request, subscribes to │
+│ <own-prefix>/myhome/rpc for the response           │
+└────────────────────────────────────────────────────┘
+```
+
+Key properties:
+- **One MQTT topic per daemon instance** (`<instance>/rpc`) — reuses the existing RPC
+  server; *no* separate MQTT subscription (repo rule).
+- A device script "calls home" by invoking `script.invoke` with the name of a script
+  that is assumed to also run on the daemon (same name, daemon flavour).
+- Daemon scripts use the *same* Shelly JS API as device scripts (so knowledge and code
+  transfer), plus a `MyHome` object for daemon-only capabilities.
+
+## Phases
+
+### Phase 1 — Instance name plumbing
+- [ ] `--instance` flag default changes `"myhome"` → `""`; resolution order:
+      flag > `daemon.instance_name` (config/env) > OS hostname.
+- [ ] Daemon with embedded broker also serves the well-known `myhome/rpc` alias
+      (it is the *main* daemon by definition).
+- [ ] `myhome.NewServerE` accepts explicit topics (instance + optional alias).
+- [ ] 4-file config rule: options.go, run.go, docs/configuration.md, myhome-example.yaml.
+
+### Phase 2 — Reusable goja Engine in pkg/shelly/script
+- [ ] Extract `createShellyRuntime` + event loop from `Run()` into an exported
+      `Engine` (`NewEngine(ctx, EngineOptions)`, `Engine.Loop(ctx)`).
+- [ ] `EngineOptions`: script name, source, `*DeviceState`, extra-API hook
+      (`Customize func(vm *goja.Runtime) error`).
+- [ ] **External invocation**: `Engine.Invoke(ctx, fnName, jsonParams) (any, error)` —
+      thread-safe dispatch into the VM through the event loop (goja VMs are
+      single-threaded); used by `script.invoke` and by Go→JS callbacks.
+- [ ] `Run()/RunWithDeviceState()` keep their behaviour (existing tests must pass).
+
+### Phase 3 — Daemon script host (`myhome/scripthost`)
+- [ ] New workspace module `myhome/scripthost` (`go work use`).
+- [ ] Loads scripts by name: user dir (`daemon.scripts.dir`, optional) first, then the
+      embedded `internal/shelly/scripts` FS — *every device script is also present on
+      the daemon*.
+- [ ] Per-script engine goroutine; crash → restart with backoff; stop on ctx cancel.
+- [ ] State persisted per script: `scripts-state/<name>.json` (KVS + Script.storage),
+      auto-saved on modification (reuses DeviceState persistence).
+- [ ] `MyHome` JS API:
+      - `MyHome.instance()` → instance name
+      - `MyHome.call(method, params, callback)` → in-process myhome verb dispatch
+      - `MyHome.deviceCall(device, method, params, callback)` → RPC to a Shelly device
+      - `MyHome.on(name, fn)` → handle `script.invoke` calls addressed to this script
+      - `MyHome.registerVerb(verb, fn)` → JS implementation of an existing RPC verb
+        (used for opt-in workflow replacement, e.g. `heater.getconfig`)
+      - `MyHome.log(...)` → hlog-backed structured logging
+- [ ] Config: `daemon.scripts.enabled`, `daemon.scripts.dir`, `daemon.scripts.run`
+      (list of script names) — 4-file rule.
+
+### Phase 4 — `script.invoke` protocol (device→daemon)
+- [ ] RPC 4 steps: Verb `script.invoke` in const.go; `ScriptInvokeParams{Script, Name,
+      Params}` / `ScriptInvokeResult{Result}` types; signatures map entry;
+      `RegisterMethodHandler` from scripthost.
+- [ ] Device-side calling convention (ES5, minify-safe):
+      publish request to `myhome/rpc` (or specific instance) with
+      `src = <device-topic-prefix> + "/myhome"`, subscribe `<prefix>/myhome/rpc`,
+      match responses by id. Helper shipped as `internal/shelly/scripts/myhome-link.js`
+      (test/demo script for development.local).
+- [ ] Document the convention in AGENTS.md.
+
+### Phase 5 — Occupancy workflow in JS (opt-in)
+- [ ] Go infra verb `lan.hosts` (wraps `pkg/sfr.GetHostsList`) — presence polling is
+      infrastructure, stays in Go.
+- [ ] `internal/shelly/scripts/occupancy.js`: subscribes `+/events/rpc` (NotifyStatus
+      with `input:` changes), polls `MyHome.call("lan.hosts")` for mobile-device
+      patterns, publishes retained `myhome/occupancy` (same payloads as Go version),
+      12 h expiry timer.
+- [ ] Opt-in: `occupancy` listed in `daemon.scripts.run` ⇒ daemon skips the Go
+      occupancy service (logs the substitution). Default unchanged (Go).
+- [ ] Unit test runs occupancy.js in the emulator (pattern: blu_listener_test.go).
+
+### Phase 6 — Heater workflow in JS (opt-in)
+- [ ] `internal/shelly/scripts/heater-myhome.js` (daemon flavour):
+      - `MyHome.registerVerb("heater.getconfig"/"heater.setconfig", …)` re-implementing
+        internal/myhome/shelly/script/heater.go logic via `MyHome.deviceCall`
+        (KVS.GetMany / KVS.Set) and `MyHome.uploadScript` Go binding (wraps
+        UploadWithVersion — uploading firmware-grade JS to devices stays Go infra).
+      - `MyHome.on("get_forecast", …)`: serves cached weather forecast to device heater
+        scripts via `script.invoke` — demonstrates distributed device↔daemon execution.
+- [ ] Opt-in: `heater-myhome` in `daemon.scripts.run` ⇒ Go HeaterService not registered.
+- [ ] Unit test via emulator.
+
+### Phase 7 — Live validation on development.local
+- [ ] Build; run dev daemon `--instance dev-claude --mqtt-broker 192.168.1.2 …`
+      (no mDNS publish, no embedded broker, separate db/state files, UI port off 6080).
+- [ ] Upload `myhome-link.js` to development.local (`--no-minify`), enable script debug,
+      verify device→daemon `script.invoke` round-trip and distributed heater forecast.
+- [ ] `make test` green.
+
+### Phase 8 — Draft PR
+- [ ] Push branch, open draft PR with summary, config examples, and migration notes
+      (main daemon: nothing to change — alias topic keeps current behaviour).
+
+## Risks / notes
+
+- goja VM is single-threaded: all external entry points (script.invoke, MyHome.call
+  callbacks) are funneled through the engine event loop.
+- Engine `MQTT.subscribe` passes the subscription *filter* (not the concrete topic) to
+  callbacks for wildcard subscriptions; occupancy.js only needs payloads. Improvement
+  tracked for later (use SubscribeWithTopic).
+- Two occupancy publishers (Go + JS) would fight over the retained `myhome/occupancy`
+  topic — hence hard substitution, not parallel run.
+- `script.invoke` responses to devices reuse the existing response topic scheme
+  (`<src>/rpc`); devices use `<prefix>/myhome` as src so the response topic does not
+  collide with the device's own RPC prefix.

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -71,14 +71,14 @@ Key properties:
 - [x] `Run()/RunWithDeviceState()` keep their behaviour (existing tests must pass).
 
 ### Phase 3 — Daemon script host (`myhome/scripthost`)
-- [ ] New workspace module `myhome/scripthost` (`go work use`).
-- [ ] Loads scripts by name: user dir (`daemon.scripts.dir`, optional) first, then the
+- [x] New workspace module `myhome/scripthost` (`go work use`).
+- [x] Loads scripts by name: user dir (`daemon.scripts.dir`, optional) first, then the
       embedded `internal/shelly/scripts` FS — *every device script is also present on
       the daemon*.
-- [ ] Per-script engine goroutine; crash → restart with backoff; stop on ctx cancel.
-- [ ] State persisted per script: `scripts-state/<name>.json` (KVS + Script.storage),
+- [x] Per-script engine goroutine; crash → restart with backoff; stop on ctx cancel.
+- [x] State persisted per script: `scripts-state/<name>.json` (KVS + Script.storage),
       auto-saved on modification (reuses DeviceState persistence).
-- [ ] `MyHome` JS API:
+- [x] `MyHome` JS API:
       - `MyHome.instance()` → instance name
       - `MyHome.call(method, params, callback)` → in-process myhome verb dispatch
       - `MyHome.deviceCall(device, method, params, callback)` → RPC to a Shelly device
@@ -86,19 +86,19 @@ Key properties:
       - `MyHome.registerVerb(verb, fn)` → JS implementation of an existing RPC verb
         (used for opt-in workflow replacement, e.g. `heater.getconfig`)
       - `MyHome.log(...)` → hlog-backed structured logging
-- [ ] Config: `daemon.scripts.enabled`, `daemon.scripts.dir`, `daemon.scripts.run`
+- [x] Config: `daemon.scripts.enabled`, `daemon.scripts.dir`, `daemon.scripts.run`
       (list of script names) — 4-file rule.
 
 ### Phase 4 — `script.invoke` protocol (device→daemon)
-- [ ] RPC 4 steps: Verb `script.invoke` in const.go; `ScriptInvokeParams{Script, Name,
+- [x] RPC 4 steps: Verb `script.invoke` in const.go; `ScriptInvokeParams{Script, Name,
       Params}` / `ScriptInvokeResult{Result}` types; signatures map entry;
       `RegisterMethodHandler` from scripthost.
-- [ ] Device-side calling convention (ES5, minify-safe):
+- [x] Device-side calling convention (ES5, minify-safe):
       publish request to `myhome/rpc` (or specific instance) with
       `src = <device-topic-prefix> + "/myhome"`, subscribe `<prefix>/myhome/rpc`,
       match responses by id. Helper shipped as `internal/shelly/scripts/myhome-link.js`
       (test/demo script for development.local).
-- [ ] Document the convention in AGENTS.md.
+- [x] Document the convention in AGENTS.md.
 
 ### Phase 5 — Occupancy workflow in JS (opt-in)
 - [ ] Go infra verb `lan.hosts` (wraps `pkg/sfr.GetHostsList`) — presence polling is

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -101,15 +101,15 @@ Key properties:
 - [x] Document the convention in AGENTS.md.
 
 ### Phase 5 — Occupancy workflow in JS (opt-in)
-- [ ] Go infra verb `lan.hosts` (wraps `pkg/sfr.GetHostsList`) — presence polling is
+- [x] Go infra verb `lan.hosts` (wraps `pkg/sfr.GetHostsList`) — presence polling is
       infrastructure, stays in Go.
-- [ ] `internal/shelly/scripts/occupancy.js`: subscribes `+/events/rpc` (NotifyStatus
+- [x] `internal/shelly/scripts/occupancy.js`: subscribes `+/events/rpc` (NotifyStatus
       with `input:` changes), polls `MyHome.call("lan.hosts")` for mobile-device
       patterns, publishes retained `myhome/occupancy` (same payloads as Go version),
       12 h expiry timer.
-- [ ] Opt-in: `occupancy` listed in `daemon.scripts.run` ⇒ daemon skips the Go
+- [x] Opt-in: `occupancy` listed in `daemon.scripts.run` ⇒ daemon skips the Go
       occupancy service (logs the substitution). Default unchanged (Go).
-- [ ] Unit test runs occupancy.js in the emulator (pattern: blu_listener_test.go).
+- [x] Unit test runs occupancy.js in the emulator (pattern: blu_listener_test.go).
 
 ### Phase 6 — Heater workflow in JS (opt-in)
 - [ ] `internal/shelly/scripts/heater-myhome.js` (daemon flavour):

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -112,15 +112,15 @@ Key properties:
 - [x] Unit test runs occupancy.js in the emulator (pattern: blu_listener_test.go).
 
 ### Phase 6 — Heater workflow in JS (opt-in)
-- [ ] `internal/shelly/scripts/heater-myhome.js` (daemon flavour):
+- [x] `internal/shelly/scripts/heater-myhome.js` (daemon flavour):
       - `MyHome.registerVerb("heater.getconfig"/"heater.setconfig", …)` re-implementing
         internal/myhome/shelly/script/heater.go logic via `MyHome.deviceCall`
         (KVS.GetMany / KVS.Set) and `MyHome.uploadScript` Go binding (wraps
         UploadWithVersion — uploading firmware-grade JS to devices stays Go infra).
       - `MyHome.on("get_forecast", …)`: serves cached weather forecast to device heater
         scripts via `script.invoke` — demonstrates distributed device↔daemon execution.
-- [ ] Opt-in: `heater-myhome` in `daemon.scripts.run` ⇒ Go HeaterService not registered.
-- [ ] Unit test via emulator.
+- [x] Opt-in: `heater-myhome` in `daemon.scripts.run` ⇒ Go HeaterService not registered.
+- [x] Unit test via emulator.
 
 ### Phase 7 — Live validation on development.local
 - [ ] Build; run dev daemon `--instance dev-claude --mqtt-broker 192.168.1.2 …`

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -61,14 +61,14 @@ Key properties:
 - [x] 4-file config rule: options.go, run.go, docs/configuration.md, myhome-example.yaml.
 
 ### Phase 2 — Reusable goja Engine in pkg/shelly/script
-- [ ] Extract `createShellyRuntime` + event loop from `Run()` into an exported
+- [x] Extract `createShellyRuntime` + event loop from `Run()` into an exported
       `Engine` (`NewEngine(ctx, EngineOptions)`, `Engine.Loop(ctx)`).
-- [ ] `EngineOptions`: script name, source, `*DeviceState`, extra-API hook
+- [x] `EngineOptions`: script name, source, `*DeviceState`, extra-API hook
       (`Customize func(vm *goja.Runtime) error`).
-- [ ] **External invocation**: `Engine.Invoke(ctx, fnName, jsonParams) (any, error)` —
+- [x] **External invocation**: `Engine.Invoke(ctx, fnName, jsonParams) (any, error)` —
       thread-safe dispatch into the VM through the event loop (goja VMs are
       single-threaded); used by `script.invoke` and by Go→JS callbacks.
-- [ ] `Run()/RunWithDeviceState()` keep their behaviour (existing tests must pass).
+- [x] `Run()/RunWithDeviceState()` keep their behaviour (existing tests must pass).
 
 ### Phase 3 — Daemon script host (`myhome/scripthost`)
 - [ ] New workspace module `myhome/scripthost` (`go work use`).

--- a/docs/plan-js-workflows.md
+++ b/docs/plan-js-workflows.md
@@ -53,12 +53,12 @@ Key properties:
 ## Phases
 
 ### Phase 1 — Instance name plumbing
-- [ ] `--instance` flag default changes `"myhome"` → `""`; resolution order:
+- [x] `--instance` flag default changes `"myhome"` → `""`; resolution order:
       flag > `daemon.instance_name` (config/env) > OS hostname.
-- [ ] Daemon with embedded broker also serves the well-known `myhome/rpc` alias
+- [x] Daemon with embedded broker also serves the well-known `myhome/rpc` alias
       (it is the *main* daemon by definition).
-- [ ] `myhome.NewServerE` accepts explicit topics (instance + optional alias).
-- [ ] 4-file config rule: options.go, run.go, docs/configuration.md, myhome-example.yaml.
+- [x] `myhome.NewServerE` accepts explicit topics (instance + optional alias).
+- [x] 4-file config rule: options.go, run.go, docs/configuration.md, myhome-example.yaml.
 
 ### Phase 2 — Reusable goja Engine in pkg/shelly/script
 - [ ] Extract `createShellyRuntime` + event loop from `Run()` into an exported

--- a/docs/plan-shelly-emulator-apis.md
+++ b/docs/plan-shelly-emulator-apis.md
@@ -1,0 +1,53 @@
+# Plan: close Shelly Gen2 scripting API gaps in the goja emulator
+
+> `pkg/shelly/script` emulates a Shelly Gen2 device for script testing (`myhome ctl
+> shelly script debug/eval`) and for daemon-hosted workflows (`myhome/scripthost`). It
+> currently covers `Shelly`, `Timer`, `MQTT`, `Script.storage`, and the `Shelly.call()`
+> method dispatch (KVS, HTTP.GET, schedule.*, switch/input config). This plan closes the
+> remaining gaps against the [Shelly Gen2 Script APIs](https://shelly-api-docs.shelly.cloud/gen2/Scripts/APIs/Shelly).
+
+## Decisions (agreed with FiX, 2026-06-21)
+
+- **Hardware-only globals fail loud, not silent**: `HTTPServer`, `BLE` (`Scanner`, `GAP`,
+  `AdvBuilder`, `advertiseOnce`), `BTHome`, and `UART` have no meaningful emulation —
+  they depend on physical radios/pins the daemon/test host doesn't have. Register them
+  so scripts referencing them get a clear "not implemented by the emulator" exception
+  instead of either a confusing `ReferenceError` or, worse, silently-wrong behavior.
+- **Virtual components and AES get real implementations** — both are pure software and
+  scripts can reasonably depend on them.
+- **Utility functions** (`btoa`, `atob`, `btoh`) are simple and get real implementations.
+- Resource-limit emulation (#250) and its `DeviceTestMode`/`DeviceExtensionMode` split
+  is a separate, already-filed concern — not part of this plan.
+
+## Phases
+
+### Phase 1 — stub-and-fail: HTTPServer, BLE, BTHome, UART (done)
+Add each global (and sub-objects: `BLE.Scanner`, `BLE.GAP`, `BLE.AdvBuilder`,
+`BTHome.DataBuilder`) with every documented method bound to a shared
+`notImplemented(global, method)` helper that panics with a descriptive message,
+catchable by script `try/catch` like a real exception. Test: one table-driven test
+per global confirming the panic message and that it's catchable.
+
+### Phase 2 — utilities: btoa, atob, btoh
+Top-level functions next to `print`/`console`. `btoa`/`atob` = standard base64;
+`btoh` = lowercase hex of the input bytes. Tests cover round-trip + known vectors.
+
+### Phase 3 — Virtual components
+`Virtual.getHandle(key)` returns an instance backed by a new `DeviceState.Virtual
+map[string]*VirtualComponent` field (mirrors the `ComponentStatus` pattern). Instance
+methods: `setValue`/`getValue`/`getStatus`/`getConfig`/`setConfig`/`on`/`off`. Support
+component kinds Number/Text/Boolean/Enum/Button/Group per the docs; `on`/`off` use the
+existing event-handler-list pattern already used for `Shelly.addEventHandler`. Test:
+get/set round-trip, `change` event firing, `Button` push events.
+
+### Phase 4 — AES
+`AES.encrypt(plainText, key, mode)` / `AES.decrypt(cypherText, key, mode)` operating on
+`goja.ArrayBuffer` (`vm.NewArrayBuffer`/`.Export().(goja.ArrayBuffer).Bytes()`). Modes:
+CBC, CFB, CTR, OFB (stdlib `crypto/cipher`), ECB (manual block-by-block, stdlib has no
+ECB — needed since Shelly docs list it). Key sizes 128/192/256 bit. Tests: encrypt then
+decrypt round-trip per mode, known-answer test vector for at least CBC.
+
+## Notes
+
+- File: `pkg/shelly/script/run.go` (globals are bound in `createShellyRuntime`).
+- Keep each phase to its own commit; update this file marking phases done as completed.

--- a/docs/plan-shelly-emulator-apis.md
+++ b/docs/plan-shelly-emulator-apis.md
@@ -40,7 +40,7 @@ component kinds Number/Text/Boolean/Enum/Button/Group per the docs; `on`/`off` u
 existing event-handler-list pattern already used for `Shelly.addEventHandler`. Test:
 get/set round-trip, `change` event firing, `Button` push events.
 
-### Phase 4 — AES
+### Phase 4 — AES (done)
 `AES.encrypt(plainText, key, mode)` / `AES.decrypt(cypherText, key, mode)` operating on
 `goja.ArrayBuffer` (`vm.NewArrayBuffer`/`.Export().(goja.ArrayBuffer).Bytes()`). Modes:
 CBC, CFB, CTR, OFB (stdlib `crypto/cipher`), ECB (manual block-by-block, stdlib has no

--- a/docs/plan-shelly-emulator-apis.md
+++ b/docs/plan-shelly-emulator-apis.md
@@ -28,7 +28,7 @@ Add each global (and sub-objects: `BLE.Scanner`, `BLE.GAP`, `BLE.AdvBuilder`,
 catchable by script `try/catch` like a real exception. Test: one table-driven test
 per global confirming the panic message and that it's catchable.
 
-### Phase 2 — utilities: btoa, atob, btoh
+### Phase 2 — utilities: btoa, atob, btoh (done)
 Top-level functions next to `print`/`console`. `btoa`/`atob` = standard base64;
 `btoh` = lowercase hex of the input bytes. Tests cover round-trip + known vectors.
 

--- a/docs/plan-shelly-emulator-apis.md
+++ b/docs/plan-shelly-emulator-apis.md
@@ -32,7 +32,7 @@ per global confirming the panic message and that it's catchable.
 Top-level functions next to `print`/`console`. `btoa`/`atob` = standard base64;
 `btoh` = lowercase hex of the input bytes. Tests cover round-trip + known vectors.
 
-### Phase 3 — Virtual components
+### Phase 3 — Virtual components (done)
 `Virtual.getHandle(key)` returns an instance backed by a new `DeviceState.Virtual
 map[string]*VirtualComponent` field (mirrors the `ComponentStatus` pattern). Instance
 methods: `setValue`/`getValue`/`getStatus`/`getConfig`/`setConfig`/`on`/`off`. Support

--- a/go.work
+++ b/go.work
@@ -37,6 +37,7 @@ use (
 	./myhome/events
 	./myhome/mqtt
 	./myhome/occupancy
+	./myhome/scripthost
 	./myhome/storage
 	./myhome/temperature
 	./pkg/devices

--- a/internal/myhome/const.go
+++ b/internal/myhome/const.go
@@ -47,6 +47,8 @@ const (
 	SwitchStatus                  Verb = "switch.status"
 	SwitchAll                     Verb = "switch.all"
 	EventList                     Verb = "event.list"
+	ScriptInvoke                  Verb = "script.invoke"
+	LanHosts                      Verb = "lan.hosts"
 )
 
 type Key string

--- a/internal/myhome/methods.go
+++ b/internal/myhome/methods.go
@@ -2,7 +2,9 @@ package myhome
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 )
 
 type MethodHandler func(ctx context.Context, in any) (any, error)
@@ -36,6 +38,30 @@ func RegisterMethodHandler(name Verb, mh MethodHandler) {
 		Signature: s,
 		ActionE:   mh,
 	}
+}
+
+// CallLocalE dispatches a verb to its registered handler in-process, decoding
+// rawParams according to the verb signature. It mirrors what the MQTT RPC
+// server does for remote requests, and is used by daemon-hosted scripts
+// (MyHome.call) to reach Go infrastructure without a network round-trip.
+func CallLocalE(ctx context.Context, verb Verb, rawParams json.RawMessage) (any, error) {
+	m, err := Methods(verb)
+	if err != nil {
+		return nil, err
+	}
+	params := m.Signature.NewParams()
+	if len(rawParams) > 0 && string(rawParams) != "null" {
+		if params != nil && reflect.ValueOf(params).Kind() == reflect.Pointer {
+			if err := json.Unmarshal(rawParams, params); err != nil {
+				return nil, fmt.Errorf("invalid params for %s: %w", verb, err)
+			}
+		} else {
+			if err := json.Unmarshal(rawParams, &params); err != nil {
+				return nil, fmt.Errorf("invalid params for %s: %w", verb, err)
+			}
+		}
+	}
+	return m.ActionE(ctx, params)
 }
 
 var methods map[Verb]*Method = make(map[Verb]*Method)
@@ -303,6 +329,22 @@ var signatures map[Verb]MethodSignature = map[Verb]MethodSignature{
 		},
 		NewResult: func() any {
 			return &EventListResponse{}
+		},
+	},
+	ScriptInvoke: {
+		NewParams: func() any {
+			return &ScriptInvokeParams{}
+		},
+		NewResult: func() any {
+			return &ScriptInvokeResult{}
+		},
+	},
+	LanHosts: {
+		NewParams: func() any {
+			return nil
+		},
+		NewResult: func() any {
+			return &LanHostsResult{}
 		},
 	},
 }

--- a/internal/myhome/script.go
+++ b/internal/myhome/script.go
@@ -1,0 +1,31 @@
+package myhome
+
+// Script-host RPC types: devices (or other daemons/CLI) invoke handlers
+// exposed by daemon-hosted scripts via MyHome.on(name, fn).
+
+// ScriptInvokeParams represents parameters for script.invoke
+type ScriptInvokeParams struct {
+	Script string `json:"script"`           // script name, with or without the .js suffix
+	Name   string `json:"name"`             // handler name registered by the script via MyHome.on()
+	Params any    `json:"params,omitempty"` // free-form JSON forwarded to the handler
+}
+
+// ScriptInvokeResult represents the result of script.invoke
+type ScriptInvokeResult struct {
+	Result any `json:"result,omitempty"` // value returned by the script handler
+}
+
+// LanHostInfo describes one host seen on the LAN (infrastructure data used by
+// the occupancy workflow).
+type LanHostInfo struct {
+	Name   string `json:"name"`
+	Ip     string `json:"ip"`
+	Mac    string `json:"mac"`
+	Status string `json:"status"`
+	Alive  uint32 `json:"alive"`
+}
+
+// LanHostsResult represents the result of lan.hosts
+type LanHostsResult struct {
+	Hosts []LanHostInfo `json:"hosts"`
+}

--- a/internal/myhome/server.go
+++ b/internal/myhome/server.go
@@ -11,7 +11,6 @@ import (
 type server struct {
 	// mc      *mymqtt.Client
 	handler Server
-	from    <-chan []byte
 	// to      chan []byte
 }
 
@@ -19,115 +18,121 @@ type Server interface {
 	MethodE(method Verb) (*Method, error)
 }
 
-func NewServerE(ctx context.Context, mc mqtt.Client, handler Server) (Server, error) {
+// NewServerE starts the RPC server message loop. By default it serves
+// ServerTopic() (i.e. "<InstanceName>/rpc"); extra topics may be passed to
+// also serve well-known aliases (e.g. the main daemon serving "myhome/rpc"
+// while running under its host-specific instance name).
+func NewServerE(ctx context.Context, mc mqtt.Client, handler Server, topics ...string) (Server, error) {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
 		panic(err)
 	}
 	log = log.WithName("myhome.rpc")
-	from, err := mc.Subscribe(ctx, ServerTopic(), 16, InstanceName+"/server")
-	if err != nil {
-		log.Error(err, "Failed to subscribe to server", "topic", ServerTopic())
-		return nil, err
+
+	if len(topics) == 0 {
+		topics = []string{ServerTopic()}
 	}
-	// to, err := mc.Publisher(ctx, ServerTopic(), 1)
-	// if err != nil {
-	// 	log.Error(err, "Failed to publish to server", "topic", ServerTopic())
-	// 	return nil, err
-	// }
+
 	s := server{
 		// mc:      mc,
 		handler: handler,
-		from:    from,
-		// to:      to,
 	}
 
-	go func(ctx context.Context) {
-		log, err := logr.FromContext(ctx)
+	for _, topic := range topics {
+		from, err := mc.Subscribe(ctx, topic, 16, InstanceName+"/server")
 		if err != nil {
-			panic(err)
+			log.Error(err, "Failed to subscribe to server", "topic", topic)
+			return nil, err
 		}
-		log.Info("Server message loop started")
-		for {
-			select {
-			case <-ctx.Done():
-				log.Info("Cancelled", "reason", ctx.Err())
-				return
-			case inMsg := <-from:
-				log.Info("Received message", "payload", string(inMsg))
-				var req request
-				var res response
-				var err error
+		go s.serve(logr.NewContext(ctx, log.WithName("Server").WithValues("topic", topic)), mc, from)
+	}
 
-				err = json.Unmarshal(inMsg, &req)
-				if err != nil {
-					log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				err = ValidateDialog(req.Dialog)
-				if err != nil {
-					log.Error(err, "Invalid dialog:"+req.Dialog.String())
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				method, err := handler.MethodE(req.Method)
-				if err != nil {
-					log.Error(err, "Failed to get action for method", "method", req.Method)
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				// re-do Unmarshalling with proper types in place, if needed
-				req.Params = method.Signature.NewParams()
-				err = json.Unmarshal(inMsg, &req)
-				if err != nil {
-					log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				tempResult := method.Signature.NewResult()
-				res.Result = &tempResult
-
-				res.Dialog = Dialog{
-					Id:  req.Id,
-					Src: mc.Id(),
-					Dst: req.Src,
-				}
-
-				out, err := method.ActionE(ctx, req.Params)
-				if err != nil {
-					log.Error(err, "Failed to call action")
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				// FIXME: produces errors like: `Error: unexpected type returned from action: got *[]devices.Device, want *interface {} (code:1)`
-				// if reflect.TypeOf(out) != reflect.TypeOf(res.Result) {
-				// 	s.fail(ctx, 1, fmt.Errorf("unexpected type returned from action: got %v, want %v", reflect.TypeOf(out), reflect.TypeOf(res.Result)), &req, mc)
-				// 	continue
-				// }
-
-				res.Result = &out
-
-				outMsg, err := json.Marshal(res)
-				if err != nil {
-					log.Error(err, "Failed to marshal response")
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-				// to <- outMsg
-				log.Info("Publishing response", "dst", res.Dst, "topic", ClientTopic(req.Src), "request_id", res.Id)
-				mc.Publish(ctx, ClientTopic(req.Src), outMsg, mqtt.AtLeastOnce, false, InstanceName+".rpc/Server")
-			}
-		}
-	}(logr.NewContext(ctx, log.WithName("Server")))
-
-	log.Info("Server started")
+	log.Info("Server started", "topics", topics)
 	return &s, nil
+}
+
+func (s *server) serve(ctx context.Context, mc mqtt.Client, from <-chan []byte) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		panic(err)
+	}
+	log.Info("Server message loop started")
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Cancelled", "reason", ctx.Err())
+			return
+		case inMsg := <-from:
+			log.Info("Received message", "payload", string(inMsg))
+			var req request
+			var res response
+			var err error
+
+			err = json.Unmarshal(inMsg, &req)
+			if err != nil {
+				log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
+				s.fail(ctx, 1, err, &req, mc)
+				continue
+			}
+
+			err = ValidateDialog(req.Dialog)
+			if err != nil {
+				log.Error(err, "Invalid dialog:"+req.Dialog.String())
+				s.fail(ctx, 1, err, &req, mc)
+				continue
+			}
+
+			method, err := s.handler.MethodE(req.Method)
+			if err != nil {
+				log.Error(err, "Failed to get action for method", "method", req.Method)
+				s.fail(ctx, 1, err, &req, mc)
+				continue
+			}
+
+			// re-do Unmarshalling with proper types in place, if needed
+			req.Params = method.Signature.NewParams()
+			err = json.Unmarshal(inMsg, &req)
+			if err != nil {
+				log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
+				s.fail(ctx, 1, err, &req, mc)
+				continue
+			}
+
+			tempResult := method.Signature.NewResult()
+			res.Result = &tempResult
+
+			res.Dialog = Dialog{
+				Id:  req.Id,
+				Src: mc.Id(),
+				Dst: req.Src,
+			}
+
+			out, err := method.ActionE(ctx, req.Params)
+			if err != nil {
+				log.Error(err, "Failed to call action")
+				s.fail(ctx, 1, err, &req, mc)
+				continue
+			}
+
+			// FIXME: produces errors like: `Error: unexpected type returned from action: got *[]devices.Device, want *interface {} (code:1)`
+			// if reflect.TypeOf(out) != reflect.TypeOf(res.Result) {
+			// 	s.fail(ctx, 1, fmt.Errorf("unexpected type returned from action: got %v, want %v", reflect.TypeOf(out), reflect.TypeOf(res.Result)), &req, mc)
+			// 	continue
+			// }
+
+			res.Result = &out
+
+			outMsg, err := json.Marshal(res)
+			if err != nil {
+				log.Error(err, "Failed to marshal response")
+				s.fail(ctx, 1, err, &req, mc)
+				continue
+			}
+			// to <- outMsg
+			log.Info("Publishing response", "dst", res.Dst, "topic", ClientTopic(req.Src), "request_id", res.Id)
+			mc.Publish(ctx, ClientTopic(req.Src), outMsg, mqtt.AtLeastOnce, false, InstanceName+".rpc/Server")
+		}
+	}
 }
 
 func (sp *server) fail(ctx context.Context, code int, err error, req *request, mc mqtt.Client) {

--- a/internal/shelly/scripts/heater-myhome.js
+++ b/internal/shelly/scripts/heater-myhome.js
@@ -1,0 +1,247 @@
+// heater-myhome.js — daemon-side heater workflow (JS port of the Go
+// HeaterService in internal/myhome/shelly/script/heater.go).
+//
+// Listed in daemon.scripts.run it takes over the heater.getconfig and
+// heater.setconfig RPC verbs (MyHome.registerVerb replaces the Go handlers),
+// and serves a get_forecast handler so device heater scripts can fetch the
+// weather forecast through the daemon instead of calling the internet
+// themselves (distributed device<->daemon execution via script.invoke).
+//
+// Handlers complete asynchronously: they receive (params, respond) and call
+// respond(result) / respond(null, "error") after the device RPC chain ends.
+//
+// KVS key schema on the heater device (same as the Go service and heater.js):
+//   script/heater/enable-logging, script/heater/cheap-start-hour,
+//   script/heater/cheap-end-hour, script/heater/poll-interval-ms,
+//   script/heater/preheat-hours, script/heater/internal-temperature-topic,
+//   script/heater/external-temperature-topic, room-id, normally-closed
+
+var KVS_KEYS = {
+  enable_logging: "script/heater/enable-logging",
+  cheap_start_hour: "script/heater/cheap-start-hour",
+  cheap_end_hour: "script/heater/cheap-end-hour",
+  poll_interval_ms: "script/heater/poll-interval-ms",
+  preheat_hours: "script/heater/preheat-hours",
+  internal_temperature_topic: "script/heater/internal-temperature-topic",
+  external_temperature_topic: "script/heater/external-temperature-topic",
+  room_id: "room-id",
+  normally_closed: "normally-closed"
+};
+
+// ------------------------------------------------------------- helpers
+
+function kvsItemValue(items, key) {
+  if (!items || !(key in items)) return null;
+  var v = items[key];
+  if (v !== null && typeof v === "object" && ("value" in v)) return v.value;
+  return v;
+}
+
+function toInt(v) {
+  var n = Number(v);
+  if (isNaN(n)) return null;
+  return Math.floor(n);
+}
+
+// ------------------------------------------------------------- heater.getconfig
+
+// Per-request context objects (req) travel through the callback chain via
+// Function.prototype.bind — no shared mutable state between requests.
+
+function handleGetConfig(params, respond) {
+  if (!params || !params.identifier) {
+    respond(null, "missing identifier");
+    return;
+  }
+  var req = {
+    identifier: params.identifier,
+    respond: respond,
+    result: { device_id: params.identifier, device_name: "", has_script: false }
+  };
+  MyHome.call("device.lookup", params.identifier, onGetConfigLookup.bind(null, req));
+}
+
+function onGetConfigLookup(req, result, error_code, error_message) {
+  if (error_code === 0 && result && result.length > 0) {
+    if (result[0].id) req.result.device_id = result[0].id;
+    if (result[0].name) req.result.device_name = result[0].name;
+  }
+  MyHome.deviceCall(req.identifier, "Script.List", null, onGetConfigScriptList.bind(null, req));
+}
+
+function onGetConfigScriptList(req, result, error_code, error_message) {
+  if (error_code !== 0) {
+    req.respond(null, "Script.List failed: " + error_message);
+    return;
+  }
+  var scripts = (result && result.scripts) ? result.scripts : [];
+  for (var i = 0; i < scripts.length; i++) {
+    if (scripts[i].name === "heater.js" || scripts[i].name === "heater") {
+      req.result.has_script = true;
+      break;
+    }
+  }
+  if (!req.result.has_script) {
+    req.respond(req.result);
+    return;
+  }
+  MyHome.deviceCall(req.identifier, "KVS.GetMany", { match: "script/heater/*" }, onGetConfigKvsMany.bind(null, req));
+}
+
+function onGetConfigKvsMany(req, result, error_code, error_message) {
+  var items = (error_code === 0 && result) ? result.items : null;
+  var config = {
+    enable_logging: kvsItemValue(items, KVS_KEYS.enable_logging) === "true",
+    room_id: "",
+    cheap_start_hour: 0,
+    cheap_end_hour: 0,
+    poll_interval_ms: 0,
+    preheat_hours: 0,
+    normally_closed: false,
+    internal_temperature_topic: "",
+    external_temperature_topic: ""
+  };
+  var v;
+  v = toInt(kvsItemValue(items, KVS_KEYS.cheap_start_hour));
+  if (v !== null) config.cheap_start_hour = v;
+  v = toInt(kvsItemValue(items, KVS_KEYS.cheap_end_hour));
+  if (v !== null) config.cheap_end_hour = v;
+  v = toInt(kvsItemValue(items, KVS_KEYS.poll_interval_ms));
+  if (v !== null) config.poll_interval_ms = v;
+  v = toInt(kvsItemValue(items, KVS_KEYS.preheat_hours));
+  if (v !== null) config.preheat_hours = v;
+  v = kvsItemValue(items, KVS_KEYS.internal_temperature_topic);
+  if (v) config.internal_temperature_topic = String(v);
+  v = kvsItemValue(items, KVS_KEYS.external_temperature_topic);
+  if (v) config.external_temperature_topic = String(v);
+
+  req.result.config = config;
+  MyHome.deviceCall(req.identifier, "KVS.Get", { key: KVS_KEYS.room_id }, onGetConfigRoomId.bind(null, req));
+}
+
+function onGetConfigRoomId(req, result, error_code, error_message) {
+  if (error_code === 0 && result && ("value" in result) && result.value !== null) {
+    req.result.config.room_id = String(result.value);
+  }
+  MyHome.deviceCall(req.identifier, "KVS.Get", { key: KVS_KEYS.normally_closed }, onGetConfigNormallyClosed.bind(null, req));
+}
+
+function onGetConfigNormallyClosed(req, result, error_code, error_message) {
+  if (error_code === 0 && result && ("value" in result)) {
+    req.result.config.normally_closed = String(result.value) === "true";
+  }
+  req.respond(req.result);
+}
+
+// ------------------------------------------------------------- heater.setconfig
+
+function handleSetConfig(params, respond) {
+  if (!params || !params.identifier) {
+    respond(null, "missing identifier");
+    return;
+  }
+  var tasks = [];
+  var fields = ["enable_logging", "room_id", "cheap_start_hour", "cheap_end_hour",
+    "poll_interval_ms", "preheat_hours", "normally_closed",
+    "internal_temperature_topic", "external_temperature_topic"];
+  for (var i = 0; i < fields.length; i++) {
+    var f = fields[i];
+    if ((f in params) && params[f] !== null && typeof params[f] !== "undefined") {
+      tasks.push({ field: f, key: KVS_KEYS[f], value: String(params[f]) });
+    }
+  }
+  var req = { identifier: params.identifier, tasks: tasks, respond: respond };
+  setConfigNext(req);
+}
+
+// setConfigNext applies KVS sets one at a time (sequential task queue: avoids
+// flooding the device with parallel RPCs), then uploads heater.js.
+function setConfigNext(req) {
+  if (req.tasks.length === 0) {
+    MyHome.uploadScript(req.identifier, "heater.js", onSetConfigUploaded.bind(null, req));
+    return;
+  }
+  var task = req.tasks[0];
+  req.tasks = req.tasks.slice(1);
+  MyHome.deviceCall(req.identifier, "KVS.Set", { key: task.key, value: task.value },
+    onSetConfigKvsSet.bind(null, req, task));
+}
+
+function onSetConfigKvsSet(req, task, result, error_code, error_message) {
+  if (error_code !== 0) {
+    req.respond({ success: false, message: "failed to set " + task.field + ": " + error_message });
+    return;
+  }
+  setConfigNext(req);
+}
+
+function onSetConfigUploaded(req, result, error_code, error_message) {
+  if (error_code !== 0) {
+    req.respond({ success: false, message: "failed to upload/start heater.js: " + error_message });
+    return;
+  }
+  MyHome.log("Heater script uploaded and started on " + req.identifier);
+  req.respond({ success: true });
+}
+
+// ------------------------------------------------------------- get_forecast
+
+// Device heater scripts invoke this through script.invoke instead of calling
+// open-meteo themselves: the daemon fetches and caches the forecast.
+
+var FORECAST = {
+  cacheMs: 60 * 60 * 1000,
+  cache: {} // "lat,lon" -> { at: ms, data: {...} }
+};
+
+function forecastUrl(lat, lon) {
+  return "https://api.open-meteo.com/v1/forecast?latitude=" + lat + "&longitude=" + lon +
+    "&hourly=temperature_2m&forecast_days=1&timezone=auto";
+}
+
+function handleGetForecast(params, respond) {
+  if (!params || typeof params.lat === "undefined" || typeof params.lon === "undefined") {
+    respond(null, "missing lat/lon");
+    return;
+  }
+  var key = String(params.lat) + "," + String(params.lon);
+  var cached = (key in FORECAST.cache) ? FORECAST.cache[key] : null;
+  if (cached && (Date.now() - cached.at) < FORECAST.cacheMs) {
+    respond({ cached: true, fetched_at: cached.at, forecast: cached.data });
+    return;
+  }
+  var req = { key: key, respond: respond };
+  Shelly.call("HTTP.GET", { url: forecastUrl(params.lat, params.lon), timeout: 15 },
+    onForecastFetched.bind(null, req));
+}
+
+function onForecastFetched(req, result, error_code, error_message) {
+  if (error_code !== 0 || !result || !result.body) {
+    req.respond(null, "forecast fetch failed: " + error_message);
+    return;
+  }
+  var data = null;
+  try {
+    data = JSON.parse(result.body);
+  } catch (e) {
+    req.respond(null, "forecast parse failed: " + String(e));
+    return;
+  }
+  FORECAST.cache[req.key] = { at: Date.now(), data: data };
+  req.respond({ cached: false, fetched_at: Date.now(), forecast: data });
+}
+
+// ------------------------------------------------------------- main
+
+function main() {
+  if (typeof MyHome === "undefined") {
+    print("heater-myhome.js is a daemon workflow; it does nothing on a device");
+    return;
+  }
+  MyHome.registerVerb("heater.getconfig", handleGetConfig);
+  MyHome.registerVerb("heater.setconfig", handleSetConfig);
+  MyHome.on("get_forecast", handleGetForecast);
+  MyHome.log("heater workflow ready on instance " + MyHome.instance());
+}
+
+main();

--- a/internal/shelly/scripts/myhome-link.js
+++ b/internal/shelly/scripts/myhome-link.js
@@ -1,0 +1,146 @@
+// myhome-link.js — device <-> daemon distributed execution: calling convention
+// demo and self-test.
+//
+// The same script runs on both sides ("every device script can assume it is
+// also present on the daemon"):
+// - On the daemon script host (goja), the MyHome global exists: the script
+//   registers invocation handlers via MyHome.on(name, fn).
+// - On a Shelly device, the script invokes those handlers through the
+//   script.invoke RPC verb: publish a request on "<instance>/rpc", receive
+//   the response on "<own-mqtt-prefix>/myhome/rpc".
+//
+// Device-side request format (myhome RPC protocol):
+//   { id: "<unique>", src: "<prefix>/myhome", dst: "<instance>",
+//     method: "script.invoke",
+//     params: { script: "<name>", name: "<handler>", params: {...} } }
+// The daemon answers on "<src>/rpc" with { id, result | error }.
+//
+// KVS configuration (device side):
+//   script/myhome-link/instance — daemon instance to call (default "myhome")
+
+var CONFIG = {
+  instance: "myhome",
+  pingPeriodMs: 60000,
+  timeoutMs: 10000
+};
+
+// ---------------------------------------------------------------- daemon side
+
+function onDaemonPing(params) {
+  return {
+    pong: true,
+    instance: MyHome.instance(),
+    received: params || null,
+    ts: Date.now()
+  };
+}
+
+function setupDaemon() {
+  MyHome.on("ping", onDaemonPing);
+  MyHome.log("myhome-link ready on instance " + MyHome.instance());
+}
+
+// ---------------------------------------------------------------- device side
+
+var STATE = {
+  topicPrefix: null,
+  pending: {}, // id -> { sentAt: ms, cb: function|null } (null = slot free)
+  nextId: 1
+};
+
+function log() {
+  var parts = [];
+  for (var i = 0; i < arguments.length; i++) {
+    var a = arguments[i];
+    parts.push(typeof a === "object" ? JSON.stringify(a) : String(a));
+  }
+  print("[myhome-link] " + parts.join(" "));
+}
+
+// callDaemon invokes handler `name` of daemon-hosted script `script`.
+// cb(result, error) is optional.
+function callDaemon(script, name, params, cb) {
+  var id = "dev-" + STATE.nextId;
+  STATE.nextId++;
+  STATE.pending[id] = { sentAt: Date.now(), cb: cb || null };
+  var req = {
+    id: id,
+    src: STATE.topicPrefix + "/myhome",
+    dst: CONFIG.instance,
+    method: "script.invoke",
+    params: { script: script, name: name, params: params }
+  };
+  MQTT.publish(CONFIG.instance + "/rpc", JSON.stringify(req));
+}
+
+function onResponse(topic, message) {
+  var res = null;
+  try {
+    res = JSON.parse(message);
+  } catch (e) {
+    log("bad response:", message, String(e));
+    return;
+  }
+  if (!res || !("id" in res)) return;
+  var p = STATE.pending[res.id];
+  if (!p) return;
+  STATE.pending[res.id] = null; // free the slot (no delete on Espruino)
+  var rtt = Date.now() - p.sentAt;
+  if ("error" in res && res.error) {
+    log("daemon error (rtt " + rtt + "ms):", res.error.message);
+    if (p.cb) p.cb(null, res.error);
+    return;
+  }
+  log("daemon response (rtt " + rtt + "ms):", res.result);
+  if (p.cb) p.cb(res.result, null);
+}
+
+// checkTimeouts drops expired requests and compacts the pending map.
+function checkTimeouts() {
+  var now = Date.now();
+  var keep = {};
+  for (var id in STATE.pending) {
+    var p = STATE.pending[id];
+    if (!p) continue;
+    if (now - p.sentAt > CONFIG.timeoutMs) {
+      log("timeout for", id);
+      if (p.cb) p.cb(null, { code: -1, message: "timeout" });
+    } else {
+      keep[id] = p;
+    }
+  }
+  STATE.pending = keep;
+}
+
+function pingDaemon() {
+  checkTimeouts();
+  var sys = Shelly.getComponentStatus("sys");
+  var uptime = sys && ("uptime" in sys) ? sys.uptime : null;
+  callDaemon("myhome-link", "ping", { from: STATE.topicPrefix, uptime: uptime }, null);
+}
+
+function setupDevice() {
+  var mqttConfig = Shelly.getComponentConfig("mqtt");
+  STATE.topicPrefix = mqttConfig.topic_prefix;
+  MQTT.subscribe(STATE.topicPrefix + "/myhome/rpc", onResponse);
+  Timer.set(CONFIG.pingPeriodMs, true, pingDaemon);
+  Timer.set(2000, false, pingDaemon); // first ping shortly after start
+  log("device mode: prefix=" + STATE.topicPrefix + " instance=" + CONFIG.instance);
+}
+
+function onInstanceLoaded(result, error_code, error_message) {
+  if (error_code === 0 && result && ("value" in result) && result.value) {
+    CONFIG.instance = String(result.value);
+  }
+  setupDevice();
+}
+
+function main() {
+  if (typeof MyHome !== "undefined") {
+    setupDaemon();
+  } else {
+    Shelly.call("KVS.Get", { key: "script/myhome-link/instance" }, onInstanceLoaded);
+  }
+}
+
+main();

--- a/internal/shelly/scripts/occupancy.js
+++ b/internal/shelly/scripts/occupancy.js
@@ -1,0 +1,162 @@
+// occupancy.js — home occupancy detection workflow (daemon-hosted).
+//
+// JS port of the Go occupancy service (myhome/occupancy): listed in
+// daemon.scripts.run it REPLACES the Go implementation (both publish the
+// retained myhome/occupancy topic).
+//
+// Heuristic (same as Go):
+// - any Gen2 NotifyStatus event with an "input:N" change marks the home
+//   occupied (button press, motion detector wired to an input, ...)
+// - a configured mobile device seen online on the LAN marks the home occupied
+//   (LAN polling is Go infrastructure, reached via MyHome.call("lan.hosts"))
+// - occupancy expires after a quiet window; expiry publishes occupied=false
+//
+// Publishes (retained): myhome/occupancy = {"occupied":bool,"reason":string}
+// RPC: occupancy.getstatus -> {"occupied":bool} (same verb as the Go service)
+//
+// KVS configuration (persisted in scripts-state/occupancy.json):
+//   script/occupancy/window-hours     — quiet window before un-occupied (default 12)
+//   script/occupancy/poll-minutes     — LAN presence poll period (default 5)
+//   script/occupancy/mobile-patterns  — comma-separated device name patterns (default "iPhone")
+
+var CONFIG = {
+  windowMs: 12 * 3600 * 1000,
+  pollMs: 5 * 60 * 1000,
+  patterns: ["iPhone"],
+  topic: "myhome/occupancy"
+};
+
+var STATE = {
+  lastSeen: 0,
+  occupied: false,
+  expiryTimer: null
+};
+
+function publishStatus(occupied, reason) {
+  STATE.occupied = occupied;
+  var msg = JSON.stringify({ occupied: occupied, reason: reason });
+  MQTT.publish(CONFIG.topic, msg, 1, true);
+  MyHome.log("occupancy: " + msg);
+}
+
+function formatElapsed(ms) {
+  var s = Math.floor(ms / 1000);
+  var h = Math.floor(s / 3600);
+  var m = Math.floor(s / 60) % 60;
+  var sec = s % 60;
+  if (h > 0) return h + "h " + m + "m " + sec + "s ago";
+  if (m > 0) return m + "m " + sec + "s ago";
+  return sec + "s ago";
+}
+
+function onWindowExpired() {
+  STATE.expiryTimer = null;
+  publishStatus(false, "last seen " + formatElapsed(Date.now() - STATE.lastSeen));
+}
+
+function markOccupied(reason) {
+  STATE.lastSeen = Date.now();
+  if (STATE.expiryTimer !== null) {
+    Timer.clear(STATE.expiryTimer);
+    STATE.expiryTimer = null;
+  }
+  publishStatus(true, reason);
+  STATE.expiryTimer = Timer.set(CONFIG.windowMs, false, onWindowExpired);
+}
+
+// Gen2 events: {"method":"NotifyStatus","params":{"input:0":{...}}}
+function onDeviceEvent(topic, message) {
+  var payload = String(message);
+  if (payload.indexOf('"NotifyStatus"') !== -1 && payload.indexOf('"input:') !== -1) {
+    markOccupied("input change: " + payload);
+  }
+}
+
+function matchesPattern(name) {
+  var lower = String(name).toLowerCase();
+  for (var i = 0; i < CONFIG.patterns.length; i++) {
+    if (lower.indexOf(CONFIG.patterns[i].toLowerCase()) !== -1) return true;
+  }
+  return false;
+}
+
+function onLanHosts(result, error_code, error_message) {
+  if (error_code !== 0) {
+    MyHome.log("lan.hosts failed: " + error_message);
+    return;
+  }
+  if (!result || !("hosts" in result) || !result.hosts) return;
+  for (var i = 0; i < result.hosts.length; i++) {
+    var h = result.hosts[i];
+    if (!matchesPattern(h.name)) continue;
+    if (String(h.status).toLowerCase() === "online" || h.alive > 0) {
+      markOccupied("seen mobile: " + h.name + " (" + h.mac + ")");
+      return;
+    }
+  }
+}
+
+function pollMobilePresence() {
+  MyHome.call("lan.hosts", null, onLanHosts);
+}
+
+function onGetStatus(params) {
+  return { occupied: STATE.occupied };
+}
+
+// ---- KVS-backed configuration (3 sequential loads, then start) ----
+
+function applyConfigValue(key, value) {
+  var v = String(value);
+  if (key === "window-hours" && Number(v) > 0) {
+    CONFIG.windowMs = Number(v) * 3600 * 1000;
+  } else if (key === "poll-minutes" && Number(v) > 0) {
+    CONFIG.pollMs = Number(v) * 60 * 1000;
+  } else if (key === "mobile-patterns" && v.length > 0) {
+    var parts = v.split(",");
+    var patterns = [];
+    for (var i = 0; i < parts.length; i++) {
+      var p = parts[i].replace(/^\s+|\s+$/g, "");
+      if (p.length > 0) patterns.push(p);
+    }
+    if (patterns.length > 0) CONFIG.patterns = patterns;
+  }
+}
+
+var CONFIG_KEYS = ["window-hours", "poll-minutes", "mobile-patterns"];
+var configIndex = 0;
+
+function onConfigLoaded(result, error_code, error_message) {
+  if (error_code === 0 && result && ("value" in result) && result.value !== null) {
+    applyConfigValue(CONFIG_KEYS[configIndex], result.value);
+  }
+  configIndex++;
+  loadNextConfig();
+}
+
+function loadNextConfig() {
+  if (configIndex >= CONFIG_KEYS.length) {
+    start();
+    return;
+  }
+  Shelly.call("KVS.Get", { key: "script/occupancy/" + CONFIG_KEYS[configIndex] }, onConfigLoaded);
+}
+
+function start() {
+  MQTT.subscribe("+/events/rpc", onDeviceEvent);
+  Timer.set(CONFIG.pollMs, true, pollMobilePresence);
+  Timer.set(3000, false, pollMobilePresence);
+  MyHome.registerVerb("occupancy.getstatus", onGetStatus);
+  MyHome.log("occupancy workflow started: window=" + (CONFIG.windowMs / 3600000) +
+    "h poll=" + (CONFIG.pollMs / 60000) + "m patterns=" + CONFIG.patterns.join(","));
+}
+
+function main() {
+  if (typeof MyHome === "undefined") {
+    print("occupancy.js is a daemon workflow; it does nothing on a device");
+    return;
+  }
+  loadNextConfig();
+}
+
+main();

--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -87,6 +87,11 @@ mqtt:
 daemon:
   # MQTT broker address (leave empty to use embedded broker)
   # mqtt_broker: "192.168.1.2"
+
+  # Daemon instance name, used in RPC topics ("<instance>/rpc").
+  # Default: short OS hostname. The daemon running the embedded broker is the
+  # main daemon and also serves the well-known "myhome/rpc" topic.
+  # instance_name: myhome
   
   # Initial delay before checking if embedded MQTT broker is ready
   # Gives the broker time to complete async initialization after Serve() returns

--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -148,6 +148,17 @@ daemon:
   # Disable auto-setup
   # disable_auto_setup: false
 
+  # Workflow scripts (JavaScript, executed on the daemon's goja engine).
+  # Scripts come from scripts.dir (if set) or the embedded library.
+  # Listing a script may replace its Go counterpart (e.g. occupancy).
+  # scripts:
+  #   enabled: true
+  #   run:
+  #     - occupancy
+  #     - heater-myhome
+  #   dir: ""
+  #   state_dir: scripts-state
+
 # Event Log Configuration
 events:
   # Path to the events SQLite database (separate from devices.db)

--- a/myhome/ctl/options/options.go
+++ b/myhome/ctl/options/options.go
@@ -74,7 +74,7 @@ var Flags struct {
 	ShellyRateLimit             time.Duration // the value taken by --shelly-rate-limit
 	AutoSetup                   bool          // the value taken by --auto-setup / -A
 	NoMdnsPublish               bool          // the value taken by --no-mdns-publish
-	InstanceName                string        // the value taken by --instance / -I
+	InstanceName                string        // the value taken by --instance / -I (daemon default: short OS hostname)
 	EventsDBPath                string        // path to events SQLite database
 	EventsRetention             time.Duration // retention period for event records
 	EnableEventsService         bool          // whether to enable the event recording service

--- a/myhome/ctl/options/options.go
+++ b/myhome/ctl/options/options.go
@@ -79,6 +79,10 @@ var Flags struct {
 	EventsRetention             time.Duration // retention period for event records
 	EnableEventsService         bool          // whether to enable the event recording service
 	RemoteProxy                 string        // the value taken by --remote-proxy; delegates /devices/... to a remote myhome daemon
+	ScriptsEnabled              bool          // whether the daemon hosts workflow scripts (goja)
+	ScriptsDir                  string        // optional user dir overriding embedded workflow scripts
+	ScriptsRun                  []string      // names of workflow scripts to run on the daemon
+	ScriptsStateDir             string        // per-script KVS/storage state files (default "scripts-state")
 }
 
 var Via types.Channel

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -247,8 +247,15 @@ func (d *daemon) Run() error {
 			log.Info("Gen2 event listener started")
 		}
 
-		// Start the main RPC server
-		d.rpc, err = myhome.NewServerE(d.ctx, mc, d.dm)
+		// Start the main RPC server. The daemon running the embedded broker is
+		// the main daemon: it also serves the well-known "myhome/rpc" topic so
+		// that CLI clients and devices keep working without knowing its
+		// instance name.
+		rpcTopics := []string{myhome.ServerTopic()}
+		if !disableEmbeddedMqttBroker && myhome.InstanceName != myhome.MYHOME {
+			rpcTopics = append(rpcTopics, myhome.MYHOME+"/rpc")
+		}
+		d.rpc, err = myhome.NewServerE(d.ctx, mc, d.dm, rpcTopics...)
 		if err != nil {
 			log.Error(err, "Failed to start MyHome RPC service")
 			return err

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/asnowfix/home-automation/internal/global"
 	"github.com/asnowfix/home-automation/internal/myhome"
-	"github.com/asnowfix/home-automation/internal/shelly/scripts"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
 	shellygen2l "github.com/asnowfix/home-automation/internal/myhome/shelly/gen2"
 	"github.com/asnowfix/home-automation/internal/myhome/ui"
+	"github.com/asnowfix/home-automation/internal/shelly/scripts"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
 	"github.com/asnowfix/home-automation/myhome/devices/impl"
 	"github.com/asnowfix/home-automation/myhome/events"

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"slices"
 	"time"
 
 	"github.com/asnowfix/home-automation/internal/global"
 	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/internal/shelly/scripts"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
 	shellygen2l "github.com/asnowfix/home-automation/internal/myhome/shelly/gen2"
 	"github.com/asnowfix/home-automation/internal/myhome/ui"
@@ -19,8 +21,10 @@ import (
 	mqttclient "github.com/asnowfix/home-automation/myhome/mqtt"
 	mqttserver "github.com/asnowfix/home-automation/myhome/mqtt"
 	"github.com/asnowfix/home-automation/myhome/occupancy"
+	"github.com/asnowfix/home-automation/myhome/scripthost"
 	"github.com/asnowfix/home-automation/myhome/storage"
 	"github.com/asnowfix/home-automation/myhome/temperature"
+	"github.com/asnowfix/home-automation/pkg/sfr"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/gen1"
 	"github.com/go-logr/logr"
@@ -41,6 +45,36 @@ type Config struct {
 
 var DefaultConfig = Config{
 	RefreshInterval: 3 * time.Minute,
+}
+
+// scriptsRunContains reports whether a workflow script is configured on the
+// daemon script host (names accepted with or without the .js suffix).
+func scriptsRunContains(name string) bool {
+	return slices.ContainsFunc(options.Flags.ScriptsRun, func(s string) bool {
+		return s == name || s == name+".js"
+	})
+}
+
+// registerLanHostsHandler exposes LAN presence polling (SFR box) to JS
+// workflows: the occupancy workflow is JS, the infrastructure stays in Go.
+func registerLanHostsHandler() {
+	myhome.RegisterMethodHandler(myhome.LanHosts, func(ctx context.Context, in any) (any, error) {
+		hosts, err := sfr.GetHostsList(ctx)
+		if err != nil {
+			return nil, err
+		}
+		res := &myhome.LanHostsResult{Hosts: make([]myhome.LanHostInfo, 0, len(*hosts))}
+		for _, h := range *hosts {
+			res.Hosts = append(res.Hosts, myhome.LanHostInfo{
+				Name:   h.Name,
+				Ip:     h.Ip.String(),
+				Mac:    h.Mac,
+				Status: h.Status,
+				Alive:  h.Alive,
+			})
+		}
+		return res, nil
+	})
 }
 
 func NewDaemon(ctx context.Context) *daemon {
@@ -147,8 +181,14 @@ func (d *daemon) Run() error {
 		log.Info("Gen1 (HTTP->MQTT) proxy disabled")
 	}
 
-	// Start Occupancy service (MQTT only)
-	if options.Flags.EnableOccupancyService {
+	// Start Occupancy service (MQTT only). When the JS occupancy workflow is
+	// configured on the script host, it replaces the Go implementation (both
+	// publish the retained myhome/occupancy topic and must not coexist).
+	jsOccupancy := options.Flags.ScriptsEnabled && scriptsRunContains("occupancy")
+	if jsOccupancy && options.Flags.EnableOccupancyService {
+		log.Info("Occupancy service: Go implementation replaced by JS workflow (daemon.scripts.run)")
+	}
+	if options.Flags.EnableOccupancyService && !jsOccupancy {
 		log.Info("Starting occupancy service")
 
 		// Create occupancy service
@@ -259,6 +299,26 @@ func (d *daemon) Run() error {
 		if err != nil {
 			log.Error(err, "Failed to start MyHome RPC service")
 			return err
+		}
+
+		// Start the script host: JS workflows running on the daemon's goja
+		// engine, invocable from devices via the script.invoke RPC verb.
+		if options.Flags.ScriptsEnabled {
+			log.Info("Starting script host", "scripts", options.Flags.ScriptsRun)
+			sh := scripthost.NewService(log, scripthost.Config{
+				Enabled:  true,
+				Dir:      options.Flags.ScriptsDir,
+				Run:      options.Flags.ScriptsRun,
+				StateDir: options.Flags.ScriptsStateDir,
+			}, scripts.GetFS(), d.dm, myhome.InstanceName)
+			if err := sh.Start(d.ctx); err != nil {
+				log.Error(err, "Failed to start script host")
+				return err
+			}
+			// Infrastructure verbs only needed by JS workflows
+			registerLanHostsHandler()
+		} else {
+			log.Info("Script host disabled")
 		}
 
 		// Register EventList RPC handler if events service is running

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -1,9 +1,12 @@
 package daemon
 
 import (
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -46,7 +49,7 @@ func init() {
 	runCmd.PersistentFlags().StringVar(&options.Flags.MetricsExporterTopic, "metrics-exporter-topic", "shelly/metrics", "MQTT topic for Shelly device metrics")
 	runCmd.PersistentFlags().BoolVar(&disableAutoSetup, "disable-auto-setup", false, "Disable automatic configuration of newly discovered unknown devices")
 	runCmd.PersistentFlags().BoolVar(&options.Flags.NoMdnsPublish, "no-mdns-publish", false, "Disable mDNS/Zeroconf publishing (useful for dev instances)")
-	runCmd.PersistentFlags().StringVarP(&options.Flags.InstanceName, "instance", "I", "myhome", "Server instance name for RPC topics (default: myhome)")
+	runCmd.PersistentFlags().StringVarP(&options.Flags.InstanceName, "instance", "I", "", "Daemon instance name used in RPC topics (default: OS hostname; the daemon running the embedded broker also serves the well-known 'myhome' topics)")
 	runCmd.PersistentFlags().StringVar(&options.Flags.EventsDBPath, "events-db", defaultEventsDBPath(), "Path to the events SQLite database")
 	runCmd.PersistentFlags().DurationVar(&options.Flags.EventsRetention, "events-retention", 90*24*time.Hour, "Retention period for event records (default 90 days)")
 	runCmd.PersistentFlags().BoolVar(&disableEventsService, "disable-events-service", false, "Disable the event recording service")
@@ -142,6 +145,20 @@ var runCmd = &cobra.Command{
 		}
 		if v.IsSet("daemon.remote_proxy") && !cmd.Flags().Changed("remote-proxy") {
 			options.Flags.RemoteProxy = v.GetString("daemon.remote_proxy")
+		}
+		if v.IsSet("daemon.instance_name") && !cmd.Flags().Changed("instance") {
+			options.Flags.InstanceName = v.GetString("daemon.instance_name")
+		}
+		// Default instance name: short OS hostname (the well-known "myhome"
+		// topics stay reachable because the daemon running the embedded broker
+		// also serves them — see daemon.Run).
+		if options.Flags.InstanceName == "" {
+			hostname, err := os.Hostname()
+			if err != nil || hostname == "" {
+				options.Flags.InstanceName = myhome.MYHOME
+			} else {
+				options.Flags.InstanceName = strings.Split(hostname, ".")[0]
+			}
 		}
 		// Handle auto-setup flag (default is enabled, --disable-auto-setup disables it)
 		// Config file can also disable it via daemon.disable_auto_setup: true

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -54,6 +54,10 @@ func init() {
 	runCmd.PersistentFlags().DurationVar(&options.Flags.EventsRetention, "events-retention", 90*24*time.Hour, "Retention period for event records (default 90 days)")
 	runCmd.PersistentFlags().BoolVar(&disableEventsService, "disable-events-service", false, "Disable the event recording service")
 	runCmd.PersistentFlags().StringVar(&options.Flags.RemoteProxy, "remote-proxy", "", "Forward /devices/... requests to a remote myhome daemon (e.g. http://home-pi:6080) instead of connecting directly")
+	runCmd.PersistentFlags().BoolVar(&options.Flags.ScriptsEnabled, "enable-scripts", false, "Enable the daemon script host (JS workflows on goja)")
+	runCmd.PersistentFlags().StringVar(&options.Flags.ScriptsDir, "scripts-dir", "", "Directory of workflow scripts overriding the embedded library")
+	runCmd.PersistentFlags().StringSliceVar(&options.Flags.ScriptsRun, "scripts-run", nil, "Workflow scripts to run on the daemon (e.g. occupancy,heater-myhome)")
+	runCmd.PersistentFlags().StringVar(&options.Flags.ScriptsStateDir, "scripts-state-dir", "scripts-state", "Directory for per-script persistent state (KVS + Script.storage)")
 	runCmd.MarkFlagsMutuallyExclusive("enable-gen1-proxy", "disable-gen1-proxy")
 	runCmd.MarkFlagsMutuallyExclusive("enable-occupancy-service", "disable-occupancy-service")
 	runCmd.MarkFlagsMutuallyExclusive("enable-temperature-service", "disable-temperature-service")
@@ -148,6 +152,22 @@ var runCmd = &cobra.Command{
 		}
 		if v.IsSet("daemon.instance_name") && !cmd.Flags().Changed("instance") {
 			options.Flags.InstanceName = v.GetString("daemon.instance_name")
+		}
+		if v.IsSet("daemon.scripts.enabled") && !cmd.Flags().Changed("enable-scripts") {
+			options.Flags.ScriptsEnabled = v.GetBool("daemon.scripts.enabled")
+		}
+		if v.IsSet("daemon.scripts.dir") && !cmd.Flags().Changed("scripts-dir") {
+			options.Flags.ScriptsDir = v.GetString("daemon.scripts.dir")
+		}
+		if v.IsSet("daemon.scripts.run") && !cmd.Flags().Changed("scripts-run") {
+			options.Flags.ScriptsRun = v.GetStringSlice("daemon.scripts.run")
+		}
+		if v.IsSet("daemon.scripts.state_dir") && !cmd.Flags().Changed("scripts-state-dir") {
+			options.Flags.ScriptsStateDir = v.GetString("daemon.scripts.state_dir")
+		}
+		// Listing scripts implies enabling the script host (unless explicitly disabled)
+		if len(options.Flags.ScriptsRun) > 0 && !cmd.Flags().Changed("enable-scripts") && !v.IsSet("daemon.scripts.enabled") {
+			options.Flags.ScriptsEnabled = true
 		}
 		// Default instance name: short OS hostname (the well-known "myhome"
 		// topics stay reachable because the daemon running the embedded broker

--- a/myhome/scripthost/go.mod
+++ b/myhome/scripthost/go.mod
@@ -1,0 +1,8 @@
+module github.com/asnowfix/home-automation/myhome/scripthost
+
+go 1.25.0
+
+require (
+	github.com/dop251/goja v0.0.0-20251103141225-af2ceb9156d7
+	github.com/go-logr/logr v1.4.3
+)

--- a/myhome/scripthost/heater_test.go
+++ b/myhome/scripthost/heater_test.go
@@ -1,0 +1,163 @@
+package scripthost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+// TestHeaterWorkflow runs the real heater-myhome.js on the script host with a
+// fake device backend and exercises the heater.getconfig / heater.setconfig
+// verbs end-to-end (async respond() completion across chained device calls).
+// No t.Parallel(): registers handlers in the shared myhome methods map.
+func TestHeaterWorkflow(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "internal", "shelly", "scripts", "heater-myhome.js"))
+	if err != nil {
+		t.Fatalf("read heater-myhome.js: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	log := testr.New(t)
+	ctx = logr.NewContext(ctx, log)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	// Fake device manager lookup (normally registered by devices/impl)
+	myhome.RegisterMethodHandler(myhome.DeviceLookup, func(ctx context.Context, in any) (any, error) {
+		return []map[string]any{{"id": "shellyplus1-test", "name": "radiator-test"}}, nil
+	})
+
+	// Fake device RPC backend
+	var mu sync.Mutex
+	kvsSets := make(map[string]string)
+	var uploads []string
+	fakeDeviceCall := func(ctx context.Context, identifier, method string, params any) (any, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch method {
+		case "Script.List":
+			return map[string]any{"scripts": []any{
+				map[string]any{"id": 1, "name": "heater.js", "running": true},
+			}}, nil
+		case "KVS.GetMany":
+			return map[string]any{"items": map[string]any{
+				// object form (etag+value) and plain form must both parse
+				"script/heater/cheap-start-hour": map[string]any{"etag": "x", "value": "23"},
+				"script/heater/enable-logging":   "true",
+				"script/heater/preheat-hours":    map[string]any{"value": "3"},
+			}}, nil
+		case "KVS.Get":
+			p := params.(map[string]any)
+			switch p["key"] {
+			case "room-id":
+				return map[string]any{"value": "office"}, nil
+			default:
+				return nil, fmt.Errorf("key not found")
+			}
+		case "KVS.Set":
+			p := params.(map[string]any)
+			kvsSets[p["key"].(string)] = p["value"].(string)
+			return map[string]any{}, nil
+		}
+		return nil, fmt.Errorf("unexpected device call %s", method)
+	}
+	fakeUpload := func(ctx context.Context, identifier, scriptName string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		uploads = append(uploads, identifier+":"+scriptName)
+		return nil
+	}
+
+	svc := NewService(log, Config{
+		Enabled:  true,
+		Run:      []string{"heater-myhome"},
+		StateDir: t.TempDir(),
+	}, fstest.MapFS{"heater-myhome.js": &fstest.MapFile{Data: src}}, nil, "test-instance").
+		WithDeviceCaller(fakeDeviceCall, fakeUpload)
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// heater.getconfig — retried until the script engine is up
+	var out any
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		out, err = myhome.CallLocalE(ctx, myhome.HeaterGetConfig, json.RawMessage(`{"identifier":"shellyplus1-test"}`))
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("heater.getconfig never succeeded: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	res, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected result type: %T (%v)", out, out)
+	}
+	if res["device_id"] != "shellyplus1-test" || res["device_name"] != "radiator-test" {
+		t.Errorf("device identity = %v / %v", res["device_id"], res["device_name"])
+	}
+	if res["has_script"] != true {
+		t.Fatalf("has_script = %v, want true", res["has_script"])
+	}
+	config, ok := res["config"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing config in %v", res)
+	}
+	if config["cheap_start_hour"] != int64(23) && config["cheap_start_hour"] != 23.0 {
+		t.Errorf("cheap_start_hour = %v (%T), want 23", config["cheap_start_hour"], config["cheap_start_hour"])
+	}
+	if config["enable_logging"] != true {
+		t.Errorf("enable_logging = %v, want true", config["enable_logging"])
+	}
+	if config["preheat_hours"] != int64(3) && config["preheat_hours"] != 3.0 {
+		t.Errorf("preheat_hours = %v, want 3", config["preheat_hours"])
+	}
+	if config["room_id"] != "office" {
+		t.Errorf("room_id = %v, want office", config["room_id"])
+	}
+	if config["normally_closed"] != false {
+		t.Errorf("normally_closed = %v, want false", config["normally_closed"])
+	}
+
+	// heater.setconfig — sequential KVS.Set chain + script upload
+	out, err = myhome.CallLocalE(ctx, myhome.HeaterSetConfig,
+		json.RawMessage(`{"identifier":"shellyplus1-test","cheap_start_hour":22,"enable_logging":true,"room_id":"salon"}`))
+	if err != nil {
+		t.Fatalf("heater.setconfig: %v", err)
+	}
+	res, ok = out.(map[string]any)
+	if !ok || res["success"] != true {
+		t.Fatalf("setconfig result = %v (%T), want success", out, out)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if kvsSets["script/heater/cheap-start-hour"] != "22" {
+		t.Errorf("cheap-start-hour set to %q, want 22", kvsSets["script/heater/cheap-start-hour"])
+	}
+	if kvsSets["script/heater/enable-logging"] != "true" {
+		t.Errorf("enable-logging set to %q, want true", kvsSets["script/heater/enable-logging"])
+	}
+	if kvsSets["room-id"] != "salon" {
+		t.Errorf("room-id set to %q, want salon", kvsSets["room-id"])
+	}
+	if len(uploads) != 1 || uploads[0] != "shellyplus1-test:heater.js" {
+		t.Errorf("uploads = %v, want [shellyplus1-test:heater.js]", uploads)
+	}
+}

--- a/myhome/scripthost/jsapi.go
+++ b/myhome/scripthost/jsapi.go
@@ -76,7 +76,7 @@ func (r *runner) installMyHomeAPI(ctx context.Context, vm *goja.Runtime) error {
 		go func() {
 			callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
-			out, err := r.doDeviceCall(callCtx, identifier, method, params)
+			out, err := r.svc.deviceCall(callCtx, identifier, method, params)
 			r.deliver(ctx, callback, out, err)
 		}()
 		return goja.Undefined()
@@ -92,7 +92,7 @@ func (r *runner) installMyHomeAPI(ctx context.Context, vm *goja.Runtime) error {
 		go func() {
 			callCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 			defer cancel()
-			err := r.doUploadScript(callCtx, identifier, scriptName)
+			err := r.svc.uploadScript(callCtx, identifier, scriptName)
 			r.deliver(ctx, callback, map[string]interface{}{"uploaded": err == nil}, err)
 		}()
 		return goja.Undefined()
@@ -149,58 +149,107 @@ func (r *runner) registerGoVerb(ctx context.Context, verb myhome.Verb) (err erro
 		callCtx, cancel := context.WithTimeout(callCtx, 30*time.Second)
 		defer cancel()
 
-		var out any
-		var jsErr error
-		err = eng.Dispatch(callCtx, func(vm *goja.Runtime) {
+		return r.callJSHandler(callCtx, eng, generic, fmt.Sprintf("verb %s", verb), func() (goja.Callable, bool) {
 			cb, ok := r.verbHandlers[verb]
-			if !ok {
-				jsErr = fmt.Errorf("script %s lost handler for %s", r.name, verb)
-				return
-			}
-			v, err := cb(goja.Undefined(), vm.ToValue(generic))
-			if err != nil {
-				jsErr = err
-				return
-			}
-			if v != nil && !goja.IsUndefined(v) && !goja.IsNull(v) {
-				out = v.Export()
-			}
+			return cb, ok
 		})
-		if err != nil {
-			return nil, err
-		}
-		if jsErr != nil {
-			return nil, jsErr
-		}
-		return out, nil
 	})
 	return nil
 }
 
-func (r *runner) doDeviceCall(ctx context.Context, identifier, method string, params any) (any, error) {
-	if r.svc.provider == nil {
+// jsOutcome carries an async handler result back to the Go caller.
+type jsOutcome struct {
+	out any
+	err error
+}
+
+// callJSHandler invokes a JS handler as handler(params, respond) on the VM
+// goroutine and waits for its result. Two completion styles are supported:
+//   - synchronous: the handler returns a value (anything but undefined)
+//   - asynchronous: the handler returns undefined and later calls
+//     respond(result, error) — typically from MyHome.call/deviceCall
+//     callbacks. The Go side blocks until respond() or callCtx timeout.
+//
+// lookup resolves the JS callable on the VM goroutine (handler maps are only
+// touched there).
+func (r *runner) callJSHandler(callCtx context.Context, eng *pkgscript.Engine, params any, what string, lookup func() (goja.Callable, bool)) (any, error) {
+	resultCh := make(chan jsOutcome, 1)
+	settle := func(out any, err error) {
+		select {
+		case resultCh <- jsOutcome{out: out, err: err}:
+		default: // already settled (sync return + late respond): keep first
+		}
+	}
+
+	err := eng.Dispatch(callCtx, func(vm *goja.Runtime) {
+		cb, ok := lookup()
+		if !ok {
+			settle(nil, fmt.Errorf("script %s has no handler for %s", r.name, what))
+			return
+		}
+		respond := vm.ToValue(func(call goja.FunctionCall) goja.Value {
+			errArg := call.Argument(1)
+			if !goja.IsUndefined(errArg) && !goja.IsNull(errArg) {
+				settle(nil, fmt.Errorf("script %s %s: %s", r.name, what, errArg.String()))
+			} else {
+				settle(exportValue(call.Argument(0)), nil)
+			}
+			return goja.Undefined()
+		})
+		v, err := cb(goja.Undefined(), toJSValue(vm, params), respond)
+		if err != nil {
+			settle(nil, fmt.Errorf("script %s %s: %w", r.name, what, err))
+			return
+		}
+		if v != nil && !goja.IsUndefined(v) {
+			// Synchronous completion (null is a valid result)
+			settle(exportValue(v), nil)
+		}
+		// undefined: handler completes asynchronously via respond()
+	})
+	if err != nil {
+		return nil, err
+	}
+	select {
+	case res := <-resultCh:
+		return res.out, res.err
+	case <-callCtx.Done():
+		return nil, fmt.Errorf("script %s %s: %w (handler returned undefined and never called respond)", r.name, what, callCtx.Err())
+	}
+}
+
+// exportValue converts a JS value to a generic Go value (nil for null/undefined).
+func exportValue(v goja.Value) any {
+	if v == nil || goja.IsUndefined(v) || goja.IsNull(v) {
+		return nil
+	}
+	return v.Export()
+}
+
+func (s *Service) doDeviceCall(ctx context.Context, identifier, method string, params any) (any, error) {
+	if s.provider == nil {
 		return nil, fmt.Errorf("no device provider on this daemon")
 	}
-	device, err := r.svc.provider.GetDeviceByAny(ctx, identifier)
+	device, err := s.provider.GetDeviceByAny(ctx, identifier)
 	if err != nil {
 		return nil, fmt.Errorf("device %s not found: %w", identifier, err)
 	}
-	sd, err := r.svc.provider.GetShellyDevice(ctx, device)
+	sd, err := s.provider.GetShellyDevice(ctx, device)
 	if err != nil {
 		return nil, fmt.Errorf("shelly device %s: %w", identifier, err)
 	}
 	return sd.CallE(ctx, types.ChannelDefault, method, params)
 }
 
-func (r *runner) doUploadScript(ctx context.Context, identifier, scriptName string) error {
-	if r.svc.provider == nil {
+func (s *Service) doUploadScript(ctx context.Context, identifier, scriptName string) error {
+	if s.provider == nil {
 		return fmt.Errorf("no device provider on this daemon")
 	}
-	device, err := r.svc.provider.GetDeviceByAny(ctx, identifier)
+	device, err := s.provider.GetDeviceByAny(ctx, identifier)
 	if err != nil {
 		return fmt.Errorf("device %s not found: %w", identifier, err)
 	}
-	sd, err := r.svc.provider.GetShellyDevice(ctx, device)
+	sd, err := s.provider.GetShellyDevice(ctx, device)
 	if err != nil {
 		return fmt.Errorf("shelly device %s: %w", identifier, err)
 	}
@@ -208,7 +257,7 @@ func (r *runner) doUploadScript(ctx context.Context, identifier, scriptName stri
 	if err != nil {
 		return fmt.Errorf("embedded script %s: %w", scriptName, err)
 	}
-	_, err = shellyscript.UploadWithVersion(ctx, r.log, types.ChannelDefault, sd, scriptName, buf, true, false)
+	_, err = shellyscript.UploadWithVersion(ctx, s.log, types.ChannelDefault, sd, scriptName, buf, true, false)
 	return err
 }
 

--- a/myhome/scripthost/jsapi.go
+++ b/myhome/scripthost/jsapi.go
@@ -1,0 +1,285 @@
+package scripthost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	shellyscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
+	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
+	"github.com/asnowfix/home-automation/pkg/shelly/types"
+
+	"github.com/dop251/goja"
+)
+
+// installMyHomeAPI adds the MyHome global to a script VM. This is the only
+// API surface daemon scripts have beyond the standard Shelly emulation:
+// workflows live in JS, infrastructure stays behind these Go bindings.
+//
+// Callback convention follows Shelly.call: callback(result, error_code,
+// error_message). All bindings are asynchronous (work runs on Go goroutines,
+// callbacks are dispatched back onto the VM goroutine).
+func (r *runner) installMyHomeAPI(ctx context.Context, vm *goja.Runtime) error {
+	obj := vm.NewObject()
+
+	// MyHome.instance() -> daemon instance name
+	obj.Set("instance", func(call goja.FunctionCall) goja.Value {
+		return vm.ToValue(r.svc.instance)
+	})
+
+	// MyHome.log(...) -> daemon structured log
+	obj.Set("log", func(call goja.FunctionCall) goja.Value {
+		args := make([]interface{}, len(call.Arguments))
+		for i, a := range call.Arguments {
+			args[i] = a.Export()
+		}
+		r.log.Info(fmt.Sprint(args...))
+		return goja.Undefined()
+	})
+
+	// MyHome.on(name, fn) -> handle script.invoke calls addressed to this script
+	obj.Set("on", func(call goja.FunctionCall) goja.Value {
+		name := call.Argument(0).String()
+		fn, ok := goja.AssertFunction(call.Argument(1))
+		if !ok {
+			panic(vm.ToValue("MyHome.on: second argument must be a function"))
+		}
+		r.invokeHandlers[name] = fn
+		r.log.Info("Registered invoke handler", "name", name)
+		return goja.Undefined()
+	})
+
+	// MyHome.call(method, params, callback) -> in-process myhome RPC verb
+	obj.Set("call", func(call goja.FunctionCall) goja.Value {
+		method := call.Argument(0).String()
+		raw := exportJSON(call.Argument(1))
+		callback := callbackOf(call, 2)
+
+		go func() {
+			callCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+			out, err := myhome.CallLocalE(callCtx, myhome.Verb(method), raw)
+			r.deliver(ctx, callback, out, err)
+		}()
+		return goja.Undefined()
+	})
+
+	// MyHome.deviceCall(device, method, params, callback) -> RPC to a Shelly device
+	obj.Set("deviceCall", func(call goja.FunctionCall) goja.Value {
+		identifier := call.Argument(0).String()
+		method := call.Argument(1).String()
+		params := call.Argument(2).Export()
+		callback := callbackOf(call, 3)
+
+		go func() {
+			callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+			defer cancel()
+			out, err := r.doDeviceCall(callCtx, identifier, method, params)
+			r.deliver(ctx, callback, out, err)
+		}()
+		return goja.Undefined()
+	})
+
+	// MyHome.uploadScript(device, scriptName, callback) -> upload + start an
+	// embedded device script (firmware-grade operation, stays in Go)
+	obj.Set("uploadScript", func(call goja.FunctionCall) goja.Value {
+		identifier := call.Argument(0).String()
+		scriptName := call.Argument(1).String()
+		callback := callbackOf(call, 2)
+
+		go func() {
+			callCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+			defer cancel()
+			err := r.doUploadScript(callCtx, identifier, scriptName)
+			r.deliver(ctx, callback, map[string]interface{}{"uploaded": err == nil}, err)
+		}()
+		return goja.Undefined()
+	})
+
+	// MyHome.registerVerb(verb, fn) -> JS implementation of an existing RPC
+	// verb (opt-in workflow replacement, e.g. heater.getconfig)
+	obj.Set("registerVerb", func(call goja.FunctionCall) goja.Value {
+		verb := myhome.Verb(call.Argument(0).String())
+		fn, ok := goja.AssertFunction(call.Argument(1))
+		if !ok {
+			panic(vm.ToValue("MyHome.registerVerb: second argument must be a function"))
+		}
+		r.verbHandlers[verb] = fn
+		if !r.registeredVerbs[verb] {
+			if err := r.registerGoVerb(ctx, verb); err != nil {
+				panic(vm.ToValue(err.Error()))
+			}
+			r.registeredVerbs[verb] = true
+		}
+		r.log.Info("Registered verb handler", "verb", verb)
+		return goja.Undefined()
+	})
+
+	vm.Set("MyHome", obj)
+	return nil
+}
+
+// registerGoVerb wires a myhome RPC verb to the script's JS handler. The Go
+// handler survives engine restarts: it resolves the current engine and JS
+// callable at call time.
+func (r *runner) registerGoVerb(ctx context.Context, verb myhome.Verb) (err error) {
+	defer func() {
+		// RegisterMethodHandler panics on verbs missing from the signatures
+		// map; surface that as a script error instead of killing the daemon.
+		if p := recover(); p != nil {
+			err = fmt.Errorf("MyHome.registerVerb(%s): %v", verb, p)
+		}
+	}()
+	myhome.RegisterMethodHandler(verb, func(callCtx context.Context, in any) (any, error) {
+		eng := r.engine()
+		if eng == nil {
+			return nil, fmt.Errorf("script %s is not running", r.name)
+		}
+		raw, err := json.Marshal(in)
+		if err != nil {
+			return nil, err
+		}
+		var generic any
+		if err := json.Unmarshal(raw, &generic); err != nil {
+			return nil, err
+		}
+
+		callCtx, cancel := context.WithTimeout(callCtx, 30*time.Second)
+		defer cancel()
+
+		var out any
+		var jsErr error
+		err = eng.Dispatch(callCtx, func(vm *goja.Runtime) {
+			cb, ok := r.verbHandlers[verb]
+			if !ok {
+				jsErr = fmt.Errorf("script %s lost handler for %s", r.name, verb)
+				return
+			}
+			v, err := cb(goja.Undefined(), vm.ToValue(generic))
+			if err != nil {
+				jsErr = err
+				return
+			}
+			if v != nil && !goja.IsUndefined(v) && !goja.IsNull(v) {
+				out = v.Export()
+			}
+		})
+		if err != nil {
+			return nil, err
+		}
+		if jsErr != nil {
+			return nil, jsErr
+		}
+		return out, nil
+	})
+	return nil
+}
+
+func (r *runner) doDeviceCall(ctx context.Context, identifier, method string, params any) (any, error) {
+	if r.svc.provider == nil {
+		return nil, fmt.Errorf("no device provider on this daemon")
+	}
+	device, err := r.svc.provider.GetDeviceByAny(ctx, identifier)
+	if err != nil {
+		return nil, fmt.Errorf("device %s not found: %w", identifier, err)
+	}
+	sd, err := r.svc.provider.GetShellyDevice(ctx, device)
+	if err != nil {
+		return nil, fmt.Errorf("shelly device %s: %w", identifier, err)
+	}
+	return sd.CallE(ctx, types.ChannelDefault, method, params)
+}
+
+func (r *runner) doUploadScript(ctx context.Context, identifier, scriptName string) error {
+	if r.svc.provider == nil {
+		return fmt.Errorf("no device provider on this daemon")
+	}
+	device, err := r.svc.provider.GetDeviceByAny(ctx, identifier)
+	if err != nil {
+		return fmt.Errorf("device %s not found: %w", identifier, err)
+	}
+	sd, err := r.svc.provider.GetShellyDevice(ctx, device)
+	if err != nil {
+		return fmt.Errorf("shelly device %s: %w", identifier, err)
+	}
+	buf, err := pkgscript.ReadEmbeddedFile(scriptName)
+	if err != nil {
+		return fmt.Errorf("embedded script %s: %w", scriptName, err)
+	}
+	_, err = shellyscript.UploadWithVersion(ctx, r.log, types.ChannelDefault, sd, scriptName, buf, true, false)
+	return err
+}
+
+// deliver invokes callback(result, error_code, error_message) on the VM
+// goroutine. A nil callback means fire-and-forget.
+func (r *runner) deliver(ctx context.Context, callback goja.Callable, out any, err error) {
+	if callback == nil {
+		if err != nil {
+			r.log.Error(err, "Async call failed (no callback)")
+		}
+		return
+	}
+	eng := r.engine()
+	if eng == nil {
+		return
+	}
+	dispatchErr := eng.DispatchAsync(ctx, func(vm *goja.Runtime) {
+		var ret goja.Value = goja.Null()
+		code := 0
+		msg := goja.Value(goja.Null())
+		if err != nil {
+			code = -1
+			msg = vm.ToValue(err.Error())
+		} else if out != nil {
+			ret = toJSValue(vm, out)
+		}
+		if _, cbErr := callback(goja.Undefined(), ret, vm.ToValue(code), msg); cbErr != nil {
+			r.log.Error(cbErr, "Callback failed")
+		}
+	})
+	if dispatchErr != nil {
+		r.log.Error(dispatchErr, "Failed to dispatch callback")
+	}
+}
+
+// callbackOf extracts an optional callback argument.
+func callbackOf(call goja.FunctionCall, idx int) goja.Callable {
+	if len(call.Arguments) <= idx {
+		return nil
+	}
+	if fn, ok := goja.AssertFunction(call.Argument(idx)); ok {
+		return fn
+	}
+	return nil
+}
+
+// exportJSON converts a JS value into raw JSON (for CallLocalE).
+func exportJSON(v goja.Value) json.RawMessage {
+	if v == nil || goja.IsUndefined(v) || goja.IsNull(v) {
+		return nil
+	}
+	raw, err := json.Marshal(v.Export())
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+// toJSValue converts any Go value to a generic JS value through a JSON
+// round-trip (typed structs become plain objects).
+func toJSValue(vm *goja.Runtime, v any) goja.Value {
+	if v == nil {
+		return goja.Null()
+	}
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return goja.Undefined()
+	}
+	var generic any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return goja.Undefined()
+	}
+	return vm.ToValue(generic)
+}

--- a/myhome/scripthost/occupancy_test.go
+++ b/myhome/scripthost/occupancy_test.go
@@ -1,0 +1,185 @@
+package scripthost
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+// testMqtt is an injectable/recording MQTT client for workflow tests.
+type testMqtt struct {
+	mu        sync.Mutex
+	subs      map[string][]chan []byte
+	published []publishedMsg
+}
+
+type publishedMsg struct {
+	topic    string
+	payload  string
+	retained bool
+}
+
+func newTestMqtt() *testMqtt {
+	return &testMqtt{subs: make(map[string][]chan []byte)}
+}
+
+func (m *testMqtt) GetServer() string { return "mock://localhost:1883" }
+func (m *testMqtt) BrokerUrl() *url.URL {
+	u, _ := url.Parse(m.GetServer())
+	return u
+}
+func (m *testMqtt) Id() string { return "test-mqtt" }
+
+func (m *testMqtt) Subscribe(ctx context.Context, topic string, qlen uint, subscriber string) (<-chan []byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan []byte, qlen)
+	m.subs[topic] = append(m.subs[topic], ch)
+	return ch, nil
+}
+
+func (m *testMqtt) SubscribeWithHandler(ctx context.Context, topic string, qlen uint, subscriber string, handle func(topic string, payload []byte, subscriber string) error) error {
+	return nil
+}
+
+func (m *testMqtt) Publisher(ctx context.Context, topic string, qlen uint, qos byte, retained bool, publisherName string) (chan<- []byte, error) {
+	ch := make(chan []byte, qlen)
+	go func() {
+		for range ch {
+		}
+	}()
+	return ch, nil
+}
+
+func (m *testMqtt) Publish(ctx context.Context, topic string, msg []byte, qos byte, retained bool, publisherName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.published = append(m.published, publishedMsg{topic: topic, payload: string(msg), retained: retained})
+	return nil
+}
+
+// inject delivers a payload to every subscription of the given filter.
+func (m *testMqtt) inject(topic string, payload string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, ch := range m.subs[topic] {
+		ch <- []byte(payload)
+	}
+}
+
+// lastPublished returns the most recent message published on a topic.
+func (m *testMqtt) lastPublished(topic string) (publishedMsg, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := len(m.published) - 1; i >= 0; i-- {
+		if m.published[i].topic == topic {
+			return m.published[i], true
+		}
+	}
+	return publishedMsg{}, false
+}
+
+// TestOccupancyWorkflow runs the real occupancy.js on the script host: an
+// injected Gen2 NotifyStatus input event must yield a retained occupied=true
+// publication and flip the occupancy.getstatus RPC verb.
+// No t.Parallel(): registers handlers in the shared myhome methods map.
+func TestOccupancyWorkflow(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "internal", "shelly", "scripts", "occupancy.js"))
+	if err != nil {
+		t.Fatalf("read occupancy.js: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	log := testr.New(t)
+	ctx = logr.NewContext(ctx, log)
+
+	mc := newTestMqtt()
+	mqtt.ResetClient()
+	mqtt.SetClient(mc)
+	t.Cleanup(mqtt.ResetClient)
+
+	// lan.hosts infrastructure fake (normally registered by the daemon)
+	myhome.RegisterMethodHandler(myhome.LanHosts, func(ctx context.Context, in any) (any, error) {
+		return &myhome.LanHostsResult{Hosts: []myhome.LanHostInfo{}}, nil
+	})
+
+	svc := NewService(log, Config{
+		Enabled:  true,
+		Run:      []string{"occupancy"},
+		StateDir: t.TempDir(),
+	}, fstest.MapFS{"occupancy.js": &fstest.MapFile{Data: src}}, nil, "test-instance")
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// Wait until the script subscribed to device events (i.e. start() ran
+	// after its KVS config loads).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		mc.mu.Lock()
+		n := len(mc.subs["+/events/rpc"])
+		mc.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("occupancy.js never subscribed to +/events/rpc")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// Inject an input state change (button press / motion)
+	mc.inject("+/events/rpc", `{"src":"shellyplus1-aabbcc","method":"NotifyStatus","params":{"input:0":{"id":0,"state":true}}}`)
+
+	// Expect a retained occupied=true publication
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		if msg, ok := mc.lastPublished("myhome/occupancy"); ok {
+			if !msg.retained {
+				t.Errorf("occupancy publication not retained: %+v", msg)
+			}
+			var status struct {
+				Occupied bool   `json:"occupied"`
+				Reason   string `json:"reason"`
+			}
+			if err := json.Unmarshal([]byte(msg.payload), &status); err != nil {
+				t.Fatalf("bad occupancy payload %q: %v", msg.payload, err)
+			}
+			if !status.Occupied {
+				t.Errorf("occupied = false, want true (reason %q)", status.Reason)
+			}
+			if !strings.Contains(status.Reason, "input change") {
+				t.Errorf("reason = %q, want input change", status.Reason)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no occupancy publication observed")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	// The occupancy.getstatus RPC verb (registered from JS) must agree
+	out, err := myhome.CallLocalE(ctx, myhome.OccupancyGetStatus, nil)
+	if err != nil {
+		t.Fatalf("CallLocalE(occupancy.getstatus): %v", err)
+	}
+	m, ok := out.(map[string]any)
+	if !ok || m["occupied"] != true {
+		t.Fatalf("occupancy.getstatus = %v (%T), want occupied=true", out, out)
+	}
+}

--- a/myhome/scripthost/service.go
+++ b/myhome/scripthost/service.go
@@ -8,6 +8,14 @@
 // embedded device-script library — so every device script can assume a script
 // of the same name is also present on the daemon. Devices invoke daemon
 // scripts through the script.invoke RPC verb on the regular myhome/rpc topic.
+//
+// Daemon-hosted scripts deliberately run unconstrained by Shelly device
+// resource limits (5 timers, 5 event/status handlers, 10 MQTT subscriptions,
+// ~30KB heap — see AGENTS.md "Resource Limits"): the whole point of hosting a
+// workflow here instead of on the device is to subcontract memory/CPU-heavy
+// work the device can't do. When script.Engine gains resource-limit
+// emulation (issue #250), engines built by this package must use
+// script.DeviceExtensionMode, never script.DeviceTestMode.
 package scripthost
 
 import (

--- a/myhome/scripthost/service.go
+++ b/myhome/scripthost/service.go
@@ -53,13 +53,18 @@ type Service struct {
 
 	mu      sync.RWMutex
 	runners map[string]*runner // key: script name without .js
+
+	// deviceCall / uploadScript back MyHome.deviceCall and
+	// MyHome.uploadScript; overridable for tests (see WithDeviceCaller).
+	deviceCall   func(ctx context.Context, identifier, method string, params any) (any, error)
+	uploadScript func(ctx context.Context, identifier, scriptName string) error
 }
 
 func NewService(log logr.Logger, cfg Config, embedded fs.FS, provider DeviceProvider, instance string) *Service {
 	if cfg.StateDir == "" {
 		cfg.StateDir = "scripts-state"
 	}
-	return &Service{
+	s := &Service{
 		log:      log.WithName("scripthost"),
 		cfg:      cfg,
 		embedded: embedded,
@@ -67,6 +72,23 @@ func NewService(log logr.Logger, cfg Config, embedded fs.FS, provider DeviceProv
 		instance: instance,
 		runners:  make(map[string]*runner),
 	}
+	s.deviceCall = s.doDeviceCall
+	s.uploadScript = s.doUploadScript
+	return s
+}
+
+// WithDeviceCaller overrides the device RPC backends (tests).
+func (s *Service) WithDeviceCaller(
+	deviceCall func(ctx context.Context, identifier, method string, params any) (any, error),
+	uploadScript func(ctx context.Context, identifier, scriptName string) error,
+) *Service {
+	if deviceCall != nil {
+		s.deviceCall = deviceCall
+	}
+	if uploadScript != nil {
+		s.uploadScript = uploadScript
+	}
+	return s
 }
 
 // Start launches every configured script and registers the script.invoke RPC
@@ -133,28 +155,12 @@ func (s *Service) Invoke(ctx context.Context, scriptName, name string, params an
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	var out any
-	var jsErr error
-	err := eng.Dispatch(ctx, func(vm *goja.Runtime) {
+	out, err := r.callJSHandler(ctx, eng, params, fmt.Sprintf("handler %q (MyHome.on)", name), func() (goja.Callable, bool) {
 		cb, ok := r.invokeHandlers[name]
-		if !ok {
-			jsErr = fmt.Errorf("script %s has no handler %q (MyHome.on)", scriptName, name)
-			return
-		}
-		v, err := cb(goja.Undefined(), toJSValue(vm, params))
-		if err != nil {
-			jsErr = fmt.Errorf("script %s handler %q: %w", scriptName, name, err)
-			return
-		}
-		if v != nil && !goja.IsUndefined(v) && !goja.IsNull(v) {
-			out = v.Export()
-		}
+		return cb, ok
 	})
 	if err != nil {
 		return nil, err
-	}
-	if jsErr != nil {
-		return nil, jsErr
 	}
 	return &myhome.ScriptInvokeResult{Result: out}, nil
 }

--- a/myhome/scripthost/service.go
+++ b/myhome/scripthost/service.go
@@ -1,0 +1,291 @@
+// Package scripthost runs MyHome workflow scripts (JavaScript) on the daemon,
+// using the same goja-based Shelly runtime as the CLI emulator
+// (pkg/shelly/script). Workflows are written in JS; communication,
+// persistence and infrastructure stay in Go and are exposed to scripts
+// through the MyHome global (see jsapi.go).
+//
+// Scripts are resolved by name: an optional user directory first, then the
+// embedded device-script library — so every device script can assume a script
+// of the same name is also present on the daemon. Devices invoke daemon
+// scripts through the script.invoke RPC verb on the regular myhome/rpc topic.
+package scripthost
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/pkg/shelly"
+	"github.com/asnowfix/home-automation/pkg/shelly/script"
+
+	"github.com/dop251/goja"
+	"github.com/go-logr/logr"
+)
+
+// Config configures the daemon script host (config keys daemon.scripts.*).
+type Config struct {
+	Enabled  bool     // daemon.scripts.enabled
+	Dir      string   // daemon.scripts.dir — optional user scripts dir, overrides embedded scripts
+	Run      []string // daemon.scripts.run — script names to run (with or without .js)
+	StateDir string   // daemon.scripts.state_dir — per-script KVS/storage JSON files (default "scripts-state")
+}
+
+// DeviceProvider gives scripts access to managed devices (implemented by
+// devices/impl.DeviceManager). Same contract as the Go heater service.
+type DeviceProvider interface {
+	GetDeviceByAny(ctx context.Context, identifier string) (*myhome.Device, error)
+	GetShellyDevice(ctx context.Context, device *myhome.Device) (*shelly.Device, error)
+}
+
+// Service hosts one engine per configured script and serves script.invoke.
+type Service struct {
+	log      logr.Logger
+	cfg      Config
+	embedded fs.FS
+	provider DeviceProvider
+	instance string
+
+	mu      sync.RWMutex
+	runners map[string]*runner // key: script name without .js
+}
+
+func NewService(log logr.Logger, cfg Config, embedded fs.FS, provider DeviceProvider, instance string) *Service {
+	if cfg.StateDir == "" {
+		cfg.StateDir = "scripts-state"
+	}
+	return &Service{
+		log:      log.WithName("scripthost"),
+		cfg:      cfg,
+		embedded: embedded,
+		provider: provider,
+		instance: instance,
+		runners:  make(map[string]*runner),
+	}
+}
+
+// Start launches every configured script and registers the script.invoke RPC
+// handler. Non-blocking: each script runs on its own goroutine until ctx ends.
+func (s *Service) Start(ctx context.Context) error {
+	if err := os.MkdirAll(s.cfg.StateDir, 0o755); err != nil {
+		return fmt.Errorf("scripts state dir %s: %w", s.cfg.StateDir, err)
+	}
+
+	for _, name := range s.cfg.Run {
+		name = normalizeName(name)
+		if _, dup := s.runners[name]; dup {
+			s.log.Info("Ignoring duplicate script", "script", name)
+			continue
+		}
+		r := &runner{
+			name: name,
+			svc:  s,
+			log:  s.log.WithValues("script", name),
+		}
+		s.mu.Lock()
+		s.runners[name] = r
+		s.mu.Unlock()
+		go r.run(ctx)
+	}
+
+	myhome.RegisterMethodHandler(myhome.ScriptInvoke, func(ctx context.Context, in any) (any, error) {
+		params, ok := in.(*myhome.ScriptInvokeParams)
+		if !ok {
+			return nil, fmt.Errorf("unexpected param type: %T", in)
+		}
+		return s.Invoke(ctx, params.Script, params.Name, params.Params)
+	})
+
+	s.log.Info("Script host started", "scripts", s.cfg.Run, "state_dir", s.cfg.StateDir)
+	return nil
+}
+
+// Runs reports whether the given script is configured to run on this host
+// (used by the daemon to substitute Go workflows with their JS versions).
+func (s *Service) Runs(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.runners[normalizeName(name)]
+	return ok
+}
+
+// Invoke calls a handler registered with MyHome.on(name, fn) in the given
+// script, passing params (generic JSON values) and returning the handler's
+// return value. It is the backend of the script.invoke RPC verb.
+func (s *Service) Invoke(ctx context.Context, scriptName, name string, params any) (*myhome.ScriptInvokeResult, error) {
+	s.mu.RLock()
+	r := s.runners[normalizeName(scriptName)]
+	s.mu.RUnlock()
+	if r == nil {
+		return nil, fmt.Errorf("script %s is not hosted here (instance %s)", scriptName, s.instance)
+	}
+
+	eng := r.engine()
+	if eng == nil {
+		return nil, fmt.Errorf("script %s is not running", scriptName)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var out any
+	var jsErr error
+	err := eng.Dispatch(ctx, func(vm *goja.Runtime) {
+		cb, ok := r.invokeHandlers[name]
+		if !ok {
+			jsErr = fmt.Errorf("script %s has no handler %q (MyHome.on)", scriptName, name)
+			return
+		}
+		v, err := cb(goja.Undefined(), toJSValue(vm, params))
+		if err != nil {
+			jsErr = fmt.Errorf("script %s handler %q: %w", scriptName, name, err)
+			return
+		}
+		if v != nil && !goja.IsUndefined(v) && !goja.IsNull(v) {
+			out = v.Export()
+		}
+	})
+	if err != nil {
+		return nil, err
+	}
+	if jsErr != nil {
+		return nil, jsErr
+	}
+	return &myhome.ScriptInvokeResult{Result: out}, nil
+}
+
+// runner manages the lifecycle of one script: load, engine build, restart
+// with backoff on crash.
+type runner struct {
+	name string
+	svc  *Service
+	log  logr.Logger
+
+	mu  sync.RWMutex
+	eng *script.Engine
+
+	// Handler maps are written during script evaluation and read by
+	// Dispatch callbacks: both happen on the VM goroutine, so no lock.
+	invokeHandlers map[string]goja.Callable
+	verbHandlers   map[myhome.Verb]goja.Callable
+	// registeredVerbs survives engine restarts: re-registration only swaps
+	// the JS callable, not the Go-side method handler.
+	registeredVerbs map[myhome.Verb]bool
+}
+
+func (r *runner) engine() *script.Engine {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.eng
+}
+
+func (r *runner) run(ctx context.Context) {
+	backoff := time.Second
+	for {
+		started := time.Now()
+		err := r.runOnce(ctx)
+		if ctx.Err() != nil {
+			r.log.Info("Script stopped", "reason", ctx.Err())
+			return
+		}
+		if err != nil {
+			r.log.Error(err, "Script crashed, restarting", "backoff", backoff)
+		} else {
+			r.log.Info("Script exited, restarting", "backoff", backoff)
+		}
+		if time.Since(started) > 5*time.Minute {
+			backoff = time.Second // stable run: reset backoff
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff < time.Minute {
+			backoff *= 2
+		}
+	}
+}
+
+func (r *runner) runOnce(ctx context.Context) error {
+	file, src, err := r.svc.load(r.name)
+	if err != nil {
+		return err
+	}
+
+	stateFile := filepath.Join(r.svc.cfg.StateDir, r.name+".json")
+	state, err := script.LoadDeviceState(r.log, stateFile)
+	if err != nil {
+		return err
+	}
+	state.OnModified = func() {
+		if err := script.SaveDeviceState(r.log, stateFile, state); err != nil {
+			r.log.Error(err, "Failed to save script state", "file", stateFile)
+		}
+	}
+
+	// Fresh handler maps for the fresh VM
+	r.invokeHandlers = make(map[string]goja.Callable)
+	r.verbHandlers = make(map[myhome.Verb]goja.Callable)
+	if r.registeredVerbs == nil {
+		r.registeredVerbs = make(map[myhome.Verb]bool)
+	}
+
+	ctx = logr.NewContext(ctx, r.log)
+	eng, err := script.NewEngine(ctx, file, src, script.EngineOptions{
+		State:               state,
+		EnableExternalCalls: true,
+		Customize: func(vm *goja.Runtime) error {
+			return r.installMyHomeAPI(ctx, vm)
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.eng = eng
+	r.mu.Unlock()
+	defer func() {
+		r.mu.Lock()
+		r.eng = nil
+		r.mu.Unlock()
+		// Persist final state on shutdown
+		if err := script.SaveDeviceState(r.log, stateFile, state); err != nil {
+			r.log.Error(err, "Failed to save script state at exit", "file", stateFile)
+		}
+	}()
+
+	err = eng.Start(ctx)
+	if err == context.Canceled {
+		return nil
+	}
+	return err
+}
+
+// load resolves a script by name: user dir first, then embedded library.
+func (s *Service) load(name string) (string, []byte, error) {
+	file := name + ".js"
+	if s.cfg.Dir != "" {
+		p := filepath.Join(s.cfg.Dir, file)
+		if data, err := os.ReadFile(p); err == nil {
+			s.log.Info("Loaded script from user dir", "script", file, "path", p)
+			return file, data, nil
+		}
+	}
+	if s.embedded != nil {
+		if data, err := fs.ReadFile(s.embedded, file); err == nil {
+			return file, data, nil
+		}
+	}
+	return "", nil, fmt.Errorf("script %s not found (dir=%q, embedded library)", file, s.cfg.Dir)
+}
+
+func normalizeName(name string) string {
+	return strings.TrimSuffix(name, ".js")
+}

--- a/myhome/scripthost/service_test.go
+++ b/myhome/scripthost/service_test.go
@@ -3,6 +3,8 @@ package scripthost
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -139,6 +141,32 @@ func TestRegisterVerb(t *testing.T) {
 	}
 	if m["device_id"] != "dev1" || m["device_name"] != "js" {
 		t.Fatalf("unexpected result: %v", m)
+	}
+}
+
+// TestMyHomeLinkDaemonMode runs the real myhome-link.js (dual-mode script) on
+// the host and exercises its daemon-side ping handler — the same handler that
+// devices reach via script.invoke.
+func TestMyHomeLinkDaemonMode(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("..", "..", "internal", "shelly", "scripts", "myhome-link.js"))
+	if err != nil {
+		t.Fatalf("read myhome-link.js: %v", err)
+	}
+	scripts := fstest.MapFS{
+		"myhome-link.js": &fstest.MapFile{Data: src},
+	}
+	ctx, svc := newTestService(t, scripts, []string{"myhome-link"})
+
+	res := invokeEventually(t, ctx, svc, "myhome-link", "ping", map[string]any{"from": "test"})
+	m, ok := res.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected result type: %T (%v)", res.Result, res.Result)
+	}
+	if m["pong"] != true {
+		t.Errorf("pong = %v, want true", m["pong"])
+	}
+	if m["instance"] != "test-instance" {
+		t.Errorf("instance = %v, want test-instance", m["instance"])
 	}
 }
 

--- a/myhome/scripthost/service_test.go
+++ b/myhome/scripthost/service_test.go
@@ -1,0 +1,150 @@
+package scripthost
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+// newTestService starts a script host with the given embedded scripts.
+// Tests must NOT call t.Parallel(): the host registers RPC method handlers in
+// the shared package-level myhome methods map.
+func newTestService(t *testing.T, scripts fstest.MapFS, run []string) (context.Context, *Service) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	log := testr.New(t)
+	ctx = logr.NewContext(ctx, log)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	svc := NewService(log, Config{
+		Enabled:  true,
+		Run:      run,
+		StateDir: t.TempDir(),
+	}, scripts, nil, "test-instance")
+
+	if err := svc.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	return ctx, svc
+}
+
+// invokeEventually retries script.invoke until the script engine is up.
+func invokeEventually(t *testing.T, ctx context.Context, svc *Service, script, name string, params any) *myhome.ScriptInvokeResult {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		res, err := svc.Invoke(ctx, script, name, params)
+		if err == nil {
+			return res
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("Invoke(%s, %s) never succeeded: %v", script, name, lastErr)
+	return nil
+}
+
+func TestInvokeHandler(t *testing.T) {
+	scripts := fstest.MapFS{
+		"hello.js": &fstest.MapFile{Data: []byte(`
+			var count = 0;
+			MyHome.on("ping", function(params) {
+				count++;
+				return { pong: params.value, count: count, instance: MyHome.instance() };
+			});
+		`)},
+	}
+	ctx, svc := newTestService(t, scripts, []string{"hello"})
+
+	res := invokeEventually(t, ctx, svc, "hello", "ping", map[string]any{"value": 42.0})
+	m, ok := res.Result.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected result type: %T (%v)", res.Result, res.Result)
+	}
+	if m["pong"] != int64(42) && m["pong"] != 42.0 {
+		t.Errorf("pong = %v (%T), want 42", m["pong"], m["pong"])
+	}
+	if m["instance"] != "test-instance" {
+		t.Errorf("instance = %v, want test-instance", m["instance"])
+	}
+
+	// Second invocation: same VM, state preserved
+	res = invokeEventually(t, ctx, svc, "hello", "ping", map[string]any{"value": 1.0})
+	m = res.Result.(map[string]any)
+	if m["count"] != int64(2) && m["count"] != 2.0 {
+		t.Errorf("count = %v, want 2", m["count"])
+	}
+}
+
+func TestInvokeViaRPCDispatch(t *testing.T) {
+	scripts := fstest.MapFS{
+		"echo.js": &fstest.MapFile{Data: []byte(`
+			MyHome.on("echo", function(params) { return params; });
+		`)},
+	}
+	ctx, svc := newTestService(t, scripts, []string{"echo.js"})
+
+	// Wait for the engine, then go through the same path as a device request:
+	// CallLocalE decodes raw JSON per the script.invoke signature.
+	invokeEventually(t, ctx, svc, "echo", "echo", nil)
+
+	raw := json.RawMessage(`{"script":"echo","name":"echo","params":{"a":"b"}}`)
+	out, err := myhome.CallLocalE(ctx, myhome.ScriptInvoke, raw)
+	if err != nil {
+		t.Fatalf("CallLocalE: %v", err)
+	}
+	res, ok := out.(*myhome.ScriptInvokeResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", out)
+	}
+	m, ok := res.Result.(map[string]any)
+	if !ok || m["a"] != "b" {
+		t.Fatalf("echo result = %v, want {a:b}", res.Result)
+	}
+}
+
+func TestRegisterVerb(t *testing.T) {
+	scripts := fstest.MapFS{
+		"verbs.js": &fstest.MapFile{Data: []byte(`
+			MyHome.registerVerb("heater.getconfig", function(params) {
+				return { device_id: params.identifier, device_name: "js", has_script: false };
+			});
+			MyHome.on("ready", function() { return true; });
+		`)},
+	}
+	ctx, svc := newTestService(t, scripts, []string{"verbs"})
+	invokeEventually(t, ctx, svc, "verbs", "ready", nil)
+
+	out, err := myhome.CallLocalE(ctx, myhome.HeaterGetConfig, json.RawMessage(`{"identifier":"dev1"}`))
+	if err != nil {
+		t.Fatalf("CallLocalE(heater.getconfig): %v", err)
+	}
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected result type: %T (%v)", out, out)
+	}
+	if m["device_id"] != "dev1" || m["device_name"] != "js" {
+		t.Fatalf("unexpected result: %v", m)
+	}
+}
+
+func TestInvokeUnknownScript(t *testing.T) {
+	ctx, svc := newTestService(t, fstest.MapFS{}, nil)
+	if _, err := svc.Invoke(ctx, "ghost", "x", nil); err == nil {
+		t.Fatal("expected error for unknown script")
+	}
+}

--- a/pkg/shelly/script/aes.go
+++ b/pkg/shelly/script/aes.go
@@ -1,0 +1,118 @@
+package script
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+const aesDefaultMode = "CBC"
+
+// installAES adds the AES global (AES.encrypt/AES.decrypt):
+// https://shelly-api-docs.shelly.cloud/gen2/Scripts/APIs/AES
+//
+// The documented API takes no IV (initialization vector) parameter, so —
+// matching the real device — encryption/decryption uses an all-zero IV.
+// This mirrors the Gen3/4 scripting API as documented, not a general-purpose
+// crypto primitive: don't reuse this construction where IV reuse matters.
+func installAES(vm *goja.Runtime) {
+	aesObj := vm.NewObject()
+	aesObj.Set("encrypt", func(call goja.FunctionCall) goja.Value {
+		return aesTransform(vm, call, true)
+	})
+	aesObj.Set("decrypt", func(call goja.FunctionCall) goja.Value {
+		return aesTransform(vm, call, false)
+	})
+	vm.Set("AES", aesObj)
+}
+
+func aesTransform(vm *goja.Runtime, call goja.FunctionCall, encrypt bool) goja.Value {
+	data, err := exportArrayBufferBytes(call.Argument(0))
+	if err != nil {
+		panic(vm.ToValue(fmt.Sprintf("AES: data argument: %v", err)))
+	}
+	key, err := exportArrayBufferBytes(call.Argument(1))
+	if err != nil {
+		panic(vm.ToValue(fmt.Sprintf("AES: key argument: %v", err)))
+	}
+	mode := aesDefaultMode
+	if len(call.Arguments) > 2 && !goja.IsUndefined(call.Argument(2)) {
+		mode = call.Argument(2).String()
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(vm.ToValue(fmt.Sprintf("AES: %v", err)))
+	}
+
+	out, err := aesCrypt(block, mode, data, encrypt)
+	if err != nil {
+		panic(vm.ToValue(fmt.Sprintf("AES: %v", err)))
+	}
+	return vm.ToValue(vm.NewArrayBuffer(out))
+}
+
+// aesCrypt runs one AES transform. iv is always zero (see installAES doc).
+func aesCrypt(block cipher.Block, mode string, data []byte, encrypt bool) ([]byte, error) {
+	iv := make([]byte, aes.BlockSize)
+
+	switch mode {
+	case "CBC":
+		if len(data)%aes.BlockSize != 0 {
+			return nil, fmt.Errorf("CBC: input length %d is not a multiple of the block size (%d)", len(data), aes.BlockSize)
+		}
+		out := make([]byte, len(data))
+		if encrypt {
+			cipher.NewCBCEncrypter(block, iv).CryptBlocks(out, data)
+		} else {
+			cipher.NewCBCDecrypter(block, iv).CryptBlocks(out, data)
+		}
+		return out, nil
+	case "CFB":
+		out := make([]byte, len(data))
+		if encrypt {
+			cipher.NewCFBEncrypter(block, iv).XORKeyStream(out, data) //nolint:staticcheck // CFB is part of the documented Shelly API surface
+		} else {
+			cipher.NewCFBDecrypter(block, iv).XORKeyStream(out, data) //nolint:staticcheck
+		}
+		return out, nil
+	case "OFB":
+		out := make([]byte, len(data))
+		cipher.NewOFB(block, iv).XORKeyStream(out, data) //nolint:staticcheck // OFB is part of the documented Shelly API surface
+		return out, nil
+	case "CTR":
+		out := make([]byte, len(data))
+		cipher.NewCTR(block, iv).XORKeyStream(out, data)
+		return out, nil
+	case "ECB":
+		// crypto/cipher deliberately omits ECB (insecure for general use),
+		// so each block is run through the raw cipher.Block directly. ECB
+		// is part of the documented Shelly API surface, so it's emulated
+		// here despite that.
+		if len(data)%aes.BlockSize != 0 {
+			return nil, fmt.Errorf("ECB: input length %d is not a multiple of the block size (%d)", len(data), aes.BlockSize)
+		}
+		out := make([]byte, len(data))
+		for i := 0; i < len(data); i += aes.BlockSize {
+			if encrypt {
+				block.Encrypt(out[i:i+aes.BlockSize], data[i:i+aes.BlockSize])
+			} else {
+				block.Decrypt(out[i:i+aes.BlockSize], data[i:i+aes.BlockSize])
+			}
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported mode %q (want CBC, CFB, CTR, OFB, or ECB)", mode)
+	}
+}
+
+func exportArrayBufferBytes(v goja.Value) ([]byte, error) {
+	exported := v.Export()
+	ab, ok := exported.(goja.ArrayBuffer)
+	if !ok {
+		return nil, fmt.Errorf("expected ArrayBuffer, got %T", exported)
+	}
+	return ab.Bytes(), nil
+}

--- a/pkg/shelly/script/aes_test.go
+++ b/pkg/shelly/script/aes_test.go
@@ -1,0 +1,121 @@
+package script
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func newAESTestVM(t *testing.T) *goja.Runtime {
+	t.Helper()
+	vm := goja.New()
+	installAES(vm)
+	return vm
+}
+
+// TestAESECBKnownVector checks against the FIPS-197 AES-128 known-answer
+// test vector. ECB needs no IV, so it's the one mode that lets us verify the
+// underlying cipher against a published vector rather than only round-trips.
+func TestAESECBKnownVector(t *testing.T) {
+	vm := newAESTestVM(t)
+	vm.Set("hexToBuf", func(call goja.FunctionCall) goja.Value {
+		b, err := hex.DecodeString(call.Argument(0).String())
+		if err != nil {
+			panic(vm.ToValue(err.Error()))
+		}
+		return vm.ToValue(vm.NewArrayBuffer(b))
+	})
+	vm.Set("bufToHex", func(call goja.FunctionCall) goja.Value {
+		ab, _ := call.Argument(0).Export().(goja.ArrayBuffer)
+		return vm.ToValue(hex.EncodeToString(ab.Bytes()))
+	})
+
+	result, err := vm.RunString(`
+		var key = hexToBuf("000102030405060708090a0b0c0d0e0f");
+		var plain = hexToBuf("00112233445566778899aabbccddeeff");
+		bufToHex(AES.encrypt(plain, key, "ECB"));
+	`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	want := "69c4e0d86a7b0430d8cdb78070b4c55a"
+	if got := result.String(); got != want {
+		t.Errorf("AES-128-ECB(known vector) = %s, want %s", got, want)
+	}
+}
+
+func TestAESRoundTripPerMode(t *testing.T) {
+	modes := []string{"CBC", "CFB", "CTR", "OFB", "ECB"}
+	for _, mode := range modes {
+		t.Run(mode, func(t *testing.T) {
+			vm := newAESTestVM(t)
+			vm.Set("mode", mode)
+			result, err := vm.RunString(`
+				var key = new Uint8Array(16);
+				for (var i = 0; i < 16; i++) key[i] = i;
+				var plain = new Uint8Array(32); // 2 blocks: also exercises block modes
+				for (var i = 0; i < 32; i++) plain[i] = 100 + i;
+				var cipherText = AES.encrypt(plain.buffer, key.buffer, mode);
+				var decrypted = new Uint8Array(AES.decrypt(cipherText, key.buffer, mode));
+				var ok = decrypted.length === plain.length;
+				if (ok) {
+					for (var i = 0; i < plain.length; i++) {
+						if (decrypted[i] !== plain[i]) { ok = false; break; }
+					}
+				}
+				ok;
+			`)
+			if err != nil {
+				t.Fatalf("RunString: %v", err)
+			}
+			if !result.ToBoolean() {
+				t.Errorf("%s: decrypt(encrypt(plain)) != plain", mode)
+			}
+		})
+	}
+}
+
+func TestAESCBCRejectsUnalignedLength(t *testing.T) {
+	vm := newAESTestVM(t)
+	result, err := vm.RunString(`
+		(function() {
+			try {
+				var key = new Uint8Array(16);
+				var plain = new Uint8Array(5); // not a multiple of 16
+				AES.encrypt(plain.buffer, key.buffer, "CBC");
+				return "no error thrown";
+			} catch (e) {
+				return String(e);
+			}
+		})();
+	`)
+	if err != nil {
+		t.Fatalf("RunString returned a Go error (exception escaped the VM): %v", err)
+	}
+	if result.String() == "no error thrown" {
+		t.Error("CBC accepted a non-block-aligned length, want a thrown exception")
+	}
+}
+
+func TestAESUnsupportedModeThrows(t *testing.T) {
+	vm := newAESTestVM(t)
+	result, err := vm.RunString(`
+		(function() {
+			try {
+				var key = new Uint8Array(16);
+				var plain = new Uint8Array(16);
+				AES.encrypt(plain.buffer, key.buffer, "GCM");
+				return "no error thrown";
+			} catch (e) {
+				return String(e);
+			}
+		})();
+	`)
+	if err != nil {
+		t.Fatalf("RunString returned a Go error (exception escaped the VM): %v", err)
+	}
+	if result.String() == "no error thrown" {
+		t.Error("unsupported mode was accepted, want a thrown exception")
+	}
+}

--- a/pkg/shelly/script/device_state.go
+++ b/pkg/shelly/script/device_state.go
@@ -23,6 +23,13 @@ type DeviceState struct {
 	// Populated by tests or loaded from a device snapshot (see FetchDeviceState).
 	ComponentStatus map[string]interface{} `json:"component_status,omitempty"`
 
+	// Virtual backs Virtual.getHandle(key): real devices only expose handles
+	// for components pre-configured through the device UI/config, never
+	// created by scripts — so this is populated by tests or a device
+	// snapshot, the same way as ComponentStatus, keyed by "<kind>:<id>"
+	// (e.g. "number:200").
+	Virtual map[string]*VirtualComponentState `json:"virtual,omitempty"`
+
 	// EventInjector, when non-nil, allows a test to push raw JSON-encoded
 	// device-event objects into the running script's event-handler loop.
 	// Send a JSON object with the same shape as Shelly device events:
@@ -102,6 +109,9 @@ func LoadDeviceState(log logr.Logger, filename string) (*DeviceState, error) {
 	}
 	if state.ComponentStatus == nil {
 		state.ComponentStatus = make(map[string]interface{})
+	}
+	if state.Virtual == nil {
+		state.Virtual = make(map[string]*VirtualComponentState)
 	}
 
 	log.Info("Loaded device state", "file", filename, "kvs_keys", len(state.KVS), "storage_keys", len(state.Storage))

--- a/pkg/shelly/script/engine.go
+++ b/pkg/shelly/script/engine.go
@@ -1,0 +1,197 @@
+package script
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+
+	"github.com/dop251/goja"
+	"github.com/go-logr/logr"
+)
+
+// EngineOptions configures a script Engine beyond the plain device emulation
+// provided by Run().
+type EngineOptions struct {
+	// State is the persistent KVS/Script.storage backing store. When nil, an
+	// empty in-memory state is used.
+	State *DeviceState
+
+	// Customize, when non-nil, is called after the Shelly runtime globals are
+	// installed and before the script is evaluated. It lets hosts add extra
+	// globals (e.g. the daemon's MyHome API).
+	Customize func(vm *goja.Runtime) error
+
+	// EnableExternalCalls keeps the event loop alive even when the script
+	// registers no timer/MQTT handlers, so that Dispatch() can be served.
+	// Daemon-hosted scripts set this; the CLI emulator does not.
+	EnableExternalCalls bool
+}
+
+// Engine runs one script in one goja VM. The VM is single-threaded: the
+// goroutine that calls Start() owns it, and all external entry points must go
+// through the event loop via Dispatch()/DispatchAsync().
+type Engine struct {
+	name     string
+	source   []byte
+	vm       *goja.Runtime
+	handlers []handler
+	state    *DeviceState
+	external *externalHandler
+	log      logr.Logger
+}
+
+// NewEngine builds the goja VM with the Shelly runtime globals (Timer, MQTT,
+// Shelly, Script.storage, KVS-backed Shelly.call methods…) but does not
+// evaluate the script yet: Start() does, on the goroutine that will own the VM.
+func NewEngine(ctx context.Context, name string, source []byte, opts EngineOptions) (*Engine, error) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	log = log.WithName("script.engine").WithValues("script", name)
+
+	mc := mqtt.GetClient(ctx)
+	if mc == nil {
+		return nil, fmt.Errorf("MQTT client not initialized")
+	}
+
+	state := opts.State
+	if state == nil {
+		state = &DeviceState{
+			KVS:     make(map[string]interface{}),
+			Storage: make(map[string]interface{}),
+		}
+	}
+
+	e := &Engine{
+		name:     name,
+		source:   source,
+		state:    state,
+		handlers: make([]handler, 0),
+		log:      log,
+	}
+
+	vm, err := createShellyRuntime(ctx, mc, &e.handlers, state)
+	if err != nil {
+		return nil, err
+	}
+	e.vm = vm
+
+	if opts.Customize != nil {
+		if err := opts.Customize(vm); err != nil {
+			return nil, fmt.Errorf("customize %s: %w", name, err)
+		}
+	}
+
+	if opts.EnableExternalCalls {
+		e.external = newExternalHandler()
+		e.handlers = append(e.handlers, e.external)
+	}
+
+	return e, nil
+}
+
+// Name returns the script name this engine runs.
+func (e *Engine) Name() string { return e.name }
+
+// State returns the engine's backing device state (KVS + Script.storage).
+func (e *Engine) State() *DeviceState { return e.state }
+
+// Start evaluates the script then runs the event loop until the context is
+// cancelled (or, without EnableExternalCalls, until all handlers are closed).
+// It blocks: run it on a dedicated goroutine, which becomes the VM owner.
+func (e *Engine) Start(ctx context.Context) error {
+	out, err := e.vm.RunScript(e.name, string(e.source))
+	if err != nil {
+		e.log.Error(err, "Script evaluation failed")
+		return err
+	}
+	e.log.Info("Script evaluated", "out", out)
+
+	if len(e.handlers) == 0 {
+		e.log.Info("No handlers registered, exiting")
+		return nil
+	}
+
+	return runEventLoop(logr.NewContext(ctx, e.log), e.vm, &e.handlers)
+}
+
+// Dispatch runs fn on the VM goroutine and waits for it to complete. It is
+// the only safe way to touch the VM from outside the event loop. Never call
+// it from script code (i.e. from within the VM goroutine): that deadlocks.
+func (e *Engine) Dispatch(ctx context.Context, fn func(vm *goja.Runtime)) error {
+	if e.external == nil {
+		return fmt.Errorf("engine %s was created without EnableExternalCalls", e.name)
+	}
+	call := &externalCall{fn: fn, done: make(chan struct{})}
+	if err := e.external.enqueue(ctx, call); err != nil {
+		return err
+	}
+	select {
+	case <-call.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// DispatchAsync queues fn for execution on the VM goroutine without waiting.
+// Safe to call from anywhere, including goroutines spawned by script APIs.
+func (e *Engine) DispatchAsync(ctx context.Context, fn func(vm *goja.Runtime)) error {
+	if e.external == nil {
+		return fmt.Errorf("engine %s was created without EnableExternalCalls", e.name)
+	}
+	return e.external.enqueue(ctx, &externalCall{fn: fn})
+}
+
+// externalCall is a function to execute on the VM goroutine. done, when
+// non-nil, is closed after execution.
+type externalCall struct {
+	fn   func(vm *goja.Runtime)
+	done chan struct{}
+}
+
+// externalHandler funnels externally-submitted calls into the event loop. It
+// satisfies the handler interface: each queued call is signalled on the Wait()
+// channel and executed by Handle() on the VM goroutine.
+type externalHandler struct {
+	signal chan []byte
+	queue  chan *externalCall
+}
+
+func newExternalHandler() *externalHandler {
+	return &externalHandler{
+		signal: make(chan []byte, 64),
+		queue:  make(chan *externalCall, 64),
+	}
+}
+
+func (h *externalHandler) enqueue(ctx context.Context, call *externalCall) error {
+	select {
+	case h.queue <- call:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case h.signal <- []byte{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}
+
+func (h *externalHandler) Wait() <-chan []byte { return h.signal }
+
+func (h *externalHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byte) error {
+	select {
+	case call := <-h.queue:
+		call.fn(vm)
+		if call.done != nil {
+			close(call.done)
+		}
+	default:
+		// Signal without a queued call (should not happen): ignore.
+	}
+	return nil
+}

--- a/pkg/shelly/script/engine.go
+++ b/pkg/shelly/script/engine.go
@@ -26,6 +26,12 @@ type EngineOptions struct {
 	// registers no timer/MQTT handlers, so that Dispatch() can be served.
 	// Daemon-hosted scripts set this; the CLI emulator does not.
 	EnableExternalCalls bool
+
+	// TODO(#250): add a Mode field (DeviceTestMode | DeviceExtensionMode) once
+	// resource-limit emulation lands. myhome/scripthost must construct its
+	// engines with DeviceExtensionMode (unlimited) — daemon-hosted scripts
+	// exist precisely to subcontract work that exceeds real device limits.
+	// Device-bound script tests must default to DeviceTestMode (enforced).
 }
 
 // Engine runs one script in one goja VM. The VM is single-threaded: the

--- a/pkg/shelly/script/engine_test.go
+++ b/pkg/shelly/script/engine_test.go
@@ -1,0 +1,108 @@
+package script
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+
+	"github.com/dop251/goja"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+// TestEngineDispatch verifies that a host can call into a running script
+// through Dispatch(): the script registers a global function, and the host
+// invokes it from another goroutine.
+func TestEngineDispatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ctx = logr.NewContext(ctx, testr.New(t))
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	src := `
+		var calls = 0;
+		function greet(name) {
+			calls++;
+			return "hello " + name + " #" + calls;
+		}
+	`
+
+	eng, err := NewEngine(ctx, "engine_test.js", []byte(src), EngineOptions{
+		EnableExternalCalls: true,
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eng.Start(ctx)
+	}()
+
+	results := make([]string, 0, 2)
+	for i := 0; i < 2; i++ {
+		err := eng.Dispatch(ctx, func(vm *goja.Runtime) {
+			fn, ok := goja.AssertFunction(vm.Get("greet"))
+			if !ok {
+				t.Error("greet is not a function")
+				return
+			}
+			v, err := fn(goja.Undefined(), vm.ToValue("daemon"))
+			if err != nil {
+				t.Errorf("greet() failed: %v", err)
+				return
+			}
+			results = append(results, v.String())
+		})
+		if err != nil {
+			t.Fatalf("Dispatch: %v", err)
+		}
+	}
+
+	if len(results) != 2 || results[0] != "hello daemon #1" || results[1] != "hello daemon #2" {
+		t.Fatalf("unexpected results: %v", results)
+	}
+
+	cancel()
+	if err := <-done; err != nil && err != context.Canceled && err != context.DeadlineExceeded {
+		t.Fatalf("engine exited with error: %v", err)
+	}
+}
+
+// TestEngineStopsOnContextCancel verifies the engine event loop ends when the
+// context is cancelled (same lifecycle as Run()).
+func TestEngineStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = logr.NewContext(ctx, testr.New(t))
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	eng, err := NewEngine(ctx, "idle_test.js", []byte(`var x = 1;`), EngineOptions{})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- eng.Start(ctx)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil && err != context.Canceled {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("engine did not stop on context cancel")
+	}
+}

--- a/pkg/shelly/script/hardware_stubs.go
+++ b/pkg/shelly/script/hardware_stubs.go
@@ -1,0 +1,65 @@
+package script
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// installHardwareStubs registers the Shelly Gen2 scripting globals that the
+// emulator cannot meaningfully fake: HTTPServer, BLE, BTHome, and UART all
+// depend on physical radios or pins the daemon/test host doesn't have. They
+// are still registered — so scripts referencing them get a clear, catchable
+// "not implemented by the emulator" exception — instead of being left
+// undefined, which would surface as an unrelated ReferenceError.
+func installHardwareStubs(vm *goja.Runtime) {
+	httpServerObj := vm.NewObject()
+	httpServerObj.Set("registerEndpoint", notImplemented(vm, "HTTPServer", "registerEndpoint"))
+	vm.Set("HTTPServer", httpServerObj)
+
+	bleObj := vm.NewObject()
+	bleObj.Set("advertiseOnce", notImplemented(vm, "BLE", "advertiseOnce"))
+
+	scannerObj := vm.NewObject()
+	for _, method := range []string{"subscribe", "start", "stop", "isRunning", "getScanOptions"} {
+		scannerObj.Set(method, notImplemented(vm, "BLE.Scanner", method))
+	}
+	bleObj.Set("Scanner", scannerObj)
+
+	gapObj := vm.NewObject()
+	for _, method := range []string{"parseName", "parseManufacturerData", "parseServiceData", "hasService"} {
+		gapObj.Set(method, notImplemented(vm, "BLE.GAP", method))
+	}
+	bleObj.Set("GAP", gapObj)
+
+	advBuilderObj := vm.NewObject()
+	for _, method := range []string{"addName", "addShellyManufacturerData", "addServiceData", "addBTHomeServiceData", "build", "reset"} {
+		advBuilderObj.Set(method, notImplemented(vm, "BLE.AdvBuilder", method))
+	}
+	bleObj.Set("AdvBuilder", advBuilderObj)
+
+	vm.Set("BLE", bleObj)
+
+	btHomeObj := vm.NewObject()
+	btHomeObj.Set("parseData", notImplemented(vm, "BTHome", "parseData"))
+
+	dataBuilderObj := vm.NewObject()
+	for _, method := range []string{"addObject", "setTriggerBased", "build", "buildEncrypted", "reset"} {
+		dataBuilderObj.Set(method, notImplemented(vm, "BTHome.DataBuilder", method))
+	}
+	btHomeObj.Set("DataBuilder", dataBuilderObj)
+
+	vm.Set("BTHome", btHomeObj)
+
+	uartObj := vm.NewObject()
+	uartObj.Set("get", notImplemented(vm, "UART", "get"))
+	vm.Set("UART", uartObj)
+}
+
+// notImplemented returns a script-callable function that immediately throws
+// a catchable JS exception identifying the unsupported global/method.
+func notImplemented(vm *goja.Runtime, global, method string) func(call goja.FunctionCall) goja.Value {
+	return func(call goja.FunctionCall) goja.Value {
+		panic(vm.ToValue(fmt.Sprintf("%s.%s is not implemented by the script emulator (hardware-only Shelly API)", global, method)))
+	}
+}

--- a/pkg/shelly/script/hardware_stubs_test.go
+++ b/pkg/shelly/script/hardware_stubs_test.go
@@ -1,0 +1,55 @@
+package script
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+// TestHardwareStubsThrowCatchableException verifies that every hardware-only
+// global (HTTPServer, BLE, BTHome, UART) is registered but throws a
+// descriptive, try/catch-able exception instead of leaving scripts to hit an
+// unrelated ReferenceError or silently misbehave.
+func TestHardwareStubsThrowCatchableException(t *testing.T) {
+	tests := []struct {
+		name string
+		call string
+	}{
+		{"HTTPServer.registerEndpoint", `HTTPServer.registerEndpoint("foo", function() {})`},
+		{"BLE.advertiseOnce", `BLE.advertiseOnce({})`},
+		{"BLE.Scanner.start", `BLE.Scanner.start({})`},
+		{"BLE.GAP.parseName", `BLE.GAP.parseName(null)`},
+		{"BLE.AdvBuilder.build", `BLE.AdvBuilder.build()`},
+		{"BTHome.parseData", `BTHome.parseData(null)`},
+		{"BTHome.DataBuilder.build", `BTHome.DataBuilder.build()`},
+		{"UART.get", `UART.get(0)`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := goja.New()
+			installHardwareStubs(vm)
+
+			// Caught from script-side try/catch: the script must observe the
+			// error, not have the host process crash.
+			result, err := vm.RunString(`
+				(function() {
+					try {
+						` + tt.call + `;
+						return "no error thrown";
+					} catch (e) {
+						return String(e);
+					}
+				})();
+			`)
+			if err != nil {
+				t.Fatalf("RunString returned a Go error (exception escaped the VM): %v", err)
+			}
+			msg := result.String()
+			if !strings.Contains(msg, "not implemented") {
+				t.Errorf("%s: message = %q, want it to mention 'not implemented'", tt.name, msg)
+			}
+		})
+	}
+}

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -741,6 +741,8 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	})
 	vm.Set("console", consoleObj)
 
+	installUtilities(vm)
+
 	// Global JSON object (usually available, but ensure it's there)
 	vm.RunString(`
 		if (typeof JSON === 'undefined') {

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -66,6 +66,20 @@ func RunWithDeviceState(ctx context.Context, name string, buf []byte, minify boo
 		return nil
 	}
 
+	return runEventLoop(ctx, vm, &handlers)
+}
+
+// runEventLoop waits on all handler channels simultaneously and dispatches
+// messages into the VM. It returns when the context is cancelled or when all
+// handler channels are closed. The calling goroutine owns the VM: handlers
+// are the only place where script callbacks are executed.
+func runEventLoop(ctx context.Context, vm *goja.Runtime, handlersPtr *[]handler) error {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+	handlers := *handlersPtr
+
 	log.Info("Starting event loop", "handlers", len(handlers))
 
 	// Build select cases: context.Done() + all handler channels
@@ -92,6 +106,7 @@ func RunWithDeviceState(ctx context.Context, name string, buf []byte, minify boo
 	for {
 		// Rebuild cases if needed (deferred from previous iteration)
 		if needsRebuild {
+			handlers = *handlersPtr
 			cases = buildCases()
 			needsRebuild = false
 		}
@@ -108,20 +123,21 @@ func RunWithDeviceState(ctx context.Context, name string, buf []byte, minify boo
 		if ok {
 			handlerIdx := chosen - 1
 			msg := value.Bytes()
-			handlerCountBefore := len(handlers)
+			handlerCountBefore := len(*handlersPtr)
 			if err := handlers[handlerIdx].Handle(ctx, vm, msg); err != nil {
 				log.Error(err, "Handler failed", "handler", handlerIdx)
 			}
 			// Check if new handlers were added during Handle()
-			if len(handlers) != handlerCountBefore {
-				log.Info("Handlers changed, will rebuild cases", "before", handlerCountBefore, "after", len(handlers))
+			if len(*handlersPtr) != handlerCountBefore {
+				log.Info("Handlers changed, will rebuild cases", "before", handlerCountBefore, "after", len(*handlersPtr))
 				needsRebuild = true
 			}
 		} else {
 			// Channel closed, remove it from cases
 			log.Info("Handler channel closed", "handler", chosen-1)
 			// Remove the closed handler
-			handlers = append(handlers[:chosen-1], handlers[chosen:]...)
+			*handlersPtr = append(handlers[:chosen-1], handlers[chosen:]...)
+			handlers = *handlersPtr
 
 			// If no handlers left, exit
 			if len(handlers) == 0 {

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -651,6 +651,7 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 
 	installHardwareStubs(vm)
 	installVirtual(vm, deviceState)
+	installAES(vm)
 
 	// Script object
 	scriptObj := vm.NewObject()

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -650,6 +650,7 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	vm.Set("MQTT", mqttObj)
 
 	installHardwareStubs(vm)
+	installVirtual(vm, deviceState)
 
 	// Script object
 	scriptObj := vm.NewObject()

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -622,12 +622,21 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 		return vm.ToValue(false)
 	})
 	mqttObj.Set("publish", func(call goja.FunctionCall) goja.Value {
+		// MQTT.publish(topic, message[, qos[, retain]]) per Shelly API
 		topic := call.Argument(0).String()
 		message := call.Argument(1).String()
+		qos := mqtt.AtLeastOnce
+		if len(call.Arguments) > 2 && !goja.IsUndefined(call.Argument(2)) {
+			qos = byte(call.Argument(2).ToInteger())
+		}
+		retain := false
+		if len(call.Arguments) > 3 {
+			retain = call.Argument(3).ToBoolean()
+		}
 
-		log.Info("MQTT.publish()", "topic", topic, "message", message)
+		log.Info("MQTT.publish()", "topic", topic, "message", message, "qos", qos, "retain", retain)
 
-		err := mc.Publish(ctx, topic, []byte(message), mqtt.AtLeastOnce, false /*retain*/, "shelly/script/run")
+		err := mc.Publish(ctx, topic, []byte(message), qos, retain, "shelly/script/run")
 		if err != nil {
 			log.Error(err, "MQTT.publish() failed", "topic", topic)
 			return vm.ToValue(false)

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -649,6 +649,8 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	})
 	vm.Set("MQTT", mqttObj)
 
+	installHardwareStubs(vm)
+
 	// Script object
 	scriptObj := vm.NewObject()
 

--- a/pkg/shelly/script/utilities.go
+++ b/pkg/shelly/script/utilities.go
@@ -1,0 +1,61 @@
+package script
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// installUtilities adds the top-level Shelly scripting utility functions:
+// https://shelly-api-docs.shelly.cloud/gen2/Scripts/APIs/Utilities
+//
+// Shelly scripts treat JS strings as byte strings (each character code is a
+// byte 0-255), matching the browser btoa/atob convention — not UTF-8 text.
+func installUtilities(vm *goja.Runtime) {
+	vm.Set("btoa", func(call goja.FunctionCall) goja.Value {
+		raw, err := stringToBytes(call.Argument(0).String())
+		if err != nil {
+			panic(vm.ToValue(fmt.Sprintf("btoa: %v", err)))
+		}
+		return vm.ToValue(base64.StdEncoding.EncodeToString(raw))
+	})
+
+	vm.Set("atob", func(call goja.FunctionCall) goja.Value {
+		raw, err := base64.StdEncoding.DecodeString(call.Argument(0).String())
+		if err != nil {
+			panic(vm.ToValue(fmt.Sprintf("atob: invalid base64 input: %v", err)))
+		}
+		return vm.ToValue(bytesToString(raw))
+	})
+
+	vm.Set("btoh", func(call goja.FunctionCall) goja.Value {
+		raw, err := stringToBytes(call.Argument(0).String())
+		if err != nil {
+			panic(vm.ToValue(fmt.Sprintf("btoh: %v", err)))
+		}
+		return vm.ToValue(hex.EncodeToString(raw))
+	})
+}
+
+// stringToBytes converts a JS byte-string (each rune in 0-255) to raw bytes.
+func stringToBytes(s string) ([]byte, error) {
+	raw := make([]byte, 0, len(s))
+	for _, r := range s {
+		if r > 0xFF {
+			return nil, fmt.Errorf("character code %d is out of byte range (0-255)", r)
+		}
+		raw = append(raw, byte(r))
+	}
+	return raw, nil
+}
+
+// bytesToString converts raw bytes back to a JS byte-string.
+func bytesToString(raw []byte) string {
+	runes := make([]rune, len(raw))
+	for i, b := range raw {
+		runes[i] = rune(b)
+	}
+	return string(runes)
+}

--- a/pkg/shelly/script/utilities_test.go
+++ b/pkg/shelly/script/utilities_test.go
@@ -1,0 +1,74 @@
+package script
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestUtilitiesKnownVectors(t *testing.T) {
+	vm := goja.New()
+	installUtilities(vm)
+
+	tests := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{"btoa", `btoa("hello")`, "aGVsbG8="},
+		{"atob", `atob("aGVsbG8=")`, "hello"},
+		{"btoh", `btoh("hi")`, "6869"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := vm.RunString(tt.expr)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.expr, err)
+			}
+			if got := result.String(); got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.expr, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUtilitiesRoundTrip(t *testing.T) {
+	vm := goja.New()
+	installUtilities(vm)
+
+	result, err := vm.RunString(`atob(btoa("round trip \x00\xff test"))`)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	// \xff in a Go string literal is the raw byte 0xFF (invalid UTF-8 alone);
+	// the JS round trip instead produces the Unicode code point U+00FF, whose
+	// Go literal is ÿ (a valid 2-byte UTF-8 sequence). Same byte value
+	// 0xFF, different Go source notation.
+	want := "round trip \x00ÿ test"
+	if got := result.String(); got != want {
+		t.Errorf("round trip = %q, want %q", got, want)
+	}
+}
+
+func TestBtoaRejectsOutOfRangeChar(t *testing.T) {
+	vm := goja.New()
+	installUtilities(vm)
+
+	result, err := vm.RunString(`
+		(function() {
+			try {
+				btoa("ሴ");
+				return "no error thrown";
+			} catch (e) {
+				return String(e);
+			}
+		})();
+	`)
+	if err != nil {
+		t.Fatalf("RunString returned a Go error (exception escaped the VM): %v", err)
+	}
+	if result.String() == "no error thrown" {
+		t.Error("btoa accepted a character outside the byte range, want a thrown exception")
+	}
+}

--- a/pkg/shelly/script/virtual.go
+++ b/pkg/shelly/script/virtual.go
@@ -1,0 +1,135 @@
+package script
+
+import (
+	"maps"
+	"reflect"
+
+	"github.com/dop251/goja"
+)
+
+// VirtualComponentState is the persisted backing data for one Virtual
+// component (Number, Text, Boolean, Enum, Button, or Group). Real devices
+// only expose handles for components configured ahead of time through the
+// device UI/config — Virtual.getHandle never creates one — so entries are
+// populated by tests or a device snapshot, like DeviceState.ComponentStatus.
+type VirtualComponentState struct {
+	Kind   string         `json:"kind"` // number, text, boolean, enum, button, group
+	Value  any            `json:"value,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
+}
+
+// virtualListener is one Virtual instance on()/off() registration.
+type virtualListener struct {
+	id       int
+	event    string
+	callback goja.Callable
+}
+
+// installVirtual adds the Virtual global (Virtual.getHandle):
+// https://shelly-api-docs.shelly.cloud/gen2/Scripts/APIs/Virtual
+//
+// It returns a trigger function that fires a named event (e.g. "single_push"
+// for a Button) on listeners registered through a handle's on(); used by
+// tests to simulate events that have no JS-side setter (buttons have no
+// setValue). setValue's own "change" event firing doesn't need it.
+func installVirtual(vm *goja.Runtime, deviceState *DeviceState) (trigger func(key, event string, data map[string]any)) {
+	listeners := make(map[string][]*virtualListener)
+	nextListenerID := 1
+
+	virtualObj := vm.NewObject()
+	virtualObj.Set("getHandle", func(call goja.FunctionCall) goja.Value {
+		key := call.Argument(0).String()
+		comp, ok := deviceState.Virtual[key]
+		if !ok {
+			return goja.Null()
+		}
+		return buildVirtualInstance(vm, deviceState, key, comp, listeners, &nextListenerID)
+	})
+	vm.Set("Virtual", virtualObj)
+
+	return func(key, event string, data map[string]any) {
+		fireVirtualEvent(vm, listeners[key], event, data)
+	}
+}
+
+func buildVirtualInstance(vm *goja.Runtime, deviceState *DeviceState, key string, comp *VirtualComponentState, listeners map[string][]*virtualListener, nextListenerID *int) *goja.Object {
+	obj := vm.NewObject()
+
+	obj.Set("getValue", func(call goja.FunctionCall) goja.Value {
+		if comp.Value == nil {
+			return goja.Undefined()
+		}
+		return vm.ToValue(comp.Value)
+	})
+
+	obj.Set("setValue", func(call goja.FunctionCall) goja.Value {
+		newValue := call.Argument(0).Export()
+		changed := !reflect.DeepEqual(comp.Value, newValue)
+		comp.Value = newValue
+		if deviceState.OnModified != nil {
+			deviceState.OnModified()
+		}
+		// Buttons are momentary (single_push, etc.); they have no "change"
+		// event and setValue isn't a real operation on them.
+		if changed && comp.Kind != "button" {
+			fireVirtualEvent(vm, listeners[key], "change", map[string]any{"value": newValue})
+		}
+		return goja.Undefined()
+	})
+
+	obj.Set("getStatus", func(call goja.FunctionCall) goja.Value {
+		return vm.ToValue(map[string]any{"id": key, "value": comp.Value})
+	})
+
+	obj.Set("getConfig", func(call goja.FunctionCall) goja.Value {
+		return vm.ToValue(comp.Config)
+	})
+
+	obj.Set("setConfig", func(call goja.FunctionCall) goja.Value {
+		if cfg, ok := call.Argument(0).Export().(map[string]any); ok {
+			if comp.Config == nil {
+				comp.Config = make(map[string]any)
+			}
+			maps.Copy(comp.Config, cfg)
+		}
+		if deviceState.OnModified != nil {
+			deviceState.OnModified()
+		}
+		return goja.Undefined()
+	})
+
+	obj.Set("on", func(call goja.FunctionCall) goja.Value {
+		event := call.Argument(0).String()
+		callback, ok := goja.AssertFunction(call.Argument(1))
+		if !ok {
+			panic(vm.ToValue("Virtual instance on(): second argument must be a function"))
+		}
+		id := *nextListenerID
+		*nextListenerID++
+		listeners[key] = append(listeners[key], &virtualListener{id: id, event: event, callback: callback})
+		return vm.ToValue(id)
+	})
+
+	obj.Set("off", func(call goja.FunctionCall) goja.Value {
+		id := int(call.Argument(0).ToInteger())
+		ls := listeners[key]
+		for i, l := range ls {
+			if l.id == id {
+				listeners[key] = append(ls[:i], ls[i+1:]...)
+				break
+			}
+		}
+		return goja.Undefined()
+	})
+
+	return obj
+}
+
+func fireVirtualEvent(vm *goja.Runtime, ls []*virtualListener, event string, data map[string]any) {
+	for _, l := range ls {
+		if l.event != event {
+			continue
+		}
+		l.callback(goja.Undefined(), vm.ToValue(data))
+	}
+}

--- a/pkg/shelly/script/virtual_test.go
+++ b/pkg/shelly/script/virtual_test.go
@@ -1,0 +1,148 @@
+package script
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func newVirtualTestVM(t *testing.T, state *DeviceState) (*goja.Runtime, func(key, event string, data map[string]any)) {
+	t.Helper()
+	vm := goja.New()
+	trigger := installVirtual(vm, state)
+	return vm, trigger
+}
+
+func TestVirtualGetHandleMissingKeyReturnsNull(t *testing.T) {
+	state := &DeviceState{Virtual: map[string]*VirtualComponentState{}}
+	vm, _ := newVirtualTestVM(t, state)
+
+	result, err := vm.RunString(`Virtual.getHandle("number:200") === null`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	if !result.ToBoolean() {
+		t.Error("getHandle on a missing key did not return null")
+	}
+}
+
+func TestVirtualNumberGetSetValue(t *testing.T) {
+	state := &DeviceState{Virtual: map[string]*VirtualComponentState{
+		"number:200": {Kind: "number", Value: 21.5, Config: map[string]any{"min": 0.0, "max": 100.0}},
+	}}
+	vm, _ := newVirtualTestVM(t, state)
+
+	result, err := vm.RunString(`
+		var h = Virtual.getHandle("number:200");
+		var before = h.getValue();
+		h.setValue(42);
+		var after = h.getValue();
+		var cfg = h.getConfig();
+		JSON.stringify({before: before, after: after, max: cfg.max});
+	`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	got := result.String()
+	want := `{"before":21.5,"after":42,"max":100}`
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+	if state.Virtual["number:200"].Value != int64(42) {
+		t.Errorf("backing state Value = %v, want 42", state.Virtual["number:200"].Value)
+	}
+}
+
+func TestVirtualSetValueFiresChangeEvent(t *testing.T) {
+	state := &DeviceState{Virtual: map[string]*VirtualComponentState{
+		"boolean:201": {Kind: "boolean", Value: false},
+	}}
+	vm, _ := newVirtualTestVM(t, state)
+
+	result, err := vm.RunString(`
+		var seen = null;
+		var h = Virtual.getHandle("boolean:201");
+		h.on("change", function(data) { seen = data.value; });
+		h.setValue(true);
+		seen;
+	`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	if !result.ToBoolean() {
+		t.Errorf("change listener did not observe the new value: %v", result.Export())
+	}
+}
+
+func TestVirtualSetValueNoChangeNoEvent(t *testing.T) {
+	state := &DeviceState{Virtual: map[string]*VirtualComponentState{
+		"boolean:202": {Kind: "boolean", Value: true},
+	}}
+	vm, _ := newVirtualTestVM(t, state)
+
+	result, err := vm.RunString(`
+		var fired = false;
+		var h = Virtual.getHandle("boolean:202");
+		h.on("change", function(data) { fired = true; });
+		h.setValue(true); // same value: no change event
+		fired;
+	`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	if result.ToBoolean() {
+		t.Error("change event fired even though the value didn't change")
+	}
+}
+
+func TestVirtualOffRemovesListener(t *testing.T) {
+	state := &DeviceState{Virtual: map[string]*VirtualComponentState{
+		"text:203": {Kind: "text", Value: "a"},
+	}}
+	vm, _ := newVirtualTestVM(t, state)
+
+	result, err := vm.RunString(`
+		var count = 0;
+		var h = Virtual.getHandle("text:203");
+		var id = h.on("change", function() { count++; });
+		h.setValue("b");
+		h.off(id);
+		h.setValue("c");
+		count;
+	`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	if got := result.ToInteger(); got != 1 {
+		t.Errorf("listener fired %d times after off(), want 1", got)
+	}
+}
+
+func TestVirtualButtonPushEventViaTrigger(t *testing.T) {
+	state := &DeviceState{Virtual: map[string]*VirtualComponentState{
+		"button:204": {Kind: "button"},
+	}}
+	vm, trigger := newVirtualTestVM(t, state)
+
+	_, err := vm.RunString(`
+		var pushes = 0;
+		var h = Virtual.getHandle("button:204");
+		h.on("single_push", function() { pushes++; });
+	`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+
+	// Buttons are momentary: there's no setValue path, so a real hardware
+	// press is simulated through the Go-side trigger, same as the
+	// device-event injector used elsewhere in this package.
+	trigger("button:204", "single_push", nil)
+
+	result, err := vm.RunString(`pushes`)
+	if err != nil {
+		t.Fatalf("RunString: %v", err)
+	}
+	if got := result.ToInteger(); got != 1 {
+		t.Errorf("pushes = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

MyHome-specific **workflows** can now be written in JavaScript and executed on the daemon by the built-in goja engine; **communication, persistence and infrastructure stay in Go**. Devices invoke daemon-hosted scripts over MQTT (`script.invoke` on the regular RPC topic), so a single workflow can span a device and a daemon. Multiple daemons coexist, differentiated by **instance name**.

Plan and architecture: `docs/plan-js-workflows.md`. Developer docs: AGENTS.md → "Daemon Script Host (JS Workflows)".

## What's in here

- **Instance names** — daemon default = short OS hostname (`--instance` / `daemon.instance_name` / `MYHOME_DAEMON_INSTANCE_NAME`). The daemon running the embedded broker is the *main* daemon and additionally serves the well-known `myhome/rpc` topic → **nothing to change on the production deployment**; CLI and devices keep working.
- **`pkg/shelly/script` Engine** — the emulator's runtime/event loop extracted into an exported `Engine` with thread-safe external dispatch (goja VMs are single-threaded). `MQTT.publish` now honors qos/retain (Shelly API compat).
- **`myhome/scripthost` (new module)** — one engine per configured script, resolved from `daemon.scripts.dir` or the embedded device-script library (*every device script is also present on the daemon*), per-script persistent state (`scripts-state/<name>.json`), crash-restart with backoff. JS API: `MyHome.instance/log/on/call/deviceCall/uploadScript/registerVerb`. Handlers complete synchronously (return value) or asynchronously (`respond(result, error)`).
- **Protocol** — new verbs `script.invoke` (device→daemon handler invocation; responses on `<src>/rpc` with `src=<prefix>/myhome`) and `lan.hosts` (Go infra for the JS occupancy workflow). `myhome.CallLocalE` for in-process verb dispatch.
- **Workflows (opt-in via `daemon.scripts.run`; Go versions remain the default)**
  - `occupancy.js` — replaces the Go occupancy service when listed (input events + LAN mobile presence, retained `myhome/occupancy`, `occupancy.getstatus` verb, KVS-backed config).
  - `heater-myhome.js` — takes over `heater.getconfig`/`heater.setconfig` (device KVS chains + script upload via Go bindings) and serves `get_forecast` to device heater scripts.
  - `myhome-link.js` — dual-mode demo/self-test of the device↔daemon calling convention.
- **Fix** — `MqttWatcher` no longer busy-loops (3.4 GB of logs/min) when its subscription channel closes.

## Configuration

```yaml
daemon:
  # instance_name: myhome        # default: short OS hostname
  scripts:
    enabled: true
    run: [occupancy, heater-myhome, myhome-link]
```

## Testing

- `make test` green (incl. new module; workflow tests run the real JS files against fake MQTT/device backends).
- **Live** on `development.local` (192.168.1.31) against the production broker with a `dev-claude` instance daemon (production daemon untouched):
  - device→daemon `script.invoke` ping round-trip every 60 s; on-device receipt verified via `Script.Eval` of the pending-request table;
  - `myhome ctl -I dev-claude heater status …` served by the JS workflow;
  - distributed forecast: device → daemon → open-meteo → device, response published 157 ms after the request.

## Notes for review

- `occupancy.js` was deliberately **not** run against the live broker: it would fight with the main daemon's Go occupancy over the retained `myhome/occupancy` topic (exactly why substitution is hard, not parallel).
- development.local still runs `myhome-link.js` pointed at instance `dev-claude` (KVS `script/myhome-link/instance`); with the dev daemon stopped it logs a harmless timeout per minute. Its MQTT (was disabled) is now enabled against 192.168.1.2, with `debug.mqtt` on.
- Known follow-ups (in plan): wildcard `MQTT.subscribe` callbacks receive the filter, not the concrete topic; JS-registered verbs keep answering "script not running" if a script is removed from config after having registered them.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- docs: plan for JS workflows on daemon-side goja engine ([b0902b1](https://github.com/asnowfix/home-automation/commit/b0902b19085046907157bfcb3deebfcb09735cda))
- feat(daemon): instance name defaults to hostname; main daemon serves myhome/rpc alias ([bd0a830](https://github.com/asnowfix/home-automation/commit/bd0a8300e5eef3626cfca379c6b0845b096eb2af))
- feat(pkg/shelly/script): exported Engine with thread-safe external dispatch ([8af1933](https://github.com/asnowfix/home-automation/commit/8af1933fb09a81120bfc319e868600a0040a5844))
- feat(scripthost): daemon-side goja script host + script.invoke RPC verb ([1d9feb0](https://github.com/asnowfix/home-automation/commit/1d9feb07110ce94cc404ec19e59980886ecda2e9))
- style: gofmt daemon.go import order ([171dfb6](https://github.com/asnowfix/home-automation/commit/171dfb61a63ee0c0a8d76408b658aafc16618e69))
- feat(scripts): myhome-link.js dual-mode device<->daemon link + docs ([f71473c](https://github.com/asnowfix/home-automation/commit/f71473cb05f7473fb144f8ad1abea561e629dafa))
- feat(occupancy): JS occupancy workflow replacing the Go service (opt-in) ([4583067](https://github.com/asnowfix/home-automation/commit/4583067db49bfb9f7fb96da25584067c5e3cdb9c))
- feat(heater): JS heater workflow (getconfig/setconfig verbs + forecast service) ([bed0ef6](https://github.com/asnowfix/home-automation/commit/bed0ef6847d96cf2e7ed4e03060726635fdb5a80))
- docs(plan): mark live validation and PR phases done ([9f7c99e](https://github.com/asnowfix/home-automation/commit/9f7c99e628ef4d8ea80f96521fc8f564674d5e44))
- chore: gitignore scripts-state/ runtime dir ([0a16665](https://github.com/asnowfix/home-automation/commit/0a16665112206e900df7b0d8a6cf28d563ec1d9e))
<!-- END-AUTO-GENERATED-COMMITS -->