### PR TITLE
Event Log UI bug-fix: device names, BLU timestamp, pretty JSON

### DIFF
--- a/docs/EVENT-LOG-UI-FIXES-PLAN.md
+++ b/docs/EVENT-LOG-UI-FIXES-PLAN.md
@@ -1,0 +1,131 @@
+# Event Log UI — bug-fix pass
+
+Status: **planned** (no code yet)
+
+## Context
+
+The devices Event Log page (`/event-log`) has three defects, treated here as **bug-fixes**
+(minimal, targeted — no architectural churn):
+
+1. **Raw device IDs** shown instead of friendly names. The row template already renders a
+   friendly name with the ID as a tooltip, but (a) we want the ID kept as its own right-most
+   column, and (b) BLU events never resolve a name because the BLU bridge stores a different
+   `device_id` than the one the device is registered under.
+2. **`1970-01-01` timestamps** on BLU events. `handleBLUEventBridge` records events without ever
+   setting `Ts`, so it defaults to `0` → epoch. (Gen2 does this correctly; BLU was never updated.)
+3. **Truncated one-line JSON** in the Data column. There is no JSON pretty-printer anywhere;
+   the only transform is a 60-char `truncate`.
+
+Decisions: Data cells are **collapsible** (compact preview, click to expand pretty JSON);
+**live SSE rows are enriched too** so they match the server-rendered table.
+
+Intended outcome: each row shows the friendly device name, the real receive time, a collapsible
+pretty-printed Data payload, and the raw device ID in the right-most column — both on load and on
+live updates.
+
+## Phases
+
+- [ ] **Phase 1** — BLU bridge: timestamp, canonical device id, populated Data
+- [ ] **Phase 2** — Events service: `Ts` safety-net default
+- [ ] **Phase 3** — Table template: name column, ID right-most, collapsible Data + client JS
+- [ ] **Phase 4** — SSE: enrich live event payload with device name
+- [ ] **Phase 5** — DRY name-resolution helper + daemon wiring
+- [ ] **Phase 6** — Tests + end-to-end verification
+
+## Changes
+
+### 1. BLU bridge — fix timestamp, device id, and empty Data
+`internal/myhome/shelly/blu/listener.go` → `handleBLUEventBridge` (lines ~160-250)
+
+- **Canonical device id (fixes name resolution + filtering):** replace `deviceID := data.Address`
+  with `deviceID := deviceIDFromCapabilities(data.Address, data)` — the same id the device is
+  registered under (`handleBLUEvent` line 270), so `GetDeviceByAny` matches the `id` column and the
+  friendly name resolves. Keep `data.Address` only for the Data payload below.
+- **Timestamp:** compute once near the top:
+  `ts := float64(time.Now().Unix()); if data.Timestamp != nil { ts = float64(*data.Timestamp) }`
+  (mirrors gen2 `listener.go:94-99`; the BTHome 0x50 `timestamp` is rarely present, so receipt time
+  is the fallback). Set `Ts: ts` on every `events.Event{...}` (motion, window, button, battery).
+- **Populate Data** (small enhancement so the Data column is informative and pretty-print has
+  something to show for BLU rows): build a compact `*string` JSON per event with the triggering
+  value(s) plus `address` and `rssi`, e.g. motion → `{"motion":1,"address":"…","rssi":-72}`.
+  Add a tiny local helper that `json.Marshal`s a `map[string]any` and returns `*string`.
+- Add `"time"` to the import block.
+
+### 2. Events service — safety net so no event ever shows 1970
+`myhome/events/service.go` → `Record` (lines 53-64)
+
+After defaulting `ReceivedAt`, add: `if e.Ts == 0 { e.Ts = e.ReceivedAt }`. Defensive: any source
+that forgets `Ts` falls back to receipt time instead of epoch. Cheap, broadly correct.
+
+### 3. Table template — name column, ID right-most, collapsible Data
+`internal/myhome/ui/events_template.go`
+
+- **`eventTemplateFuncs`** (lines 9-37): add `eventDataCell(s *string) template.HTML`:
+  - nil/empty → `""`.
+  - valid JSON (try `json.Indent`) → return
+    `<details class="event-data"><summary>{escaped 60-char preview}</summary><pre>{escaped pretty JSON}</pre></details>`
+    built from `template.HTMLEscapeString` parts, returned as `template.HTML`.
+  - not JSON → escaped raw text in a `<span>`.
+  - Keep `truncate` (reused for the preview).
+- **`eventRowTemplate`** (lines 41-48): new column order —
+  `Time | Device(name, fallback id) | Component | Event | Severity | Data | Device ID`.
+  Device cell: `{{if .DeviceName}}{{.DeviceName}}{{else}}{{.DeviceID}}{{end}}`.
+  Data cell: `{{eventDataCell .Data}}`. New right-most cell: `<td><code>{{.DeviceID}}</code></td>`.
+- **`eventsTableTemplate`** thead (lines 96-105): add `<th>Device ID</th>` as the last column.
+- **colspans**: `6 → 7` in the "Load more" rows of both `eventsRowsTemplate` (line 55) and
+  `eventsTableTemplate` (line 111).
+- **Client JS** in `eventLogPageHTML` (lines 203-219): rebuild the `eventlog` listener to emit the
+  same 7 columns — name column (use new `device_name`, fallback `device_id`), collapsible
+  `<details><summary>…</summary><pre>…</pre></details>` for data (pretty-print via
+  `JSON.stringify(JSON.parse(ev.data), null, 2)` with a try/catch fallback to raw), and the raw
+  `device_id` in a right-most `<code>` cell. Build via DOM nodes (current style) to avoid XSS.
+
+### 4. SSE — enrich live event payload with the device name
+`internal/myhome/ui/sse.go`
+
+- Add `nameFor func(string) string` field to `SSEBroadcaster` and a setter
+  `SetDeviceNameResolver(fn func(string) string)`.
+- Change `BroadcastEvent` (line 152) to marshal an enriched anonymous struct
+  `{ts, device_id, device_name, component, event, severity, data}` (resolve `device_name` via
+  `nameFor` when set) instead of broadcasting the raw `events.Event`. Keep the `"eventlog"` SSE
+  event name and all existing fields — only **add** `device_name` (the CLI follow command also
+  parses this payload, so the change must be additive).
+
+### 5. Reuse one name-resolution helper (DRY)
+`internal/myhome/ui/htmx.go`
+
+Extract the per-id lookup inside `deviceNameMap` (lines 254-267) into a small method
+`func (h *HTMXHandler) deviceName(id string) string` (GetDeviceByAny → MAC fallback → name).
+`deviceNameMap` calls it in a loop. This same logic backs the SSE resolver.
+
+### 6. Wire the resolver in the daemon
+`myhome/daemon/daemon.go` (around line 210, after `storage` at line 202 and the broadcaster)
+
+Call `sseBroadcaster.SetDeviceNameResolver(func(id string) string { … })` using `storage`
+(same lookup as `HTMXHandler.deviceName`). Wire it right after the broadcaster is created so live
+events resolve names.
+
+## Tests
+
+- `internal/myhome/shelly/blu/listener_test.go`: add a focused test for `handleBLUEventBridge`
+  feeding a motion payload through an in-memory `events.Service`, then `Store().Query` and assert:
+  `Ts != 0` (≈ now), `DeviceID == deviceIDFromCapabilities(addr, data)`, and `Data != nil` with the
+  expected JSON. Existing BLU tests don't touch the bridge, so no breakage.
+- `myhome/events/service_test.go`: assert `Record` of an event with `Ts == 0` stores
+  `Ts == ReceivedAt` (non-zero).
+- Run `make test` (canonical — covers go.work sub-modules).
+
+## Verification (end-to-end)
+
+1. `make build` (runs `go generate` first — required for embedded CSS/JS assets).
+2. `make test`.
+3. `make run`, open `http://localhost:6080/event-log`.
+   - Confirm columns: `Time | Device | Component | Event | Severity | Data | Device ID`.
+   - Trigger a BLU sensor (or use the `shelly_call`/MQTT mock) to emit a motion/window event.
+     Confirm the new row shows: real time (not 1970), friendly name (or shellyblu… id) in Device,
+     raw MAC/ID in the right-most column, and a collapsible Data cell that expands to indented JSON.
+   - Confirm a gen2 `script:N shelly-blu` row's Data expands to pretty JSON.
+   - Confirm the **live** row (appears without reload, via SSE) has the name column filled and the
+     same collapsible Data — i.e. matches a row after page reload.
+4. Sanity: the CLI event-follow still parses the `eventlog` SSE payload (only an additive
+   `device_name` field).

