### PR TITLE
fix(daemon): stop MqttWatcher busy-loop when subscription channel closes

### DIFF
--- a/myhome/daemon/watch/mqtt.go
+++ b/myhome/daemon/watch/mqtt.go
@@ -42,7 +42,13 @@ func mqttWatcher(ctx context.Context, log logr.Logger, topic string, dm devices.
 			log.Info("Cancelled", "topic", topic)
 			return
 
-		case msg := <-ch:
+		case msg, ok := <-ch:
+			if !ok {
+				// Subscription channel closed (reconnect/shutdown): exit
+				// instead of spinning on nil receives.
+				log.Info("Subscription channel closed, stopping watcher", "topic", topic)
+				return
+			}
 			log.V(1).Info("Received", "topic", topic)
 			if msg == nil {
 				log.Error(fmt.Errorf("nil message"), "Skipping", "topic", topic)

--- a/myhome/daemon/watch/mqtt_test.go
+++ b/myhome/daemon/watch/mqtt_test.go
@@ -1,0 +1,62 @@
+package watch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/asnowfix/home-automation/myhome/mqtt"
+
+	"github.com/go-logr/logr/testr"
+)
+
+// TestMqttWatcherStopsOnChannelClose is a regression test: a closed
+// subscription channel used to make mqttWatcher spin forever on nil receives
+// (logging "nil message" in a tight loop). The watcher must exit instead.
+func TestMqttWatcherStopsOnChannelClose(t *testing.T) {
+	ctx := context.Background()
+	log := testr.New(t)
+
+	ch := make(chan mqtt.Message)
+	done := make(chan struct{})
+	go func() {
+		mqttWatcher(ctx, log, "+/events/rpc", nil, nil, ch)
+		close(done)
+	}()
+
+	// A nil message on an open channel is skipped, not fatal
+	ch <- nil
+	select {
+	case <-done:
+		t.Fatal("watcher exited on a nil message; it should only skip it")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Closing the channel must end the watcher (not busy-loop)
+	close(ch)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop after the subscription channel closed")
+	}
+}
+
+// TestMqttWatcherStopsOnContextCancel covers the pre-existing shutdown path.
+func TestMqttWatcherStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := testr.New(t)
+
+	ch := make(chan mqtt.Message)
+	done := make(chan struct{})
+	go func() {
+		mqttWatcher(ctx, log, "+/events/rpc", nil, nil, ch)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop on context cancellation")
+	}
+}


### PR DESCRIPTION
## Problem

`mqttWatcher` (myhome/daemon/watch/mqtt.go) reads its subscription channel with `case msg := <-ch:`. When the channel is **closed** (MQTT reconnect / shutdown), a receive on a closed channel returns the zero value immediately and forever — so the watcher spins in a tight loop, logging

```
"error":"nil message","logger":"DeviceManager/MqttWatcher","topic":"+/events/rpc","message":"Skipping"
```

millions of times. Observed in the wild while testing a secondary daemon against the production broker: **3.4 GB of log output in ~12 minutes**, one core pegged.

## Fix

Use the two-value receive and exit the watcher when the channel is closed:

```go
case msg, ok := <-ch:
    if !ok {
        log.Info("Subscription channel closed, stopping watcher", "topic", topic)
        return
    }
```

The existing `msg == nil` guard stays for nil messages delivered on an open channel.

## Testing

- `myhome/daemon` builds and vets clean; `make generate` + package tests pass.
- Reproduced live before the fix (log flood within minutes); after the fix the same daemon ran with a normal log volume (<1 MB over the same period).

Cherry-picked from the worktree-feature+my-js-home branch (also included in #254) so it can land on main independently.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(daemon): stop MqttWatcher when subscription channel closes ([cf19b88](https://github.com/asnowfix/home-automation/commit/cf19b88bd356e480a46722512640b065941e936d))
- test(daemon): regression tests for MqttWatcher channel-close and ctx-cancel exits ([0a5b5f2](https://github.com/asnowfix/home-automation/commit/0a5b5f26f280e0bf23e75d1b04a0a97fe38c65f6))
<!-- END-AUTO-GENERATED-COMMITS -->