### PR TITLE
fix(ctl): resolve flag shorthand conflicts in wifi config subcommand

### DIFF
--- a/myhome/ctl/ctl.go
+++ b/myhome/ctl/ctl.go
@@ -125,7 +125,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.PersistentFlags().StringVarP(&options.Flags.CpuProfile, "cpuprofile", "P", "", "write CPU profile to `file`")
+	Cmd.PersistentFlags().StringVarP(&options.Flags.CpuProfile, "cpuprofile", "C", "", "write CPU profile to `file`")
 	Cmd.PersistentFlags().DurationVarP(&options.Flags.Wait, "wait", "w", options.COMMAND_DEFAULT_TIMEOUT, "Maximum time to wait for command to finish (0 = wait indefinitely)")
 	Cmd.PersistentFlags().BoolVarP(&options.Flags.Verbose, "verbose", "v", false, "verbose output (info level, mutually exclusive with --debug and --quiet)")
 	Cmd.PersistentFlags().BoolVarP(&options.Flags.Debug, "debug", "d", false, "debug output (debug level, shows V(1) logs, mutually exclusive with --verbose and --quiet)")

--- a/myhome/ctl/shelly/wifi/config.go
+++ b/myhome/ctl/shelly/wifi/config.go
@@ -41,7 +41,7 @@ func init() {
 
 	configCmd.Flags().StringVarP(&flags.Ssid, "ssid", "S", "", "WiFi SSID")
 	configCmd.Flags().StringVarP(&flags.Password, "password", "P", "", "WiFi password")
-	configCmd.Flags().StringVarP(&flags.Ip, "ip", "I", "", "Static IP address (Station mode only)")
+	configCmd.Flags().StringVarP(&flags.Ip, "ip", "i", "", "Static IP address (Station mode only)")
 	configCmd.Flags().StringVarP(&flags.Netmask, "netmask", "N", "", "Static netmask (Access Point mode only)")
 	configCmd.Flags().StringVarP(&flags.Gateway, "gateway", "g", "", "Static gateway (Access Point mode only)")
 }

--- a/myhome/main.go
+++ b/myhome/main.go
@@ -108,7 +108,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
-	Cmd.PersistentFlags().StringVarP(&options.Flags.CpuProfile, "cpuprofile", "P", "", "write CPU profile to `file`")
+	Cmd.PersistentFlags().StringVarP(&options.Flags.CpuProfile, "cpuprofile", "C", "", "write CPU profile to `file`")
 	Cmd.PersistentFlags().BoolVarP(&options.Flags.Verbose, "verbose", "v", false, "verbose output (info level, mutually exclusive with --debug and --quiet)")
 	Cmd.PersistentFlags().BoolVarP(&options.Flags.Debug, "debug", "d", false, "debug output (debug level, one level higher than --verbose, mutually exclusive with --verbose and --quiet)")
 	Cmd.PersistentFlags().BoolVarP(&options.Flags.Quiet, "quiet", "q", false, "quiet output (error level only, mutually exclusive with --verbose and --debug)")


### PR DESCRIPTION
## Summary

- `-P` was registered twice: globally for `--cpuprofile` and locally for `--password` in `shelly wifi config`, causing a panic on any invocation of that subcommand
- `-I` was similarly registered twice: globally for `--instance` and locally for `--ip` in `shelly wifi config`

## Fix

- `--cpuprofile` shorthand: `-P` → `-C` (`myhome/main.go`, `myhome/ctl/ctl.go`)
- `--ip` shorthand: `-I` → `-i` (`myhome/ctl/shelly/wifi/config.go`)

Both `-C` and `-i` are unused across the full persistent-flag hierarchy.

## Test plan

- [ ] `go run ./myhome ctl shelly wifi config <device>` no longer panics
- [ ] `go run ./myhome ctl shelly wifi config <device> --password <pw>` works (`-P` now routes to `--password`)
- [ ] `go run ./myhome ctl shelly wifi config <device> -i <ip>` works
- [ ] `make test` passes<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(ctl): resolve flag shorthand conflicts in wifi config subcommand ([d8192b4](https://github.com/asnowfix/home-automation/commit/d8192b4c90a042db577dafe03f3048ab42bf6d9d))
<!-- END-AUTO-GENERATED-COMMITS -->