--- a/internal/myhome/shelly/blu/listener.go
+++ b/internal/myhome/shelly/blu/listener.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/events"
@@ -157,6 +158,16 @@ func StartBLUListenerWithEvents(ctx context.Context, mc mqtt.Client, registry De
 	return nil
 }
 
+// bluData marshals a map to a compact JSON *string for the event Data field.
+func bluData(fields map[string]any) *string {
+	b, err := json.Marshal(fields)
+	if err != nil {
+		return nil
+	}
+	s := string(b)
+	return &s
+}
+
 // handleBLUEventBridge maps BTHome object IDs to event log entries and tracker observations.
 func handleBLUEventBridge(ctx context.Context, log logr.Logger, payload []byte, eventSvc *events.Service, tracker *events.SensorDailyTracker) {
 	var data BLUEventData
@@ -167,70 +178,78 @@ func handleBLUEventBridge(ctx context.Context, log logr.Logger, payload []byte, 
 		return
 	}
 
-	// device_id = BLU sensor MAC address
-	deviceID := data.Address
+	// Use the canonical type-inferred device id so the name lookup in the UI
+	// can match the device registration record (which uses the same id).
+	deviceID := deviceIDFromCapabilities(data.Address, data)
+
+	// Use the device-side BTHome timestamp when available (0x50); fall back
+	// to the daemon's receive time so the event never displays as 1970-01-01.
+	ts := float64(time.Now().Unix())
+	if data.Timestamp != nil {
+		ts = float64(*data.Timestamp)
+	}
 
 	// Motion (0x21)
-	if data.Motion != nil {
-		if eventSvc != nil {
-			eventName := "motion.cleared"
-			if *data.Motion == 1 {
-				eventName = "motion.detected"
-			}
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "motion:0",
-				Event:     eventName,
-				Severity:  "info",
-			}); err != nil {
-				log.Error(err, "Failed to record motion event", "device_id", deviceID)
-			}
+	if data.Motion != nil && eventSvc != nil {
+		eventName := "motion.cleared"
+		if *data.Motion == 1 {
+			eventName = "motion.detected"
+		}
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "motion:0",
+			Event:     eventName,
+			Severity:  "info",
+			Data:      bluData(map[string]any{"motion": *data.Motion, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record motion event", "device_id", deviceID)
 		}
 	}
 
 	// Window (0x2D)
-	if data.Window != nil {
-		if eventSvc != nil {
-			eventName := "window.closed"
-			if *data.Window == 1 {
-				eventName = "window.opened"
-			}
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "window:0",
-				Event:     eventName,
-				Severity:  "info",
-			}); err != nil {
-				log.Error(err, "Failed to record window event", "device_id", deviceID)
-			}
+	if data.Window != nil && eventSvc != nil {
+		eventName := "window.closed"
+		if *data.Window == 1 {
+			eventName = "window.opened"
+		}
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "window:0",
+			Event:     eventName,
+			Severity:  "info",
+			Data:      bluData(map[string]any{"window": *data.Window, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record window event", "device_id", deviceID)
 		}
 	}
 
 	// Button (0x3A)
-	if data.Button != nil {
-		if eventSvc != nil {
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "button:0",
-				Event:     "button.push",
-				Severity:  "info",
-			}); err != nil {
-				log.Error(err, "Failed to record button event", "device_id", deviceID)
-			}
+	if data.Button != nil && eventSvc != nil {
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "button:0",
+			Event:     "button.push",
+			Severity:  "info",
+			Data:      bluData(map[string]any{"button": *data.Button, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record button event", "device_id", deviceID)
 		}
 	}
 
 	// Battery low
-	if data.Battery != nil && *data.Battery < 20 {
-		if eventSvc != nil {
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "battery",
-				Event:     "battery.low",
-				Severity:  "warn",
-			}); err != nil {
-				log.Error(err, "Failed to record battery.low event", "device_id", deviceID)
-			}
+	if data.Battery != nil && *data.Battery < 20 && eventSvc != nil {
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "battery",
+			Event:     "battery.low",
+			Severity:  "warn",
+			Data:      bluData(map[string]any{"battery": *data.Battery, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record battery.low event", "device_id", deviceID)
 		}
 	}
 

--- a/internal/myhome/shelly/blu/listener_test.go
+++ b/internal/myhome/shelly/blu/listener_test.go
@@ -3,9 +3,12 @@ package blu
 import (
 	"context"
 	"encoding/json"
-	"github.com/asnowfix/home-automation/internal/myhome"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/myhome/events"
 	"github.com/go-logr/logr"
 )
 
@@ -118,5 +121,62 @@ func TestHandleBLUEvent_NoSensorsNoCache(t *testing.T) {
 	}
 	if len(reg.sensorUpdates) != 0 {
 		t.Errorf("expected 0 cache updates, got %d", len(reg.sensorUpdates))
+	}
+}
+
+func newTestEventsService(t *testing.T) *events.Service {
+	t.Helper()
+	store, err := events.NewStorage(logr.Discard(), ":memory:")
+	if err != nil {
+		t.Fatalf("events.NewStorage: %v", err)
+	}
+	t.Cleanup(store.Close)
+	return events.NewService(logr.Discard(), store, nil, nil, 0)
+}
+
+// TestHandleBLUEventBridge_WindowEvent checks that a window open/close event is
+// stored with a non-zero Ts, the canonical device id (not the raw MAC), and a
+// populated Data field containing the triggering sensor value.
+func TestHandleBLUEventBridge_WindowEvent(t *testing.T) {
+	const mac = "7c:c6:b6:9e:7c:99"
+	open := 1
+	data := BLUEventData{
+		Address: mac,
+		Window:  &open,
+		RSSI:    -70,
+	}
+	payload := buildBLUPayload(t, data)
+
+	svc := newTestEventsService(t)
+	before := time.Now().Unix()
+	handleBLUEventBridge(context.Background(), logr.Discard(), payload, svc, nil)
+	after := time.Now().Unix()
+
+	evts, err := svc.Store().Query(context.Background(), events.Query{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	e := evts[0]
+
+	// Ts must be a plausible receive time, not epoch 0
+	if e.Ts < float64(before) || e.Ts > float64(after)+1 {
+		t.Errorf("Ts=%v is not within [%d, %d]", e.Ts, before, after+1)
+	}
+
+	// DeviceID must be the canonical type-inferred id, not the raw MAC
+	wantID := deviceIDFromCapabilities(mac, data)
+	if e.DeviceID != wantID {
+		t.Errorf("DeviceID=%q, want canonical %q", e.DeviceID, wantID)
+	}
+
+	// Data must be populated and contain the triggering field
+	if e.Data == nil {
+		t.Fatal("Data must not be nil for a window event")
+	}
+	if !strings.Contains(*e.Data, "window") {
+		t.Errorf("Data %q should contain 'window'", *e.Data)
 	}
 }

--- a/internal/myhome/shelly/gen2/listener.go
+++ b/internal/myhome/shelly/gen2/listener.go
@@ -168,6 +168,18 @@ func (l *Listener) handleNotifyEvent(ctx context.Context, payload []byte) error 
 		delete(all, "event")
 		delete(all, "ts")
 
+		// For shelly-blu events the relay Shelly is not the sensor: extract the
+		// BLU sensor address from the nested data frame and use it as DeviceID so
+		// the event appears under the correct BLU device. Store the relay device
+		// in the Data payload so duplicate gateway configurations can be detected.
+		deviceID := msg.Src
+		if entry.Event == "shelly-blu" {
+			if bluAddr := shellyBLUAddress(all); bluAddr != "" {
+				deviceID = bluAddr
+				all["relay"] = msg.Src
+			}
+		}
+
 		var dataPtr *string
 		if len(all) > 0 {
 			b, _ := json.Marshal(all)
@@ -189,7 +201,7 @@ func (l *Listener) handleNotifyEvent(ctx context.Context, payload []byte) error 
 
 		e := events.Event{
 			Ts:        ts,
-			DeviceID:  msg.Src,
+			DeviceID:  deviceID,
 			Component: entry.Component,
 			Event:     entry.Event,
 			Severity:  severityFor(entry.Event),
@@ -269,6 +281,21 @@ func severityFor(event string) string {
 		return "debug"
 	}
 	return "info"
+}
+
+// shellyBLUAddress extracts the BLU sensor MAC address from a shelly-blu event
+// data map. The address is nested one level deep under a "data" key.
+func shellyBLUAddress(all map[string]interface{}) string {
+	inner, ok := all["data"]
+	if !ok {
+		return ""
+	}
+	m, ok := inner.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	addr, _ := m["address"].(string)
+	return addr
 }
 
 func floatFrom(m map[string]interface{}, key string) (float64, bool) {

--- a/internal/myhome/shelly/gen2/listener_test.go
+++ b/internal/myhome/shelly/gen2/listener_test.go
@@ -1,0 +1,99 @@
+package gen2
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/asnowfix/home-automation/myhome/events"
+	"github.com/go-logr/logr"
+)
+
+func newTestEventsService(t *testing.T) *events.Service {
+	t.Helper()
+	store, err := events.NewStorage(logr.Discard(), ":memory:")
+	if err != nil {
+		t.Fatalf("events.NewStorage: %v", err)
+	}
+	t.Cleanup(store.Close)
+	return events.NewService(logr.Discard(), store, nil, nil, 0)
+}
+
+// buildShellyBLUNotifyEvent builds a realistic +/events/rpc payload for a
+// shelly-blu event relayed by a Gen2 device running the BLU bridge script.
+func buildShellyBLUNotifyEvent(t *testing.T, relaySrc, bluAddress string, ts float64) []byte {
+	t.Helper()
+	inner := map[string]any{
+		"BTHome_version": 2,
+		"address":        bluAddress,
+		"motion":         1,
+		"rssi":           -68,
+		"battery":        90,
+		"pid":            5,
+		"encryption":     false,
+	}
+	payload := map[string]any{
+		"src":    relaySrc,
+		"method": "NotifyEvent",
+		"params": map[string]any{
+			"ts": ts,
+			"events": []any{
+				map[string]any{
+					"component": "script:3",
+					"id":        3,
+					"event":     "shelly-blu",
+					"ts":        0, // per-event ts absent; falls back to params.ts
+					"data":      inner,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return b
+}
+
+// TestHandleNotifyEvent_ShellyBLU verifies that a relayed shelly-blu event is
+// stored under the BLU sensor's address (not the relay device's id), and that
+// the relay device id is preserved in the Data field.
+func TestHandleNotifyEvent_ShellyBLU(t *testing.T) {
+	const relaySrc = "shelly1minig3-543204641d24"
+	const bluMAC = "e8:e0:7e:d0:f9:89"
+	const frameTs = 1.781600000e+09 // plausible recent unix ts
+
+	svc := newTestEventsService(t)
+	l := NewListener(logr.Discard(), nil, svc, nil)
+	payload := buildShellyBLUNotifyEvent(t, relaySrc, bluMAC, frameTs)
+
+	if err := l.handleNotifyEvent(context.Background(), payload); err != nil {
+		t.Fatalf("handleNotifyEvent: %v", err)
+	}
+
+	evts, err := svc.Store().Query(context.Background(), events.Query{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	e := evts[0]
+
+	// DeviceID must be the BLU sensor, not the relay Shelly
+	if e.DeviceID != bluMAC {
+		t.Errorf("DeviceID=%q, want BLU MAC %q", e.DeviceID, bluMAC)
+	}
+	if e.DeviceID == relaySrc {
+		t.Errorf("DeviceID must not be the relay device %q", relaySrc)
+	}
+
+	// Data must be populated and contain the relay device id
+	if e.Data == nil {
+		t.Fatal("Data must not be nil")
+	}
+	if !strings.Contains(*e.Data, relaySrc) {
+		t.Errorf("Data %q should contain relay device id %q", *e.Data, relaySrc)
+	}
+}

--- a/internal/myhome/ui/events_template.go
+++ b/internal/myhome/ui/events_template.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/json"
 	"html/template"
 	"time"
 )
@@ -33,18 +35,44 @@ func eventTemplateFuncs() template.FuncMap {
 				return ""
 			}
 		},
+		// eventDataCell renders Data as a collapsible <details> when the value is
+		// valid JSON, or a plain span otherwise. Returns template.HTML so the
+		// caller does not need to mark it safe.
+		"eventDataCell": func(s *string) template.HTML {
+			if s == nil || *s == "" {
+				return ""
+			}
+			raw := *s
+			var pretty bytes.Buffer
+			if err := json.Indent(&pretty, []byte(raw), "", "  "); err != nil {
+				// Not JSON — render as escaped plain text
+				return template.HTML("<span>" + template.HTMLEscapeString(raw) + "</span>")
+			}
+			preview := raw
+			if len(preview) > 60 {
+				preview = preview[:60] + "…"
+			}
+			return template.HTML(
+				`<details class="event-data">` +
+					`<summary><code>` + template.HTMLEscapeString(preview) + `</code></summary>` +
+					`<pre>` + template.HTMLEscapeString(pretty.String()) + `</pre>` +
+					`</details>`,
+			)
+		},
 	}
 }
 
 // eventRowTemplate is the shared <tr> fragment for a single event.
 // Used both in the HTMX table and in BroadcastEvent SSE push.
+// Columns: Time | Device (name or id) | Component | Event | Severity | Data | Device ID
 const eventRowTemplate = `<tr class="{{severityClass .Severity}}">
   <td>{{formatTime .Ts}}</td>
-  <td>{{if .DeviceName}}<span title="{{.DeviceID}}">{{.DeviceName}}</span>{{else}}{{.DeviceID}}{{end}}</td>
+  <td>{{if .DeviceName}}{{.DeviceName}}{{else}}{{.DeviceID}}{{end}}</td>
   <td>{{.Component}}</td>
   <td>{{.Event}}</td>
   <td>{{.Severity}}</td>
-  <td>{{truncate .Data}}</td>
+  <td>{{eventDataCell .Data}}</td>
+  <td><code class="is-size-7 has-text-grey">{{.DeviceID}}</code></td>
 </tr>`
 
 // eventsRowsTemplate renders a list of <tr> rows plus a "Load more" button.
@@ -52,7 +80,7 @@ const eventsRowsTemplate = `{{range .Events}}` + eventRowTemplate + `
 {{end}}
 {{if .Events}}
 <tr id="load-more-row">
-  <td colspan="6" class="has-text-centered">
+  <td colspan="7" class="has-text-centered">
     <button class="button is-small is-light"
             hx-get="/htmx/events/more?offset={{.Offset}}&device={{.Device}}&type={{.Type}}&severity={{.Severity}}"
             hx-swap="outerHTML"
@@ -101,6 +129,7 @@ const eventsTableTemplate = `<form id="events-filter-form"
         <th>Event</th>
         <th>Severity</th>
         <th>Data</th>
+        <th>Device ID</th>
       </tr>
     </thead>
     <tbody id="events-tbody">
@@ -108,7 +137,7 @@ const eventsTableTemplate = `<form id="events-filter-form"
       {{end}}
       {{if .Events}}
       <tr id="load-more-row">
-        <td colspan="6" class="has-text-centered">
+        <td colspan="7" class="has-text-centered">
           <button class="button is-small is-light"
                   hx-get="/htmx/events/more?offset={{.Offset}}&device={{.Device}}&type={{.Type}}&severity={{.Severity}}"
                   hx-swap="outerHTML"
@@ -207,14 +236,45 @@ const eventLogPageHTML = `<!doctype html>
             try { ev = JSON.parse(e.data); } catch(_) { return; }
             var ts = new Date(ev.ts * 1000).toISOString().replace('T', ' ').substring(0, 19);
             var sevClass = {'alarm': 'has-text-danger', 'warn': 'has-text-warning', 'debug': 'has-text-grey-light'}[ev.severity] || '';
-            var data = ev.data ? (ev.data.length > 60 ? ev.data.substring(0, 60) + '…' : ev.data) : '';
+            var deviceLabel = ev.device_name || ev.device_id;
             var tr = document.createElement('tr');
             if (sevClass) { tr.className = sevClass; }
-            ['ts_fmt', 'device_id', 'component', 'event', 'severity', 'data_trunc'].forEach(function(f, i) {
+            // Columns: Time | Device | Component | Event | Severity | Data | Device ID
+            [ts, deviceLabel, ev.component, ev.event, ev.severity].forEach(function(val) {
               var td = document.createElement('td');
-              td.textContent = [ts, ev.device_id, ev.component, ev.event, ev.severity, data][i];
+              td.textContent = val || '';
               tr.appendChild(td);
             });
+            // Data cell — collapsible pretty JSON when possible
+            var dataTd = document.createElement('td');
+            if (ev.data) {
+              try {
+                var parsed = JSON.parse(ev.data);
+                var pretty = JSON.stringify(parsed, null, 2);
+                var preview = ev.data.length > 60 ? ev.data.substring(0, 60) + '…' : ev.data;
+                var details = document.createElement('details');
+                details.className = 'event-data';
+                var summary = document.createElement('summary');
+                var code = document.createElement('code');
+                code.textContent = preview;
+                summary.appendChild(code);
+                var pre = document.createElement('pre');
+                pre.textContent = pretty;
+                details.appendChild(summary);
+                details.appendChild(pre);
+                dataTd.appendChild(details);
+              } catch(_) {
+                dataTd.textContent = ev.data;
+              }
+            }
+            tr.appendChild(dataTd);
+            // Device ID column (rightmost)
+            var idTd = document.createElement('td');
+            var idCode = document.createElement('code');
+            idCode.className = 'is-size-7 has-text-grey';
+            idCode.textContent = ev.device_id || '';
+            idTd.appendChild(idCode);
+            tr.appendChild(idTd);
             tbody.insertBefore(tr, tbody.firstChild);
           });
 

--- a/internal/myhome/ui/events_template.go
+++ b/internal/myhome/ui/events_template.go
@@ -55,7 +55,7 @@ func eventTemplateFuncs() template.FuncMap {
 			return template.HTML(
 				`<details class="event-data">` +
 					`<summary><code>` + template.HTMLEscapeString(preview) + `</code></summary>` +
-					`<pre>` + template.HTMLEscapeString(pretty.String()) + `</pre>` +
+					`<pre style="max-height:12em;overflow-y:auto">` + template.HTMLEscapeString(pretty.String()) + `</pre>` +
 					`</details>`,
 			)
 		},
@@ -64,15 +64,14 @@ func eventTemplateFuncs() template.FuncMap {
 
 // eventRowTemplate is the shared <tr> fragment for a single event.
 // Used both in the HTMX table and in BroadcastEvent SSE push.
-// Columns: Time | Device (name or id) | Component | Event | Severity | Data | Device ID
+// Columns: Time | Device (name + id below) | Component | Event | Severity | Data
 const eventRowTemplate = `<tr class="{{severityClass .Severity}}">
   <td>{{formatTime .Ts}}</td>
-  <td>{{if .DeviceName}}{{.DeviceName}}{{else}}{{.DeviceID}}{{end}}</td>
+  <td>{{if .DeviceName}}{{.DeviceName}}<br><code class="is-size-7 has-text-grey">{{.DeviceID}}</code>{{else}}{{.DeviceID}}{{end}}</td>
   <td>{{.Component}}</td>
   <td>{{.Event}}</td>
   <td>{{.Severity}}</td>
   <td>{{eventDataCell .Data}}</td>
-  <td><code class="is-size-7 has-text-grey">{{.DeviceID}}</code></td>
 </tr>`
 
 // eventsRowsTemplate renders a list of <tr> rows plus a "Load more" button.
@@ -80,7 +79,7 @@ const eventsRowsTemplate = `{{range .Events}}` + eventRowTemplate + `
 {{end}}
 {{if .Events}}
 <tr id="load-more-row">
-  <td colspan="7" class="has-text-centered">
+  <td colspan="6" class="has-text-centered">
     <button class="button is-small is-light"
             hx-get="/htmx/events/more?offset={{.Offset}}&device={{.Device}}&type={{.Type}}&severity={{.Severity}}"
             hx-swap="outerHTML"
@@ -129,7 +128,6 @@ const eventsTableTemplate = `<form id="events-filter-form"
         <th>Event</th>
         <th>Severity</th>
         <th>Data</th>
-        <th>Device ID</th>
       </tr>
     </thead>
     <tbody id="events-tbody">
@@ -137,7 +135,7 @@ const eventsTableTemplate = `<form id="events-filter-form"
       {{end}}
       {{if .Events}}
       <tr id="load-more-row">
-        <td colspan="7" class="has-text-centered">
+        <td colspan="6" class="has-text-centered">
           <button class="button is-small is-light"
                   hx-get="/htmx/events/more?offset={{.Offset}}&device={{.Device}}&type={{.Type}}&severity={{.Severity}}"
                   hx-swap="outerHTML"
@@ -236,11 +234,27 @@ const eventLogPageHTML = `<!doctype html>
             try { ev = JSON.parse(e.data); } catch(_) { return; }
             var ts = new Date(ev.ts * 1000).toISOString().replace('T', ' ').substring(0, 19);
             var sevClass = {'alarm': 'has-text-danger', 'warn': 'has-text-warning', 'debug': 'has-text-grey-light'}[ev.severity] || '';
-            var deviceLabel = ev.device_name || ev.device_id;
             var tr = document.createElement('tr');
             if (sevClass) { tr.className = sevClass; }
-            // Columns: Time | Device | Component | Event | Severity | Data | Device ID
-            [ts, deviceLabel, ev.component, ev.event, ev.severity].forEach(function(val) {
+            // Time
+            var timeTd = document.createElement('td');
+            timeTd.textContent = ts;
+            tr.appendChild(timeTd);
+            // Device: name on top, id below in small grey code
+            var deviceTd = document.createElement('td');
+            if (ev.device_name) {
+              deviceTd.appendChild(document.createTextNode(ev.device_name));
+              deviceTd.appendChild(document.createElement('br'));
+              var idCode = document.createElement('code');
+              idCode.className = 'is-size-7 has-text-grey';
+              idCode.textContent = ev.device_id || '';
+              deviceTd.appendChild(idCode);
+            } else {
+              deviceTd.textContent = ev.device_id || '';
+            }
+            tr.appendChild(deviceTd);
+            // Component | Event | Severity
+            [ev.component, ev.event, ev.severity].forEach(function(val) {
               var td = document.createElement('td');
               td.textContent = val || '';
               tr.appendChild(td);
@@ -259,6 +273,8 @@ const eventLogPageHTML = `<!doctype html>
                 code.textContent = preview;
                 summary.appendChild(code);
                 var pre = document.createElement('pre');
+                pre.style.maxHeight = '12em';
+                pre.style.overflowY = 'auto';
                 pre.textContent = pretty;
                 details.appendChild(summary);
                 details.appendChild(pre);
@@ -268,13 +284,6 @@ const eventLogPageHTML = `<!doctype html>
               }
             }
             tr.appendChild(dataTd);
-            // Device ID column (rightmost)
-            var idTd = document.createElement('td');
-            var idCode = document.createElement('code');
-            idCode.className = 'is-size-7 has-text-grey';
-            idCode.textContent = ev.device_id || '';
-            idTd.appendChild(idCode);
-            tr.appendChild(idTd);
             tbody.insertBefore(tr, tbody.firstChild);
           });
 

--- a/internal/myhome/ui/htmx.go
+++ b/internal/myhome/ui/htmx.go
@@ -240,11 +240,31 @@ func (h *HTMXHandler) resolveDeviceFilter(filter string) []string {
 	return ids
 }
 
+// deviceName resolves a single device id to a friendly name.
+// It queries by id first, then falls back to the MAC derived from a Shelly id suffix.
+// Returns "" when no friendly name is found (caller shows the raw id).
+func (h *HTMXHandler) deviceName(id string) string {
+	d, err := h.db.GetDeviceByAny(h.ctx, id)
+	if err != nil {
+		if mac := shellyapi.MacFromShellyID(id); mac != nil {
+			d, err = h.db.GetDeviceByAny(h.ctx, mac.String())
+		}
+	}
+	if err != nil {
+		return ""
+	}
+	if n := d.Name(); n != "" && n != id {
+		return n
+	}
+	return ""
+}
+
+// DeviceNameResolver returns a function suitable for SSEBroadcaster.SetDeviceNameResolver.
+func (h *HTMXHandler) DeviceNameResolver() func(string) string {
+	return h.deviceName
+}
+
 // deviceNameMap resolves names for all unique device IDs that appear in evts.
-// It uses GetDeviceByAny so it matches across id, mac, name, and host columns.
-// For Shelly devices whose stored id differs from the MQTT src, it also tries
-// the MAC address derived from the device ID suffix as a fallback.
-// Unknown or unnamed devices are omitted; callers fall back to the raw ID.
 func (h *HTMXHandler) deviceNameMap(evts []events.Event) map[string]string {
 	seen := make(map[string]struct{}, len(evts))
 	for _, e := range evts {
@@ -252,16 +272,7 @@ func (h *HTMXHandler) deviceNameMap(evts []events.Event) map[string]string {
 	}
 	m := make(map[string]string, len(seen))
 	for id := range seen {
-		d, err := h.db.GetDeviceByAny(h.ctx, id)
-		if err != nil {
-			if mac := shellyapi.MacFromShellyID(id); mac != nil {
-				d, err = h.db.GetDeviceByAny(h.ctx, mac.String())
-			}
-		}
-		if err != nil {
-			continue
-		}
-		if n := d.Name(); n != "" && n != id {
+		if n := h.deviceName(id); n != "" {
 			m[id] = n
 		}
 	}

--- a/internal/myhome/ui/server.go
+++ b/internal/myhome/ui/server.go
@@ -94,6 +94,9 @@ func Start(ctx context.Context, log logr.Logger, listenPort int, resolver mynet.
 
 	// HTMX endpoints for partial HTML responses
 	htmxHandler := NewHTMXHandler(ctx, log.WithName("HTMXHandler"), db, eventsSvc)
+	if sseBroadcaster != nil {
+		sseBroadcaster.SetDeviceNameResolver(htmxHandler.DeviceNameResolver())
+	}
 	mux.HandleFunc("/htmx/devices", htmxHandler.DeviceCards)
 	mux.HandleFunc("/htmx/device/", htmxHandler.DeviceCard)
 	mux.HandleFunc("/htmx/rooms", htmxHandler.RoomsList)

--- a/internal/myhome/ui/sse.go
+++ b/internal/myhome/ui/sse.go
@@ -41,6 +41,7 @@ type SSEBroadcaster struct {
 	clients map[chan string]*sseClient
 	mu      sync.Mutex
 	log     logr.Logger
+	nameFor func(string) string // optional: resolves device id → friendly name
 }
 
 // NewSSEBroadcaster creates a new SSE broadcaster
@@ -49,6 +50,15 @@ func NewSSEBroadcaster(log logr.Logger) *SSEBroadcaster {
 		clients: make(map[chan string]*sseClient),
 		log:     log.WithName("SSEBroadcaster"),
 	}
+}
+
+// SetDeviceNameResolver registers a function that maps a device id to a
+// friendly name. When set, BroadcastEvent includes a device_name field in the
+// SSE payload so live rows match the server-rendered table.
+func (b *SSEBroadcaster) SetDeviceNameResolver(fn func(string) string) {
+	b.mu.Lock()
+	b.nameFor = fn
+	b.mu.Unlock()
 }
 
 // Subscribe adds a new SSE client and returns a channel for receiving events
@@ -146,11 +156,27 @@ func (b *SSEBroadcaster) BroadcastDeviceUpdate(dv DeviceView) {
 	b.broadcast("device-update", dv)
 }
 
+// eventLogPayload is the JSON structure sent over SSE for new event log entries.
+// It extends events.Event with an optional device_name field so live rows can
+// display a friendly name without a round-trip. Existing fields are kept as-is
+// so CLI consumers (event follow) continue to work without changes.
+type eventLogPayload struct {
+	events.Event
+	DeviceName string `json:"device_name,omitempty"`
+}
+
 // BroadcastEvent broadcasts a new event log entry as JSON to all SSE clients.
 // The payload is sent as SSE event "eventlog". The web UI renders the row from JSON;
 // the CLI follow command also parses JSON from this event type.
 func (b *SSEBroadcaster) BroadcastEvent(e events.Event) {
-	b.broadcast("eventlog", e)
+	b.mu.Lock()
+	nameFor := b.nameFor
+	b.mu.Unlock()
+	payload := eventLogPayload{Event: e}
+	if nameFor != nil {
+		payload.DeviceName = nameFor(e.DeviceID)
+	}
+	b.broadcast("eventlog", payload)
 }
 
 // ServeHTTP handles SSE client connections using the broadcaster's client list

--- a/myhome/events/service.go
+++ b/myhome/events/service.go
@@ -54,6 +54,9 @@ func (s *Service) Record(ctx context.Context, e Event) error {
 	if e.ReceivedAt == 0 {
 		e.ReceivedAt = float64(time.Now().Unix())
 	}
+	if e.Ts == 0 {
+		e.Ts = e.ReceivedAt
+	}
 	if err := s.store.Record(ctx, e); err != nil {
 		return err
 	}

--- a/myhome/events/service_test.go
+++ b/myhome/events/service_test.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestService_RecordDefaultsTsFromReceivedAt(t *testing.T) {
+	store := newTestStorage(t)
+	svc := NewService(logr.Discard(), store, nil, nil, 0)
+	ctx := context.Background()
+
+	if err := svc.Record(ctx, Event{
+		DeviceID:  "dev-1",
+		Component: "motion:0",
+		Event:     "motion.detected",
+		Severity:  "info",
+		// Ts deliberately zero
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	evts, err := store.Query(ctx, Query{DeviceID: "dev-1"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	if evts[0].Ts == 0 {
+		t.Error("Ts must not be zero after Record; expected it to be defaulted to ReceivedAt")
+	}
+	if evts[0].Ts != evts[0].ReceivedAt {
+		t.Errorf("Ts (%v) should equal ReceivedAt (%v) when Ts was not set by caller", evts[0].Ts, evts[0].ReceivedAt)
+	}
+}


### PR DESCRIPTION
## Summary

Bug-fix pass on the devices Event Log page (`/event-log`). **Plan only — no code yet**, opened for review of the approach before implementation. Full plan: `docs/EVENT-LOG-UI-FIXES-PLAN.md`.

Three defects, treated as bug-fixes:

1. **Raw device IDs** instead of friendly names — show the name in the Device column and keep the raw ID as a new right-most column. BLU events also never resolved a name because the bridge stored a different `device_id` than the registered device; fixed by using the canonical `deviceIDFromCapabilities(...)` id.
2. **`1970-01-01` timestamps** on BLU events — `handleBLUEventBridge` never set `Ts` (defaults to epoch 0). Set it from the BTHome `timestamp` if present, else receipt time (mirrors the gen2 path), plus a safety-net default in `events.Service.Record`.
3. **Truncated one-line JSON** in the Data column — add a collapsible pretty-printed Data cell (preview → expand to indented JSON), server-side and in the live SSE rows.

## Decisions baked in
- Data cells are **collapsible** (`<details>`), not always-expanded.
- **Live SSE rows are enriched** with the resolved device name so they match the reloaded table (additive `device_name` field on the `eventlog` SSE payload — keeps CLI follow parsing intact).
- BLU events now also carry a compact JSON Data payload (triggering value + address + rssi) so the column is informative.

## Files (planned)
`internal/myhome/shelly/blu/listener.go`, `myhome/events/service.go`, `internal/myhome/ui/events_template.go`, `internal/myhome/ui/sse.go`, `internal/myhome/ui/htmx.go`, `myhome/daemon/daemon.go`, plus focused tests.

## Verification
`make build` / `make test`, then `make run` and exercise `/event-log` (BLU motion event + a gen2 `script:N shelly-blu` row), confirming real timestamps, name + ID columns, and collapsible pretty JSON on both server-rendered and live rows.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- docs(event-log): plan UI bug-fix pass (names, BLU timestamp, pretty JSON) ([7d52e17](https://github.com/asnowfix/home-automation/commit/7d52e179753526e382f7f7b4f88b6a892c63da2c))
- fix(events): default Ts to ReceivedAt when caller omits it ([4318c38](https://github.com/asnowfix/home-automation/commit/4318c3813aeb7ab03ef1cf76ecb117ef3ab476ec))
- fix(blu): canonical device id, receive timestamp, and Data payload in events ([2df2660](https://github.com/asnowfix/home-automation/commit/2df2660494bed2aab436b138d7f500ab60f6a8bd))
- feat(event-log): device name column, raw ID column, collapsible JSON data ([d97b6b3](https://github.com/asnowfix/home-automation/commit/d97b6b320c5f5db88c1903d54533c7563df754d9))
- fix(gen2): attribute shelly-blu relay events to the BLU sensor, not the relay device ([12583e8](https://github.com/asnowfix/home-automation/commit/12583e86ea02cddc76d87e2f7a19cfa6ed252321))
- fix(event-log): merge device id under name, cap expanded data height ([9457238](https://github.com/asnowfix/home-automation/commit/94572388f45d34863312055f336fcfa1ced6be62))
<!-- END-AUTO-GENERATED-COMMITS -->