### PR TITLE
feat(ctl): add unfollow/unpublish commands, fix BLU namespace, add tests

### DIFF
--- a/internal/myhome/blu/resolve.go
+++ b/internal/myhome/blu/resolve.go
@@ -40,20 +40,25 @@ func ResolveMac(ctx context.Context, identifier string) (string, error) {
 	device := (*devices)[0]
 	deviceID := device.Id()
 
-	// Check if this is a BLU device (ID starts with "shellyblu-")
-	if !strings.HasPrefix(deviceID, "shellyblu-") {
-		return "", fmt.Errorf("device %q is not a BLU device (id: %s)", identifier, deviceID)
+	mac, err = macFromBluDeviceID(deviceID)
+	if err != nil {
+		return "", fmt.Errorf("device %q: %w", identifier, err)
 	}
+	return mac, nil
+}
 
-	// Extract MAC from device ID: "shellyblu-e8e07ea60c6f" -> "e8e07ea60c6f"
-	macHex := strings.TrimPrefix(deviceID, "shellyblu-")
-
-	// Normalize to colon-separated format
-	mac = tools.NormalizeMac(macHex)
-	if mac == "" || !isValidMac(mac) {
-		return "", fmt.Errorf("failed to extract valid MAC from device %q (id: %s)", identifier, deviceID)
+// macFromBluDeviceID extracts and normalizes the MAC address from a Shelly BLU device ID.
+// BLU device IDs follow the pattern <model>-<mac12hex> where model starts with "shellyblu".
+// Examples: "shellyblu-e8e07ea60c6f", "shellyblumotion1-e8e07ed0f989", "shellyblubutton1-..."
+func macFromBluDeviceID(deviceID string) (string, error) {
+	if !strings.HasPrefix(deviceID, "shellyblu") {
+		return "", fmt.Errorf("not a BLU device (id: %s)", deviceID)
 	}
-
+	parts := strings.Split(deviceID, "-")
+	mac := tools.NormalizeMac(parts[len(parts)-1])
+	if !isValidMac(mac) {
+		return "", fmt.Errorf("failed to extract valid MAC from BLU device ID %q", deviceID)
+	}
 	return mac, nil
 }
 

--- a/internal/myhome/blu/resolve_test.go
+++ b/internal/myhome/blu/resolve_test.go
@@ -1,0 +1,85 @@
+package blu
+
+import (
+	"testing"
+)
+
+func TestMacFromBluDeviceID(t *testing.T) {
+	tests := []struct {
+		name     string
+		deviceID string
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "generic shellyblu prefix",
+			deviceID: "shellyblu-e8e07ea60c6f",
+			want:     "e8:e0:7e:a6:0c:6f",
+		},
+		{
+			name:     "motion sensor (shellyblumotion1)",
+			deviceID: "shellyblumotion1-e8e07ed0f989",
+			want:     "e8:e0:7e:d0:f9:89",
+		},
+		{
+			name:     "motion sensor parking (shellyblumotion1)",
+			deviceID: "shellyblumotion1-b0c7de1158d5",
+			want:     "b0:c7:de:11:58:d5",
+		},
+		{
+			name:     "button (shellyblubutton1)",
+			deviceID: "shellyblubutton1-aabbcc112233",
+			want:     "aa:bb:cc:11:22:33",
+		},
+		{
+			name:    "non-BLU Shelly device",
+			deviceID: "shellypm-aabbcc112233",
+			wantErr: true,
+		},
+		{
+			name:    "shelly pro2",
+			deviceID: "shellypro2-2cbcbb9fb834",
+			wantErr: true,
+		},
+		{
+			name:    "truncated MAC in device ID",
+			deviceID: "shellyblumotion1-e8e07e",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := macFromBluDeviceID(tt.deviceID)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("macFromBluDeviceID(%q) error = %v, wantErr %v", tt.deviceID, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("macFromBluDeviceID(%q) = %q, want %q", tt.deviceID, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValidMac(t *testing.T) {
+	tests := []struct {
+		mac  string
+		want bool
+	}{
+		{"e8:e0:7e:a6:0c:6f", true},
+		{"b0:c7:de:11:58:d5", true},
+		{"aa:bb:cc:11:22:33", true},
+		{"e8e07ea60c6f", false},    // no colons
+		{"e8-e0-7e-a6-0c-6f", false}, // dashes
+		{"e8:e0:7e:a6:0c", false},  // too short
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mac, func(t *testing.T) {
+			if got := isValidMac(tt.mac); got != tt.want {
+				t.Errorf("isValidMac(%q) = %v, want %v", tt.mac, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/shelly/scripts/blu-publisher.js
+++ b/internal/shelly/scripts/blu-publisher.js
@@ -76,7 +76,7 @@ const CONFIG = {
   // Specify the destination event where the decoded BLE data will be emitted. It allows for easy identification by other applications/scripts
   eventName: "shelly-blu",
 
-  kvsPrefix: "follow/shelly-blu/",
+  kvsPrefix: "publish/shelly-blu/",
 
   // If the script owns the scanner and this value is set to true, the scan will be active.
   // If the script does not own the scanner, it may remain passive even when set to true.
@@ -86,8 +86,8 @@ const CONFIG = {
 
 var STATE = {
   // In-memory cache of follows loaded from KVS by loadFollowsFromKVS()
-  // KVS keys are set externally via "myhome ctl follow blu" command
-  // Each followed MAC has its own KVS key: follow/shelly-blu/<mac>
+  // KVS keys are set externally via "myhome ctl blu publish" command
+  // Each followed MAC has its own KVS key: publish/shelly-blu/<mac>
   // Empty map = publish ALL BLU events (no filtering)
   follows: {}
 };

--- a/internal/tools/normalize_test.go
+++ b/internal/tools/normalize_test.go
@@ -1,0 +1,38 @@
+package tools
+
+import "testing"
+
+func TestNormalizeMac(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		// Already canonical
+		{"e8:e0:7e:a6:0c:6f", "e8:e0:7e:a6:0c:6f"},
+		// Uppercase colon-separated
+		{"E8:E0:7E:A6:0C:6F", "e8:e0:7e:a6:0c:6f"},
+		// Plain hex (no separators)
+		{"E8E07EA60C6F", "e8:e0:7e:a6:0c:6f"},
+		{"e8e07ea60c6f", "e8:e0:7e:a6:0c:6f"},
+		// Dash-separated
+		{"e8-e0-7e-a6-0c-6f", "e8:e0:7e:a6:0c:6f"},
+		{"E8-E0-7E-A6-0C-6F", "e8:e0:7e:a6:0c:6f"},
+		// Real device MACs seen in the field
+		{"b0c7de1158d5", "b0:c7:de:11:58:d5"},
+		{"e8e07ed0f989", "e8:e0:7e:d0:f9:89"},
+		// Non-MAC strings pass through lowercased/trimmed
+		{"hello", "hello"},
+		{"  HELLO  ", "hello"},
+		// Empty
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := NormalizeMac(tt.in)
+			if got != tt.want {
+				t.Errorf("NormalizeMac(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/myhome/ctl/blu/follow/blu.go
+++ b/myhome/ctl/blu/follow/blu.go
@@ -138,31 +138,18 @@ func configureBluFollow(cmd *cobra.Command, followerDevice, bluDevice string) er
 		return fmt.Errorf("failed to resolve BLU device %q: %w", bluDevice, err)
 	}
 
-	// Validate illuminance values
-	if err := validateIlluminanceValue(bluFlagIllumMin); err != nil {
-		return fmt.Errorf("invalid illuminance-min: %w", err)
-	}
-	if err := validateIlluminanceValue(bluFlagIllumMax); err != nil {
-		return fmt.Errorf("invalid illuminance-max: %w", err)
-	}
-
-	// Build JSON payload with defaults and optional fields
-	payload := make(map[string]any)
-	payload["switch_id"] = bluFlagSwitchID
-	payload["auto_off"] = bluFlagAutoOff
-
-	if cmd.Flags().Changed("illuminance-min") && strings.TrimSpace(bluFlagIllumMin) != "" {
-		payload["illuminance_min"] = parseIlluminanceValue(bluFlagIllumMin)
-	}
-	if cmd.Flags().Changed("illuminance-max") && strings.TrimSpace(bluFlagIllumMax) != "" {
-		payload["illuminance_max"] = parseIlluminanceValue(bluFlagIllumMax)
-	} else if !cmd.Flags().Changed("illuminance-max") {
-		// Set default max to 10% if not explicitly provided
-		payload["illuminance_max"] = "10%"
-	}
-
-	if cmd.Flags().Changed("next-switch") && strings.TrimSpace(bluFlagNextSwitch) != "" {
-		payload["next_switch"] = bluFlagNextSwitch
+	payload, err := buildBluFollowPayload(bluFollowOptions{
+		switchID:      bluFlagSwitchID,
+		autoOff:       bluFlagAutoOff,
+		illumMin:      bluFlagIllumMin,
+		illumMax:      bluFlagIllumMax,
+		illumMinSet:   cmd.Flags().Changed("illuminance-min"),
+		illumMaxSet:   cmd.Flags().Changed("illuminance-max"),
+		nextSwitch:    bluFlagNextSwitch,
+		nextSwitchSet: cmd.Flags().Changed("next-switch"),
+	})
+	if err != nil {
+		return err
 	}
 
 	valueBytes, err := json.Marshal(payload)
@@ -226,6 +213,17 @@ func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device de
 	return kvs.SetKeyValue(ctx, log, via, sd, key, value)
 }
 
+// doDeleteKVS is a helper function for deleting KVS entries on Shelly devices
+func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	sd, ok := device.(*shelly.Device)
+	if !ok {
+		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+	}
+	key := args[0]
+	log.Info("Deleting follow config", "key", key, "device", sd.Id())
+	return kvs.DeleteKey(ctx, log, via, sd, key)
+}
+
 // uploadScript is a helper function to upload and start scripts on Shelly devices
 func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
@@ -243,6 +241,65 @@ func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, devic
 	}
 	fmt.Printf("✓ Successfully uploaded %s to %s (id: %d)\n", scriptName, sd.Name(), id)
 	return id, nil
+}
+
+// deleteScript is a helper function to stop and delete scripts on Shelly devices
+func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	sd, ok := device.(*shelly.Device)
+	if !ok {
+		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+	}
+	scriptName := args[0]
+	fmt.Printf(". Removing %s from %s...\n", scriptName, sd.Name())
+	out, err := mhscript.DeleteWithVersion(ctx, log, via, sd, scriptName)
+	if err != nil {
+		fmt.Printf("✗ %v\n", err)
+		return nil, err
+	}
+	fmt.Printf("✓ Successfully removed %s from %s\n", scriptName, sd.Name())
+	return out, nil
+}
+
+var UnfollowCmd = &cobra.Command{
+	Use:   "unfollow <follower-device> <blu-device>",
+	Short: "Remove BLU follow configuration and blu-listener script",
+	Long: `Remove follow configuration between a Shelly device and a BLU device.
+
+Deletes the KVS key that configures the follow relationship and stops/deletes
+the blu-listener.js script from the follower device.
+
+The <blu-device> can be specified as:
+- MAC address: "e8:e0:7e:a6:0c:6f", "E8E07EA60C6F", "e8-e0-7e-a6-0c-6f"
+- Device ID: "shellyblu-e8e07ea60c6f"
+- Device name: "motion-sensor-hallway"
+
+Examples:
+  myhome ctl blu unfollow hallway-light motion-sensor-hallway`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		followerDevice := args[0]
+		bluDevice := args[1]
+
+		mac, err := mhblu.ResolveMac(cmd.Context(), bluDevice)
+		if err != nil {
+			return fmt.Errorf("failed to resolve BLU device %q: %w", bluDevice, err)
+		}
+
+		kvKey := "follow/shelly-blu/" + mac
+
+		_, err = myhome.Foreach(cmd.Context(), hlog.Logger, followerDevice, options.Via, doDeleteKVS, []string{kvKey})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("\nRemoving blu-listener.js script...\n")
+		_, err = myhome.Foreach(cmd.Context(), hlog.Logger, followerDevice, options.Via, deleteScript, []string{"blu-listener.js"})
+		if err != nil {
+			return fmt.Errorf("failed to remove script: %w", err)
+		}
+
+		return nil
+	},
 }
 
 // listFollowedBluDevices lists the BLU devices followed by the specified follower device
@@ -274,4 +331,46 @@ func listFollowedBluDevices(ctx context.Context, followerDevice string) error {
 		return nil, nil
 	}, []string{})
 	return err
+}
+
+type bluFollowOptions struct {
+	switchID      string
+	autoOff       int
+	illumMin      string
+	illumMax      string
+	illumMinSet   bool
+	illumMaxSet   bool
+	nextSwitch    string
+	nextSwitchSet bool
+}
+
+// buildBluFollowPayload constructs the KVS payload for blu-listener.js.
+// illuminance_max defaults to "10%" when not explicitly set.
+func buildBluFollowPayload(opts bluFollowOptions) (map[string]any, error) {
+	if err := validateIlluminanceValue(opts.illumMin); err != nil {
+		return nil, fmt.Errorf("invalid illuminance-min: %w", err)
+	}
+	if err := validateIlluminanceValue(opts.illumMax); err != nil {
+		return nil, fmt.Errorf("invalid illuminance-max: %w", err)
+	}
+
+	payload := map[string]any{
+		"switch_id": opts.switchID,
+		"auto_off":  opts.autoOff,
+	}
+
+	if opts.illumMinSet && strings.TrimSpace(opts.illumMin) != "" {
+		payload["illuminance_min"] = parseIlluminanceValue(opts.illumMin)
+	}
+	if opts.illumMaxSet && strings.TrimSpace(opts.illumMax) != "" {
+		payload["illuminance_max"] = parseIlluminanceValue(opts.illumMax)
+	} else if !opts.illumMaxSet {
+		payload["illuminance_max"] = "10%"
+	}
+
+	if opts.nextSwitchSet && strings.TrimSpace(opts.nextSwitch) != "" {
+		payload["next_switch"] = opts.nextSwitch
+	}
+
+	return payload, nil
 }

--- a/myhome/ctl/blu/follow/blu_test.go
+++ b/myhome/ctl/blu/follow/blu_test.go
@@ -1,0 +1,166 @@
+package follow
+
+import "testing"
+
+func TestBuildBluFollowPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    bluFollowOptions
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "defaults: switch:0, auto_off=300, illuminance_max=10%",
+			opts: bluFollowOptions{
+				switchID: "switch:0",
+				autoOff:  300,
+			},
+			want: map[string]any{
+				"switch_id":      "switch:0",
+				"auto_off":       300,
+				"illuminance_max": "10%",
+			},
+		},
+		{
+			name: "explicit switch:1",
+			opts: bluFollowOptions{
+				switchID: "switch:1",
+				autoOff:  300,
+			},
+			want: map[string]any{
+				"switch_id":      "switch:1",
+				"auto_off":       300,
+				"illuminance_max": "10%",
+			},
+		},
+		{
+			name: "numeric illuminance_max overrides default",
+			opts: bluFollowOptions{
+				switchID:    "switch:0",
+				autoOff:     300,
+				illumMax:    "50",
+				illumMaxSet: true,
+			},
+			want: map[string]any{
+				"switch_id":      "switch:0",
+				"auto_off":       300,
+				"illuminance_max": 50,
+			},
+		},
+		{
+			name: "percentage illuminance_max",
+			opts: bluFollowOptions{
+				switchID:    "switch:0",
+				autoOff:     300,
+				illumMax:    "20%",
+				illumMaxSet: true,
+			},
+			want: map[string]any{
+				"switch_id":      "switch:0",
+				"auto_off":       300,
+				"illuminance_max": "20%",
+			},
+		},
+		{
+			name: "illuminance_min set",
+			opts: bluFollowOptions{
+				switchID:    "switch:0",
+				autoOff:     300,
+				illumMin:    "5",
+				illumMinSet: true,
+			},
+			want: map[string]any{
+				"switch_id":      "switch:0",
+				"auto_off":       300,
+				"illuminance_min": 5,
+				"illuminance_max": "10%",
+			},
+		},
+		{
+			name: "next_switch set",
+			opts: bluFollowOptions{
+				switchID:      "switch:0",
+				autoOff:       300,
+				nextSwitch:    "switch:1",
+				nextSwitchSet: true,
+			},
+			want: map[string]any{
+				"switch_id":      "switch:0",
+				"auto_off":       300,
+				"illuminance_max": "10%",
+				"next_switch":    "switch:1",
+			},
+		},
+		{
+			name: "invalid illuminance_min returns error",
+			opts: bluFollowOptions{
+				illumMin:    "notanumber",
+				illumMinSet: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "percentage out of range returns error",
+			opts: bluFollowOptions{
+				illumMax:    "150%",
+				illumMaxSet: true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildBluFollowPayload(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildBluFollowPayload() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			for k, wantV := range tt.want {
+				gotV, ok := got[k]
+				if !ok {
+					t.Errorf("missing key %q in payload", k)
+					continue
+				}
+				if gotV != wantV {
+					t.Errorf("payload[%q] = %v (%T), want %v (%T)", k, gotV, gotV, wantV, wantV)
+				}
+			}
+			for k := range got {
+				if _, ok := tt.want[k]; !ok {
+					t.Errorf("unexpected key %q in payload (value: %v)", k, got[k])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateIlluminanceValue(t *testing.T) {
+	tests := []struct {
+		value   string
+		wantErr bool
+	}{
+		{"", false},
+		{"0", false},
+		{"100", false},
+		{"50.5", false},
+		{"0%", false},
+		{"100%", false},
+		{"20%", false},
+		{"101%", true},
+		{"-1%", true},
+		{"abc", true},
+		{"20x", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			err := validateIlluminanceValue(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateIlluminanceValue(%q) error = %v, wantErr %v", tt.value, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/myhome/ctl/blu/main.go
+++ b/myhome/ctl/blu/main.go
@@ -14,5 +14,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(follow.Cmd)
+	Cmd.AddCommand(follow.UnfollowCmd)
 	Cmd.AddCommand(PublishCmd)
+	Cmd.AddCommand(UnpublishCmd)
 }

--- a/myhome/ctl/blu/publish.go
+++ b/myhome/ctl/blu/publish.go
@@ -89,7 +89,7 @@ func enablePublishAll(ctx context.Context, gatewayDevice string, clear bool) err
 		return fmt.Errorf("failed to enable BLE gateway: %w", err)
 	}
 
-	// Clear all existing follow/shelly-blu/* KVS entries if --clear flag is set
+	// Clear all existing publish/shelly-blu/* KVS entries if --clear flag is set
 	if clear {
 		fmt.Printf("Clearing existing BLU follow entries...\n")
 		_, err = myhome.Foreach(ctx, log, gatewayDevice, options.Via, clearBluFollows, []string{})
@@ -123,7 +123,7 @@ func addDevicePublishingBlu(ctx context.Context, gatewayDevice, mac string, clea
 		return fmt.Errorf("failed to enable BLE gateway: %w", err)
 	}
 
-	// Clear all existing follow/shelly-blu/* KVS entries if --clear flag is set
+	// Clear all existing publish/shelly-blu/* KVS entries if --clear flag is set
 	if clear {
 		fmt.Printf("Clearing existing BLU follow entries...\n")
 		_, err = myhome.Foreach(ctx, log, gatewayDevice, options.Via, clearBluFollows, []string{})
@@ -140,7 +140,7 @@ func addDevicePublishingBlu(ctx context.Context, gatewayDevice, mac string, clea
 	if err != nil {
 		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
-	kvKey := "follow/shelly-blu/" + mac
+	kvKey := "publish/shelly-blu/" + mac
 
 	fmt.Printf("Configuring follow for BLU MAC %s...\n", mac)
 	_, err = myhome.Foreach(ctx, log, gatewayDevice, options.Via, doSetKVS, []string{kvKey, string(valueBytes)})
@@ -164,7 +164,7 @@ func addDevicePublishingBlu(ctx context.Context, gatewayDevice, mac string, clea
 // listDevicesPublishingBlu lists all Shelly devices that publish the given BLU MAC address
 func listDevicesPublishingBlu(ctx context.Context, mac string) error {
 	log := hlog.Logger
-	kvKey := "follow/shelly-blu/" + mac
+	kvKey := "publish/shelly-blu/" + mac
 
 	// Query all known Shelly devices using "*" wildcard
 	_, err := myhome.Foreach(ctx, log, "*", options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
@@ -215,15 +215,15 @@ func enableBleGateway(ctx context.Context, log logr.Logger, via types.Channel, d
 	return resp, nil
 }
 
-// clearBluFollows deletes all follow/shelly-blu/* KVS entries to enable publish-all mode
+// clearBluFollows deletes all publish/shelly-blu/* KVS entries to enable publish-all mode
 func clearBluFollows(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
 	}
 
-	// List all keys with the follow/shelly-blu/ prefix
-	kvsPrefix := "follow/shelly-blu/"
+	// List all keys with the publish/shelly-blu/ prefix
+	kvsPrefix := "publish/shelly-blu/"
 	keys, err := kvs.ListKeys(ctx, log, via, sd, kvsPrefix+"*")
 	if err != nil {
 		log.Info("No existing BLU follow entries to clear", "device", sd.Id())
@@ -261,6 +261,17 @@ func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device de
 	return kvs.SetKeyValue(ctx, log, via, sd, key, value)
 }
 
+// doDeleteKVS is a helper function for deleting a KVS entry on Shelly devices
+func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	sd, ok := device.(*shelly.Device)
+	if !ok {
+		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+	}
+	key := args[0]
+	log.Info("Deleting publish config", "key", key, "device", sd.Id())
+	return kvs.DeleteKey(ctx, log, via, sd, key)
+}
+
 // uploadScript is a helper function to upload and start scripts on Shelly devices
 func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
@@ -278,4 +289,100 @@ func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, devic
 	}
 	fmt.Printf("✓ Successfully uploaded %s to %s (id: %d)\n", scriptName, sd.Name(), id)
 	return id, nil
+}
+
+// deleteScript is a helper function to stop and delete scripts on Shelly devices
+func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	sd, ok := device.(*shelly.Device)
+	if !ok {
+		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+	}
+	scriptName := args[0]
+	fmt.Printf(". Removing %s from %s...\n", scriptName, sd.Name())
+	out, err := mhscript.DeleteWithVersion(ctx, log, via, sd, scriptName)
+	if err != nil {
+		fmt.Printf("✗ %v\n", err)
+		return nil, err
+	}
+	fmt.Printf("✓ Successfully removed %s from %s\n", scriptName, sd.Name())
+	return out, nil
+}
+
+var UnpublishCmd = &cobra.Command{
+	Use:   "unpublish <gateway-device> [blu-device]",
+	Short: "Remove BLU publisher configuration and blu-publisher script",
+	Long: `Remove BLU publisher configuration from a Shelly gateway device.
+
+When [blu-device] is omitted, removes all publish/shelly-blu/* KVS entries and
+stops/deletes the blu-publisher.js script.
+
+When [blu-device] is provided, removes only that device's KVS entry and
+stops/deletes the blu-publisher.js script.
+
+The [blu-device] can be specified as:
+- MAC address: "e8:e0:7e:a6:0c:6f", "E8E07EA60C6F", "e8-e0-7e-a6-0c-6f"
+- Device ID: "shellyblu-e8e07ea60c6f"
+- Device name: "motion-sensor-hallway"
+
+Examples:
+  # Remove all BLU publish config and script
+  myhome ctl blu unpublish gateway-device
+
+  # Remove one BLU device and script
+  myhome ctl blu unpublish gateway-device motion-sensor-hallway`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		gatewayDevice := args[0]
+
+		if len(args) == 1 {
+			return removePublishAll(cmd.Context(), gatewayDevice)
+		}
+
+		mac, err := mhblu.ResolveMac(cmd.Context(), args[1])
+		if err != nil {
+			return fmt.Errorf("failed to resolve BLU device %q: %w", args[1], err)
+		}
+		return removeDevicePublishing(cmd.Context(), gatewayDevice, mac)
+	},
+}
+
+// removePublishAll removes all BLU follow KVS entries and deletes blu-publisher.js
+func removePublishAll(ctx context.Context, gatewayDevice string) error {
+	log := hlog.Logger
+
+	fmt.Printf("Clearing all BLU follow entries on %s...\n", gatewayDevice)
+	_, err := myhome.Foreach(ctx, log, gatewayDevice, options.Via, clearBluFollows, []string{})
+	if err != nil {
+		return fmt.Errorf("failed to clear BLU follows: %w", err)
+	}
+
+	fmt.Printf("Removing blu-publisher.js script...\n")
+	_, err = myhome.Foreach(ctx, log, gatewayDevice, options.Via, deleteScript, []string{"blu-publisher.js"})
+	if err != nil {
+		return fmt.Errorf("failed to remove script: %w", err)
+	}
+
+	fmt.Printf("✓ BLU publish config removed from %s\n", gatewayDevice)
+	return nil
+}
+
+// removeDevicePublishing removes a specific BLU follow KVS entry and deletes blu-publisher.js
+func removeDevicePublishing(ctx context.Context, gatewayDevice, mac string) error {
+	log := hlog.Logger
+	kvKey := "publish/shelly-blu/" + mac
+
+	fmt.Printf("Removing follow entry for BLU MAC %s from %s...\n", mac, gatewayDevice)
+	_, err := myhome.Foreach(ctx, log, gatewayDevice, options.Via, doDeleteKVS, []string{kvKey})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Removing blu-publisher.js script...\n")
+	_, err = myhome.Foreach(ctx, log, gatewayDevice, options.Via, deleteScript, []string{"blu-publisher.js"})
+	if err != nil {
+		return fmt.Errorf("failed to remove script: %w", err)
+	}
+
+	fmt.Printf("✓ BLU publish config for MAC %s removed from %s\n", mac, gatewayDevice)
+	return nil
 }

--- a/myhome/ctl/shelly/follow/shelly.go
+++ b/myhome/ctl/shelly/follow/shelly.go
@@ -12,6 +12,7 @@ import (
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,23 +27,32 @@ var (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "follow <follower-device> <followed-device>",
-	Short: "Configure Shelly device to follow another Shelly device status",
-	Long: `Configure Shelly device to follow another Shelly device with two modes:
+	Use:   "follow <follower-device> [followed-device]",
+	Short: "Configure Shelly device to follow another Shelly device, or list followed devices",
+	Long: `Configure Shelly device to follow another Shelly device status.
 
+When called with only <follower-device>, lists the currently followed Shelly devices.
+
+Two follow modes when configuring:
 1. activation-only: Follower turns on when followed device activates, then uses auto-off timeout.
-   This is the mode BLU motion sensor followers use. Automatically enabled when --auto-off is provided.
-   
+   Automatically enabled when --auto-off is provided.
 2. full: Follower mirrors both activation and deactivation of the followed device (default).
 
 Examples:
+  # List followed Shelly devices
+  myhome ctl shelly follow hallway-light
+
   # Full mirror mode (default) - follows both ON and OFF
   myhome ctl shelly follow hallway-light office-switch
-  
+
   # Activation-only mode - turns on for 5 minutes when motion detected (--auto-off implies activation-only)
   myhome ctl shelly follow hallway-light motion-sensor --auto-off=300`,
-	Args: cobra.ExactArgs(2),
+	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 {
+			return listFollowedShellyDevices(cmd.Context(), args[0])
+		}
+
 		followerDevice := args[0]
 		followedDevice := args[1]
 
@@ -61,28 +71,17 @@ Examples:
 		}
 
 		// Build JSON payload for status-listener.js
-		payload := make(map[string]any)
-		payload["switch_id"] = shellyFlagSwitchID
-		payload["follow_id"] = shellyFlagFollowID
-
-		// Determine follow mode: activation-only if auto-off is provided, otherwise full
-		var followMode string
-		if cmd.Flags().Changed("auto-off") && shellyFlagAutoOff > 0 {
-			followMode = "activation-only"
-			payload["auto_off"] = shellyFlagAutoOff
-		} else if cmd.Flags().Changed("follow-mode") {
-			// Allow explicit override if needed
-			if shellyFlagFollowMode != "activation-only" && shellyFlagFollowMode != "full" {
-				return fmt.Errorf("invalid follow-mode: %q (must be 'activation-only' or 'full')", shellyFlagFollowMode)
-			}
-			followMode = shellyFlagFollowMode
-			if cmd.Flags().Changed("auto-off") {
-				payload["auto_off"] = shellyFlagAutoOff
-			}
-		} else {
-			followMode = "full" // default
+		payload, err := buildShellyFollowPayload(shellyFollowOptions{
+			switchID:      shellyFlagSwitchID,
+			followID:      shellyFlagFollowID,
+			followMode:    shellyFlagFollowMode,
+			autoOff:       shellyFlagAutoOff,
+			autoOffSet:    cmd.Flags().Changed("auto-off"),
+			followModeSet: cmd.Flags().Changed("follow-mode"),
+		})
+		if err != nil {
+			return err
 		}
-		payload["follow_mode"] = followMode
 
 		valueBytes, err := json.Marshal(payload)
 		if err != nil {
@@ -116,6 +115,50 @@ func init() {
 	Cmd.Flags().IntVar(&shellyFlagAutoOff, "auto-off", 0, "Seconds before auto turn off (only for activation-only mode, 0 to disable)")
 }
 
+var UnfollowCmd = &cobra.Command{
+	Use:   "unfollow <follower-device> <followed-device>",
+	Short: "Remove Shelly follow configuration and status-listener script",
+	Long: `Remove follow configuration between two Shelly devices.
+
+Deletes the KVS key that configures the follow relationship and stops/deletes
+the status-listener.js script from the follower device.
+
+Examples:
+  myhome ctl shelly unfollow hallway-light office-switch`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		followerDevice := args[0]
+		followedDevice := args[1]
+
+		followedDevices, err := myhome.TheClient.LookupDevices(cmd.Context(), followedDevice)
+		if err != nil {
+			return fmt.Errorf("failed to lookup followed device: %w", err)
+		}
+		if len(*followedDevices) == 0 {
+			return fmt.Errorf("followed device not found: %q", followedDevice)
+		}
+		followedDeviceId := (*followedDevices)[0].Id()
+		if followedDeviceId == "" {
+			return fmt.Errorf("invalid followed device ID: %q", followedDevice)
+		}
+
+		kvKey := "follow/status/" + followedDeviceId
+
+		_, err = myhome.Foreach(cmd.Context(), hlog.Logger, followerDevice, options.Via, doDeleteKVS, []string{kvKey})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("\nRemoving status-listener.js script...\n")
+		_, err = myhome.Foreach(cmd.Context(), hlog.Logger, followerDevice, options.Via, deleteScript, []string{"status-listener.js"})
+		if err != nil {
+			return fmt.Errorf("failed to remove script: %w", err)
+		}
+
+		return nil
+	},
+}
+
 // doSetKVS is a helper function for setting KVS entries on Shelly devices
 func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
@@ -126,6 +169,17 @@ func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device de
 	value := args[1]
 	log.Info("Setting follow config", "key", key, "value", value, "device", sd.Id())
 	return kvs.SetKeyValue(ctx, log, via, sd, key, value)
+}
+
+// doDeleteKVS is a helper function for deleting KVS entries on Shelly devices
+func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	sd, ok := device.(*shelly.Device)
+	if !ok {
+		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+	}
+	key := args[0]
+	log.Info("Deleting follow config", "key", key, "device", sd.Id())
+	return kvs.DeleteKey(ctx, log, via, sd, key)
 }
 
 // uploadScript is a helper function to upload and start scripts on Shelly devices
@@ -145,4 +199,88 @@ func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, devic
 	}
 	fmt.Printf("✓ Successfully uploaded %s to %s (id: %d)\n", scriptName, sd.Name(), id)
 	return id, nil
+}
+
+// listFollowedShellyDevices lists the Shelly devices followed by the given follower device
+func listFollowedShellyDevices(ctx context.Context, followerDevice string) error {
+	log := hlog.Logger
+	_, err := myhome.Foreach(ctx, log, followerDevice, options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+		sd, ok := device.(*shelly.Device)
+		if !ok {
+			return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+		}
+
+		resp, err := kvs.GetManyValues(ctx, log, via, sd, "follow/status/*")
+		if err != nil {
+			return nil, fmt.Errorf("failed to list followed Shelly devices: %w", err)
+		}
+
+		if len(resp.Items) == 0 {
+			fmt.Printf("No followed Shelly devices on %s\n", sd.Name())
+			return nil, nil
+		}
+
+		fmt.Printf("Followed Shelly devices on %s:\n", sd.Name())
+		for key, value := range resp.Items {
+			deviceId := strings.TrimPrefix(key, "follow/status/")
+			fmt.Printf("  %s: %v\n", deviceId, value)
+		}
+		return nil, nil
+	}, []string{})
+	return err
+}
+
+// deleteScript is a helper function to stop and delete scripts on Shelly devices
+func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	sd, ok := device.(*shelly.Device)
+	if !ok {
+		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
+	}
+	scriptName := args[0]
+	fmt.Printf(". Removing %s from %s...\n", scriptName, sd.Name())
+	out, err := mhscript.DeleteWithVersion(ctx, log, via, sd, scriptName)
+	if err != nil {
+		fmt.Printf("✗ %v\n", err)
+		return nil, err
+	}
+	fmt.Printf("✓ Successfully removed %s from %s\n", scriptName, sd.Name())
+	return out, nil
+}
+
+type shellyFollowOptions struct {
+	switchID      string
+	followID      string
+	followMode    string
+	autoOff       int
+	autoOffSet    bool
+	followModeSet bool
+}
+
+// buildShellyFollowPayload constructs the KVS payload for status-listener.js.
+// Follow mode is inferred: activation-only when autoOffSet+autoOff>0, explicit
+// when followModeSet, otherwise full.
+func buildShellyFollowPayload(opts shellyFollowOptions) (map[string]any, error) {
+	payload := map[string]any{
+		"switch_id": opts.switchID,
+		"follow_id": opts.followID,
+	}
+
+	var followMode string
+	switch {
+	case opts.autoOffSet && opts.autoOff > 0:
+		followMode = "activation-only"
+		payload["auto_off"] = opts.autoOff
+	case opts.followModeSet:
+		if opts.followMode != "activation-only" && opts.followMode != "full" {
+			return nil, fmt.Errorf("invalid follow-mode: %q (must be 'activation-only' or 'full')", opts.followMode)
+		}
+		followMode = opts.followMode
+		if opts.autoOffSet {
+			payload["auto_off"] = opts.autoOff
+		}
+	default:
+		followMode = "full"
+	}
+	payload["follow_mode"] = followMode
+	return payload, nil
 }

--- a/myhome/ctl/shelly/follow/shelly_test.go
+++ b/myhome/ctl/shelly/follow/shelly_test.go
@@ -1,0 +1,120 @@
+package follow
+
+import "testing"
+
+func TestBuildShellyFollowPayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    shellyFollowOptions
+		want    map[string]any
+		wantErr bool
+	}{
+		{
+			name: "defaults: full mode, no auto-off",
+			opts: shellyFollowOptions{
+				switchID: "switch:0",
+				followID: "switch:0",
+			},
+			want: map[string]any{
+				"switch_id":   "switch:0",
+				"follow_id":   "switch:0",
+				"follow_mode": "full",
+			},
+		},
+		{
+			name: "activation-only via --auto-off",
+			opts: shellyFollowOptions{
+				switchID:   "switch:0",
+				followID:   "switch:1",
+				autoOff:    300,
+				autoOffSet: true,
+			},
+			want: map[string]any{
+				"switch_id":   "switch:0",
+				"follow_id":   "switch:1",
+				"follow_mode": "activation-only",
+				"auto_off":    300,
+			},
+		},
+		{
+			name: "--auto-off=0 does not trigger activation-only",
+			opts: shellyFollowOptions{
+				switchID:   "switch:0",
+				followID:   "switch:0",
+				autoOff:    0,
+				autoOffSet: true,
+			},
+			want: map[string]any{
+				"switch_id":   "switch:0",
+				"follow_id":   "switch:0",
+				"follow_mode": "full",
+			},
+		},
+		{
+			name: "explicit --follow-mode full",
+			opts: shellyFollowOptions{
+				switchID:      "switch:0",
+				followID:      "switch:0",
+				followMode:    "full",
+				followModeSet: true,
+			},
+			want: map[string]any{
+				"switch_id":   "switch:0",
+				"follow_id":   "switch:0",
+				"follow_mode": "full",
+			},
+		},
+		{
+			name: "explicit --follow-mode activation-only with auto-off",
+			opts: shellyFollowOptions{
+				switchID:      "switch:0",
+				followID:      "switch:0",
+				followMode:    "activation-only",
+				followModeSet: true,
+				autoOff:       60,
+				autoOffSet:    true,
+			},
+			want: map[string]any{
+				"switch_id":   "switch:0",
+				"follow_id":   "switch:0",
+				"follow_mode": "activation-only",
+				"auto_off":    60,
+			},
+		},
+		{
+			name: "invalid follow-mode returns error",
+			opts: shellyFollowOptions{
+				followMode:    "mirror",
+				followModeSet: true,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildShellyFollowPayload(tt.opts)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("buildShellyFollowPayload() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			for k, wantV := range tt.want {
+				gotV, ok := got[k]
+				if !ok {
+					t.Errorf("missing key %q in payload", k)
+					continue
+				}
+				if gotV != wantV {
+					t.Errorf("payload[%q] = %v (%T), want %v (%T)", k, gotV, gotV, wantV, wantV)
+				}
+			}
+			for k := range got {
+				if _, ok := tt.want[k]; !ok {
+					t.Errorf("unexpected key %q in payload", k)
+				}
+			}
+		})
+	}
+}

--- a/myhome/ctl/shelly/main.go
+++ b/myhome/ctl/shelly/main.go
@@ -26,6 +26,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(call.Cmd)
 	Cmd.AddCommand(follow.Cmd)
+	Cmd.AddCommand(follow.UnfollowCmd)
 	Cmd.AddCommand(jobs.Cmd)
 	Cmd.AddCommand(mqtt.Cmd)
 	Cmd.AddCommand(kvs.Cmd)


### PR DESCRIPTION
## Summary

- **`shelly unfollow` / `blu unfollow` / `blu unpublish`** — new commands to cleanly remove follow/publish KVS entries and stop+delete the associated scripts from follower/gateway devices
- **BLU namespace fix** — `blu-publisher.js` and `publish.go` now use `publish/shelly-blu/<mac>` instead of `follow/shelly-blu/<mac>`, preventing collision with `blu-listener.js` configs that use `follow/shelly-blu/<mac>`
- **`shelly follow` single-arg listing** — `shelly follow <device>` now lists currently followed Shelly devices, mirroring the `blu follow` behaviour
- **`ResolveMac` fix** — accepts all BLU device ID prefixes (`shellyblumotion1-`, `shellyblubutton1-`, …) not just `shellyblu-`; extracts `macFromBluDeviceID` helper for testability
- **Payload builders extracted** — `buildShellyFollowPayload` and `buildBluFollowPayload` pulled out of `RunE` closures into pure functions
- **Unit tests** — 36 test cases across 4 packages: `NormalizeMac`, `macFromBluDeviceID`, `buildShellyFollowPayload`, `buildBluFollowPayload`, `validateIlluminanceValue`

## Test plan

- [ ] `make test` passes
- [ ] `go test ./internal/tools/... ./internal/myhome/blu/... ./myhome/ctl/shelly/follow/... ./myhome/ctl/blu/follow/...`
- [ ] `myhome ctl shelly follow <device>` (1 arg) lists followed devices
- [ ] `myhome ctl shelly unfollow <follower> <followed>` removes KVS + script
- [ ] `myhome ctl blu unfollow <follower> <blu-device>` removes KVS + script
- [ ] `myhome ctl blu unpublish <gateway>` removes all publish entries + script
- [ ] `myhome ctl blu unpublish <gateway> <blu-device>` removes single entry + script
- [ ] `myhome ctl blu follow <device> <shellyblumotion1-*>` resolves MAC correctly<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(ctl): add unfollow/unpublish commands, fix BLU namespace collision, add tests ([1f48021](https://github.com/asnowfix/home-automation/commit/1f4802196bbb66fc5adb4dc148796b6009a3801a))
<!-- END-AUTO-GENERATED-COMMITS -->