### PR TITLE
docs(agents): resilience rules, observability pattern, MCP worktree fix + pool events

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "shelly": {
       "type": "stdio",
-      "command": "go",
-      "args": ["run", "./myhome", "ctl", "--mqtt-broker", "tcp://192.168.1.2:1883", "mcp"]
+      "command": "sh",
+      "args": ["-c", "(test -f internal/myhome/ui/static/alpine.min.js || go generate ./internal/myhome/ui/...) && exec go run ./myhome ctl --mqtt-broker tcp://192.168.1.2:1883 mcp"]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,32 @@ MyHome is designed with the following core principles (from README):
 
 These principles ensure resilience, privacy, and independence from third-party services, while remaining compatible with the manufacturers' own apps (e.g., Shelly app & Cloud).
 
+### Resilience Rules for Agents
+
+Two rules must hold for every change. Check them before marking a task done.
+
+#### Rule 1 — Internet-optional
+
+The system must stay fully functional on the local LAN when the internet is unreachable. Any code that reaches an external URL (weather APIs, firmware update servers, cloud dashboards, package registries at runtime) must:
+
+1. Set an explicit HTTP/dial timeout (no infinite waits).
+2. Return a cached value, a zero value, or a no-op — never an error that propagates up and kills unrelated functionality.
+3. Log the failure at `warn` level and continue.
+
+**Violation examples**: a goroutine that blocks indefinitely on a DNS lookup; a startup function that `log.Fatal`s when a weather endpoint is unreachable; an HTTP handler that returns 500 because a cloud API is down.
+
+**Test signal**: if you add an external call, add a test (or at minimum a comment) that proves the feature degrades cleanly when the call fails.
+
+#### Rule 2 — Daemon-optional per device
+
+Each Shelly device must keep operating normally when the `myhome` daemon is down. Device scripts run on the device firmware (Espruino/JS) and must not rely on the daemon for their core function.
+
+- Cross-device flows implemented *through* the daemon (device A → MQTT → daemon → device B) are acceptable but must be documented as "degraded when daemon is down".
+- A device's local automation (heater script, watchdog, BLU listener) must keep working with only the MQTT broker running and no daemon.
+- When refactoring logic from a device script into the daemon, the PR description must name the degraded mode explicitly.
+
+**Violation examples**: moving a script's keep-alive timer into a daemon goroutine; making a device's switch behaviour depend on a live RPC call to `myhome/rpc`; removing a device-side fallback because "the daemon handles it now".
+
 ---
 
 ## Shelly Device Scripting
@@ -312,7 +338,69 @@ function loadData(callback) {
 }
 ```
 
-#### Script Lifecycle Logging
+#### Observability: Script Event Emissions
+
+Scripts must call `Shelly.emitEvent(name, data)` for any change a human operator might want to know about — schedule decisions, safety actions, pump start/stop, mode changes. These flow through the device's standard `NotifyEvent` MQTT notification (`<device_id>/events/rpc`), are picked up by the daemon's Gen2 listener (`internal/myhome/shelly/gen2/listener.go`), and are stored in the events database where the web UI and `myhome ctl events` can display them.
+
+#### When to emit
+
+| Category | Examples | Severity |
+|---|---|---|
+| Schedule decisions | daily run-window computed, summer/winter mode selected | `info` |
+| Start/stop | pump started at speed X, pump stopped | `info` |
+| Safety actions | water-supply protection activated, anti-cycling fuse tripped | `warn` |
+| Restoration | pump restored after water supply turned off | `info` |
+
+**Rule of thumb**: if it would make sense as a line in a physical maintenance logbook, emit it.
+
+#### How to call
+
+```javascript
+// Fire-and-forget — does NOT count against the 5-concurrent-RPC limit.
+Shelly.emitEvent("pool.run_window", {
+  mode: "summer",
+  max_temp_c: 28.5,
+  run_hours: 7.3,
+  start_h: 9.5,   // fractional hour — 9.5 means 09:30
+  stop_h: 16.8
+});
+```
+
+The firmware publishes a standard `NotifyEvent` to `<device_id>/events/rpc` with `component: "script:<id>"`. The daemon's Gen2 listener (`internal/myhome/shelly/gen2/listener.go`) catches this and records it exactly like any other device event. The second argument is stored **nested under a `"data"` key** in the event's `data` column:
+
+```json
+{
+  "component": "script:1",
+  "event": "pool.run_window",
+  "id": 1,
+  "ts": 1234567890,
+  "data": { "mode": "summer", "max_temp_c": 28.5, "run_hours": 7.3, "start_h": 9.5, "stop_h": 16.8 }
+}
+```
+
+This is proven by captured real-device traffic — see `pkg/shelly/mqtt/testdata/notify_event__shelly1minig3__script_3__remote_button_event.json`.
+
+#### Naming convention
+
+- Format: `<script_name>.<verb>` — lowercase, underscores only: `pool.pump_start`, `pool.fuse_tripped`.
+- Use the script's `SCRIPT_NAME` constant as the prefix so events are grouped in the UI.
+- Name the specific occurrence, not a generic noun: `pool.pump_start` not `pool.event`.
+
+#### Data payload guidelines
+
+- Include enough context to understand the event without cross-referencing other state.
+- Use `snake_case` field names.
+- Include units in the name when non-obvious: `max_temp_c`, `run_hours`, not `temp`, `run`.
+- Do not include timestamps — the event already has `ts`.
+- Keep payloads small (under ~200 bytes). Avoid embedding arrays or large structures.
+
+#### Severity for new event types
+
+Severity is assigned by `internal/myhome/shelly/gen2/listener.go:severityFor()`. New event names default to `"info"`. When you add events that represent a degraded state or a safety interrupt, also add the event name to `severityFor()` with `"warn"` or `"alarm"` — do this in the same commit as the JS change.
+
+---
+
+### Script Lifecycle Logging
 
 Always add startup and stop logging to Shelly scripts:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ go run ./myhome ctl shelly script debug <device> true
 go run ./tools/classify-events [events-dir] [testdata-dir]   # classify raw event dumps → pkg/shelly/mqtt/testdata/
 ```
 
-To query live devices, use the built-in MCP server (`shelly_list`, `shelly_call` tools). It is pre-configured in `.mcp.json` with MQTT broker `tcp://192.168.1.2:1883` and approved via `enabledMcpjsonServers` in `.claude/settings.json`. Restart Claude Code to activate.
+To query live devices, use the built-in MCP server (`shelly_list`, `shelly_call` tools). It is pre-configured in `.mcp.json` with MQTT broker `tcp://192.168.1.2:1883` and approved via `enabledMcpjsonServers` in `.claude/settings.json`. The `.mcp.json` command automatically runs `go generate ./internal/myhome/ui/...` on first use in a fresh worktree (fetches CSS/JS assets required to compile); this needs internet access once per worktree. Restart Claude Code to activate.
 
 `make test` is canonical — never bare `go test ./...` (it skips workspace sub-modules). New CI test commands must also invoke `make test`, not go directly to `go test`.
 
@@ -89,6 +89,8 @@ Ports: 6080 (dev web UI), 80 (systemd), 6060 (pprof), 9100 (Prometheus).
 - **SQLite database paths**: new databases use a plain relative filename (e.g. `"foo.db"`), matching `myhome.db`. Do not invent a new default directory (e.g. `~/.myhome/`, XDG paths) unless all existing databases already use it. If a flag or config key lets the user supply an absolute path, the `NewStorage` constructor must call `os.MkdirAll(filepath.Dir(path), 0o755)` before opening the file — SQLite cannot create missing parent directories.
 - **File moves**: always `git mv`, never delete-and-recreate (preserves `git log --follow` history).
 - **Non-trivial tasks**: create a plan file under `docs/` before writing code; mark each phase done before starting the next; commit plan updates alongside the implementation.
+- **Resilience — internet-optional**: the system must remain fully operational on the local network when the internet is unreachable. Features that use remote sources (weather, cloud APIs, firmware checks) must time out and degrade gracefully; they must not block or break local operation. Always add a timeout and a fallback/no-op path before shipping any code that calls an external URL.
+- **Resilience — daemon-optional per device**: each Shelly device must continue operating normally when the `myhome` daemon is down. Cross-device automation flows (device A triggers device B via the daemon) may pause during an outage, but no device's core function may depend solely on the daemon. Before moving logic from a device script into the daemon, explicitly document the degraded mode in the PR description.
 
 ### Shelly JavaScript
 

--- a/internal/myhome/shelly/gen2/listener.go
+++ b/internal/myhome/shelly/gen2/listener.go
@@ -257,7 +257,8 @@ func severityFor(event string) string {
 	switch event {
 	case "smoke.alarm", "smoke.alarm_test", "smoke.alarm_off":
 		return "alarm"
-	case "battery.low", "ota_error", "switch.active_power_change":
+	case "battery.low", "ota_error", "switch.active_power_change",
+		"pool.fuse_tripped", "pool.water_supply_protected":
 		return "warn"
 	}
 	if strings.HasPrefix(event, "input.button_") ||

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -994,6 +994,11 @@ function fuseAllowOn() {
     FUSE_TRIPPED = true;
     FUSE_TRIP_TIME = now;
     turnOffAllSwitches();
+    Shelly.emitEvent("pool.fuse_tripped", {
+      changes: FUSE_CHANGES.length,
+      window_s: FUSE_WINDOW_MS / 1000,
+      cooldown_s: FUSE_COOLDOWN_MS / 1000
+    });
     return false;
   }
 
@@ -1152,6 +1157,7 @@ function handleWaterSupply(waterSupplyActive) {
     STATE.savedOutput = STATE.activeOutput;
     log("Water supply ON - saving current output:", STATE.savedOutput);
 
+    Shelly.emitEvent("pool.water_supply_protected", {saved_output: STATE.savedOutput});
     activateOutput(-1, function() {
       log("All pumps turned off for water supply protection");
     });
@@ -1159,6 +1165,7 @@ function handleWaterSupply(waterSupplyActive) {
     // Water supply is OFF (signal is LOW after invert) - restore previous state
     log("Water supply OFF - restoring output:", STATE.savedOutput);
 
+    Shelly.emitEvent("pool.water_supply_restored", {restored_output: STATE.savedOutput});
     activateOutput(STATE.savedOutput, function() {
       log("Pump restored after water supply turned off");
     });
@@ -1719,6 +1726,7 @@ function decideModeFromForecast() {
   log('Selected mode:', newMode, maxTemp > CONFIG.temperatureThreshold ? '(above threshold)' : '(below threshold)');
 
   if (newMode !== 'summer') {
+    Shelly.emitEvent("pool.run_window", {mode: "winter", max_temp_c: maxTemp});
     updateScheduleMode(newMode, null, null);
     return;
   }
@@ -1747,6 +1755,14 @@ function decideModeFromForecast() {
   log('Run hours:', Math.round(runHours * 10) / 10,
       'Start:', Math.floor(startHour) + ':' + lpad2(Math.round((startHour % 1) * 60)),
       'Stop:',  Math.floor(stopHour)  + ':' + lpad2(Math.round((stopHour  % 1) * 60)));
+
+  Shelly.emitEvent("pool.run_window", {
+    mode: "summer",
+    max_temp_c: maxTemp,
+    run_hours: Math.round(runHours * 10) / 10,
+    start_h: Math.round(startHour * 100) / 100,
+    stop_h:  Math.round(stopHour  * 100) / 100
+  });
 
   updateScheduleMode(newMode, startHour, stopHour);
 }
@@ -1782,6 +1798,7 @@ function doStart(speed, reason) {
   }
 
   log('Starting pump at speed:', speed, '-> switch:', switchId);
+  Shelly.emitEvent("pool.pump_start", {speed: speed, switch_id: switchId});
   activateOutput(switchId);
 }
 
@@ -1800,6 +1817,7 @@ function doStop(reason) {
     // Continue to turn off even with water supply active
   }
 
+  Shelly.emitEvent("pool.pump_stop", {reason: reason || "stop"});
   activateOutput(-1, function() {
     log('Pump stopped');
   });


### PR DESCRIPTION
## Summary

- **AGENTS.md / CLAUDE.md**: Add two resilience rules (internet-optional, daemon-optional per device) as a named section in AGENTS.md and a checklist item in CLAUDE.md conventions — gives agents a concrete pre-merge checklist.
- **AGENTS.md**: Add observability section covering `Shelly.emitEvent()` — when to emit, naming convention, payload guidelines, severity wiring, and proven JSON schema from captured device traffic.
- **.mcp.json**: Fix MCP server startup in fresh worktrees — wrap the `go run` in a shell that auto-runs `go generate ./internal/myhome/ui/...` when the static assets are missing, so the MCP server works without a manual pre-step.
- **CLAUDE.md**: Note the auto-generate behaviour so future worktree setup docs are accurate.
- **pool-pump.js / gen2/listener.go**: Wire up the first batch of `Shelly.emitEvent()` calls — `pool.run_window`, `pool.pump_start`, `pool.pump_stop`, `pool.fuse_tripped`, `pool.water_supply_protected`, `pool.water_supply_restored` — and register the two warn-severity events in `severityFor()`.

## Test plan

- [ ] Open a fresh worktree and verify the MCP server starts without needing a manual `make generate`
- [ ] Tail device MQTT events after a scheduled run and confirm `pool.run_window` and `pool.pump_start`/`pool.pump_stop` appear in `myhome ctl events`
- [ ] Manually trigger the anti-cycling fuse (rapid on/off) and confirm `pool.fuse_tripped` shows up with `warn` severity<!-- AUTO-GENERATED-COMMITS -->

## Commits

- docs(agents): add resilience principles, MCP worktree fix, and observability pattern ([0013c84](https://github.com/asnowfix/home-automation/commit/0013c84843710d673ed1645889d1afea52295a4b))
<!-- END-AUTO-GENERATED-COMMITS -->