### PR TITLE
Backport event log, BLU listener, and MCP bootstrap fixes to v0.10.x

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "shelly": {
       "type": "stdio",
-      "command": "go",
-      "args": ["run", "./myhome", "ctl", "--mqtt-broker", "tcp://192.168.1.2:1883", "mcp"]
+      "command": "./myhome-local.sh",
+      "args": ["mcp"]
     }
   }
 }

--- a/internal/myhome/shelly/blu/listener.go
+++ b/internal/myhome/shelly/blu/listener.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/events"
@@ -157,6 +158,16 @@ func StartBLUListenerWithEvents(ctx context.Context, mc mqtt.Client, registry De
 	return nil
 }
 
+// bluData marshals a map to a compact JSON *string for the event Data field.
+func bluData(fields map[string]any) *string {
+	b, err := json.Marshal(fields)
+	if err != nil {
+		return nil
+	}
+	s := string(b)
+	return &s
+}
+
 // handleBLUEventBridge maps BTHome object IDs to event log entries and tracker observations.
 func handleBLUEventBridge(ctx context.Context, log logr.Logger, payload []byte, eventSvc *events.Service, tracker *events.SensorDailyTracker) {
 	var data BLUEventData
@@ -167,70 +178,78 @@ func handleBLUEventBridge(ctx context.Context, log logr.Logger, payload []byte, 
 		return
 	}
 
-	// device_id = BLU sensor MAC address
-	deviceID := data.Address
+	// Use the canonical type-inferred device id so the name lookup in the UI
+	// can match the device registration record (which uses the same id).
+	deviceID := deviceIDFromCapabilities(data.Address, data)
+
+	// Use the device-side BTHome timestamp when available (0x50); fall back
+	// to the daemon's receive time so the event never displays as 1970-01-01.
+	ts := float64(time.Now().Unix())
+	if data.Timestamp != nil {
+		ts = float64(*data.Timestamp)
+	}
 
 	// Motion (0x21)
-	if data.Motion != nil {
-		if eventSvc != nil {
-			eventName := "motion.cleared"
-			if *data.Motion == 1 {
-				eventName = "motion.detected"
-			}
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "motion:0",
-				Event:     eventName,
-				Severity:  "info",
-			}); err != nil {
-				log.Error(err, "Failed to record motion event", "device_id", deviceID)
-			}
+	if data.Motion != nil && eventSvc != nil {
+		eventName := "motion.cleared"
+		if *data.Motion == 1 {
+			eventName = "motion.detected"
+		}
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "motion:0",
+			Event:     eventName,
+			Severity:  "info",
+			Data:      bluData(map[string]any{"motion": *data.Motion, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record motion event", "device_id", deviceID)
 		}
 	}
 
 	// Window (0x2D)
-	if data.Window != nil {
-		if eventSvc != nil {
-			eventName := "window.closed"
-			if *data.Window == 1 {
-				eventName = "window.opened"
-			}
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "window:0",
-				Event:     eventName,
-				Severity:  "info",
-			}); err != nil {
-				log.Error(err, "Failed to record window event", "device_id", deviceID)
-			}
+	if data.Window != nil && eventSvc != nil {
+		eventName := "window.closed"
+		if *data.Window == 1 {
+			eventName = "window.opened"
+		}
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "window:0",
+			Event:     eventName,
+			Severity:  "info",
+			Data:      bluData(map[string]any{"window": *data.Window, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record window event", "device_id", deviceID)
 		}
 	}
 
 	// Button (0x3A)
-	if data.Button != nil {
-		if eventSvc != nil {
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "button:0",
-				Event:     "button.push",
-				Severity:  "info",
-			}); err != nil {
-				log.Error(err, "Failed to record button event", "device_id", deviceID)
-			}
+	if data.Button != nil && eventSvc != nil {
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "button:0",
+			Event:     "button.push",
+			Severity:  "info",
+			Data:      bluData(map[string]any{"button": *data.Button, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record button event", "device_id", deviceID)
 		}
 	}
 
 	// Battery low
-	if data.Battery != nil && *data.Battery < 20 {
-		if eventSvc != nil {
-			if err := eventSvc.Record(ctx, events.Event{
-				DeviceID:  deviceID,
-				Component: "battery",
-				Event:     "battery.low",
-				Severity:  "warn",
-			}); err != nil {
-				log.Error(err, "Failed to record battery.low event", "device_id", deviceID)
-			}
+	if data.Battery != nil && *data.Battery < 20 && eventSvc != nil {
+		if err := eventSvc.Record(ctx, events.Event{
+			Ts:        ts,
+			DeviceID:  deviceID,
+			Component: "battery",
+			Event:     "battery.low",
+			Severity:  "warn",
+			Data:      bluData(map[string]any{"battery": *data.Battery, "address": data.Address, "rssi": data.RSSI}),
+		}); err != nil {
+			log.Error(err, "Failed to record battery.low event", "device_id", deviceID)
 		}
 	}
 

--- a/internal/myhome/shelly/blu/listener_test.go
+++ b/internal/myhome/shelly/blu/listener_test.go
@@ -3,9 +3,12 @@ package blu
 import (
 	"context"
 	"encoding/json"
-	"github.com/asnowfix/home-automation/internal/myhome"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/myhome/events"
 	"github.com/go-logr/logr"
 )
 
@@ -118,5 +121,62 @@ func TestHandleBLUEvent_NoSensorsNoCache(t *testing.T) {
 	}
 	if len(reg.sensorUpdates) != 0 {
 		t.Errorf("expected 0 cache updates, got %d", len(reg.sensorUpdates))
+	}
+}
+
+func newTestEventsService(t *testing.T) *events.Service {
+	t.Helper()
+	store, err := events.NewStorage(logr.Discard(), ":memory:")
+	if err != nil {
+		t.Fatalf("events.NewStorage: %v", err)
+	}
+	t.Cleanup(store.Close)
+	return events.NewService(logr.Discard(), store, nil, nil, 0)
+}
+
+// TestHandleBLUEventBridge_WindowEvent checks that a window open/close event is
+// stored with a non-zero Ts, the canonical device id (not the raw MAC), and a
+// populated Data field containing the triggering sensor value.
+func TestHandleBLUEventBridge_WindowEvent(t *testing.T) {
+	const mac = "7c:c6:b6:9e:7c:99"
+	open := 1
+	data := BLUEventData{
+		Address: mac,
+		Window:  &open,
+		RSSI:    -70,
+	}
+	payload := buildBLUPayload(t, data)
+
+	svc := newTestEventsService(t)
+	before := time.Now().Unix()
+	handleBLUEventBridge(context.Background(), logr.Discard(), payload, svc, nil)
+	after := time.Now().Unix()
+
+	evts, err := svc.Store().Query(context.Background(), events.Query{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	e := evts[0]
+
+	// Ts must be a plausible receive time, not epoch 0
+	if e.Ts < float64(before) || e.Ts > float64(after)+1 {
+		t.Errorf("Ts=%v is not within [%d, %d]", e.Ts, before, after+1)
+	}
+
+	// DeviceID must be the canonical type-inferred id, not the raw MAC
+	wantID := deviceIDFromCapabilities(mac, data)
+	if e.DeviceID != wantID {
+		t.Errorf("DeviceID=%q, want canonical %q", e.DeviceID, wantID)
+	}
+
+	// Data must be populated and contain the triggering field
+	if e.Data == nil {
+		t.Fatal("Data must not be nil for a window event")
+	}
+	if !strings.Contains(*e.Data, "window") {
+		t.Errorf("Data %q should contain 'window'", *e.Data)
 	}
 }

--- a/internal/myhome/shelly/gen2/listener.go
+++ b/internal/myhome/shelly/gen2/listener.go
@@ -168,6 +168,18 @@ func (l *Listener) handleNotifyEvent(ctx context.Context, payload []byte) error 
 		delete(all, "event")
 		delete(all, "ts")
 
+		// For shelly-blu events the relay Shelly is not the sensor: extract the
+		// BLU sensor address from the nested data frame and use it as DeviceID so
+		// the event appears under the correct BLU device. Store the relay device
+		// in the Data payload so duplicate gateway configurations can be detected.
+		deviceID := msg.Src
+		if entry.Event == "shelly-blu" {
+			if bluAddr := shellyBLUAddress(all); bluAddr != "" {
+				deviceID = bluAddr
+				all["relay"] = msg.Src
+			}
+		}
+
 		var dataPtr *string
 		if len(all) > 0 {
 			b, _ := json.Marshal(all)
@@ -189,7 +201,7 @@ func (l *Listener) handleNotifyEvent(ctx context.Context, payload []byte) error 
 
 		e := events.Event{
 			Ts:        ts,
-			DeviceID:  msg.Src,
+			DeviceID:  deviceID,
 			Component: entry.Component,
 			Event:     entry.Event,
 			Severity:  severityFor(entry.Event),
@@ -268,6 +280,21 @@ func severityFor(event string) string {
 		return "debug"
 	}
 	return "info"
+}
+
+// shellyBLUAddress extracts the BLU sensor MAC address from a shelly-blu event
+// data map. The address is nested one level deep under a "data" key.
+func shellyBLUAddress(all map[string]interface{}) string {
+	inner, ok := all["data"]
+	if !ok {
+		return ""
+	}
+	m, ok := inner.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	addr, _ := m["address"].(string)
+	return addr
 }
 
 func floatFrom(m map[string]interface{}, key string) (float64, bool) {

--- a/internal/myhome/shelly/gen2/listener_test.go
+++ b/internal/myhome/shelly/gen2/listener_test.go
@@ -1,0 +1,99 @@
+package gen2
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/asnowfix/home-automation/myhome/events"
+	"github.com/go-logr/logr"
+)
+
+func newTestEventsService(t *testing.T) *events.Service {
+	t.Helper()
+	store, err := events.NewStorage(logr.Discard(), ":memory:")
+	if err != nil {
+		t.Fatalf("events.NewStorage: %v", err)
+	}
+	t.Cleanup(store.Close)
+	return events.NewService(logr.Discard(), store, nil, nil, 0)
+}
+
+// buildShellyBLUNotifyEvent builds a realistic +/events/rpc payload for a
+// shelly-blu event relayed by a Gen2 device running the BLU bridge script.
+func buildShellyBLUNotifyEvent(t *testing.T, relaySrc, bluAddress string, ts float64) []byte {
+	t.Helper()
+	inner := map[string]any{
+		"BTHome_version": 2,
+		"address":        bluAddress,
+		"motion":         1,
+		"rssi":           -68,
+		"battery":        90,
+		"pid":            5,
+		"encryption":     false,
+	}
+	payload := map[string]any{
+		"src":    relaySrc,
+		"method": "NotifyEvent",
+		"params": map[string]any{
+			"ts": ts,
+			"events": []any{
+				map[string]any{
+					"component": "script:3",
+					"id":        3,
+					"event":     "shelly-blu",
+					"ts":        0, // per-event ts absent; falls back to params.ts
+					"data":      inner,
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return b
+}
+
+// TestHandleNotifyEvent_ShellyBLU verifies that a relayed shelly-blu event is
+// stored under the BLU sensor's address (not the relay device's id), and that
+// the relay device id is preserved in the Data field.
+func TestHandleNotifyEvent_ShellyBLU(t *testing.T) {
+	const relaySrc = "shelly1minig3-543204641d24"
+	const bluMAC = "e8:e0:7e:d0:f9:89"
+	const frameTs = 1.781600000e+09 // plausible recent unix ts
+
+	svc := newTestEventsService(t)
+	l := NewListener(logr.Discard(), nil, svc, nil)
+	payload := buildShellyBLUNotifyEvent(t, relaySrc, bluMAC, frameTs)
+
+	if err := l.handleNotifyEvent(context.Background(), payload); err != nil {
+		t.Fatalf("handleNotifyEvent: %v", err)
+	}
+
+	evts, err := svc.Store().Query(context.Background(), events.Query{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	e := evts[0]
+
+	// DeviceID must be the BLU sensor, not the relay Shelly
+	if e.DeviceID != bluMAC {
+		t.Errorf("DeviceID=%q, want BLU MAC %q", e.DeviceID, bluMAC)
+	}
+	if e.DeviceID == relaySrc {
+		t.Errorf("DeviceID must not be the relay device %q", relaySrc)
+	}
+
+	// Data must be populated and contain the relay device id
+	if e.Data == nil {
+		t.Fatal("Data must not be nil")
+	}
+	if !strings.Contains(*e.Data, relaySrc) {
+		t.Errorf("Data %q should contain relay device id %q", *e.Data, relaySrc)
+	}
+}

--- a/internal/shelly/scripts/blu-listener.js
+++ b/internal/shelly/scripts/blu-listener.js
@@ -46,7 +46,12 @@ var STATE = {
   // In-memory cache of follows loaded from KVS by loadFollowsFromKVS()
   // KVS keys are set externally via "myhome ctl follow blu" command
   // Each followed MAC has its own KVS key: follow/shelly-blu/<mac>
-  follows: {}
+  follows: {},
+
+  // True while a KVS reload is in progress (KVS.List → KVS.Get chain).
+  // BLU events that arrive during a reload are deferred through the task
+  // queue so they are processed after follows are updated, never dropped.
+  reloading: false
 };
 
 // === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
@@ -190,6 +195,7 @@ function processKvsKey(k, newMap, onComplete) {
 }
 
 function onAllKeysProcessed(newMap, callback) {
+  STATE.reloading = false;
   setFollows(newMap);
   log("Loaded follows:", newMap);
   if (callback) callback(true);
@@ -210,6 +216,7 @@ function processKeysSequentially(list, newMap, callback, index) {
 function onKvsListResponse(callback, resp, err) {
   if (err) {
     log("KVS.List error:", err);
+    STATE.reloading = false;
     if (callback) callback(false);
     return;
   }
@@ -234,6 +241,7 @@ function onKvsListResponse(callback, resp, err) {
   var newMap = {};
 
   if (!list || !list.length) {
+    STATE.reloading = false;
     setFollows(newMap);
     log("No followed MACs.");
     if (callback) callback(true);
@@ -244,6 +252,7 @@ function onKvsListResponse(callback, resp, err) {
 }
 
 function loadFollowsFromKVS(callback) {
+  STATE.reloading = true;
   Shelly.call("KVS.List", { prefix: CONFIG.kvsPrefix }, onKvsListResponse.bind(null, callback));
 }
 
@@ -283,6 +292,12 @@ function ensureAutoOffTimer(switchIndex, seconds, follow) {
 }
 
 function handleBluEvent(topic, message) {
+  // If a KVS reload is in progress, defer this event so it is processed
+  // after follows are updated rather than being silently dropped.
+  if (STATE.reloading) {
+    queueTask(function() { handleBluEvent(topic, message); });
+    return;
+  }
   var data = null;
   try {
     data = JSON.parse(message);

--- a/internal/shelly/scripts/blu_listener_test.go
+++ b/internal/shelly/scripts/blu_listener_test.go
@@ -347,12 +347,12 @@ func TestBluListener_KVSReloadPicksUpNewFollow(t *testing.T) {
 	})
 	state.EventInjector <- kvsEvent
 
-	// Allow reload chain to complete
-	time.Sleep(400 * time.Millisecond)
-
-	injectBluEvent(t, state.EventInjector, mac, 50, 1)
-
-	ok := waitFor(5*time.Second, 50*time.Millisecond, func() bool {
+	// Re-inject a motion event on each poll iteration. Once the async KVS reload
+	// chain has installed the new follow (kvs event → task-queue timer → KVS.List
+	// → KVS.Get), the next injection will turn the switch on. This avoids a fixed
+	// sleep that is fragile under CI load.
+	ok := waitFor(8*time.Second, 100*time.Millisecond, func() bool {
+		injectBluEvent(t, state.EventInjector, mac, 50, 1)
 		return switchIsOn(state, "switch:0")
 	})
 	cancel()

--- a/myhome-local.sh
+++ b/myhome-local.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# myhome-local.sh — Bootstrap and run myhome from a local checkout (main tree or any git worktree).
+#
+# Generates the gitignored assets/code that `go build`/`go run` require (UI static
+# assets, pool defaults) — skipping each step if already present — then execs
+# `go run ./myhome ctl`. Each git worktree has its own untracked files, so a fresh
+# worktree needs these regenerated even if the main checkout already has them.
+#
+# Usage:
+#   ./myhome-local.sh [ctl-args...]
+#   ./myhome-local.sh mcp                          # MCP stdio server (default if no args)
+#   ./myhome-local.sh shelly script upload ...
+#
+#   MYHOME_MQTT_BROKER=tcp://192.168.1.2:1883 ./myhome-local.sh mcp
+#
+# This is the command referenced by .mcp.json so contributors get a working MCP
+# server regardless of whether they're in the main tree or a worktree.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+BROKER="${MYHOME_MQTT_BROKER:-tcp://192.168.1.2:1883}"
+
+[ -f internal/myhome/ui/static/alpine.min.js ] || go generate ./internal/myhome/ui/...
+[ -f myhome/ctl/pool/pool_defaults_generated.go ] || go generate ./myhome/ctl/pool
+
+if [ "$#" -eq 0 ]; then
+  set -- mcp
+fi
+
+exec go run ./myhome ctl --instance local --mqtt-broker "$BROKER" "$@"

--- a/myhome/events/service.go
+++ b/myhome/events/service.go
@@ -54,6 +54,9 @@ func (s *Service) Record(ctx context.Context, e Event) error {
 	if e.ReceivedAt == 0 {
 		e.ReceivedAt = float64(time.Now().Unix())
 	}
+	if e.Ts == 0 {
+		e.Ts = e.ReceivedAt
+	}
 	if err := s.store.Record(ctx, e); err != nil {
 		return err
 	}

--- a/myhome/events/service_test.go
+++ b/myhome/events/service_test.go
@@ -1,0 +1,38 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestService_RecordDefaultsTsFromReceivedAt(t *testing.T) {
+	store := newTestStorage(t)
+	svc := NewService(logr.Discard(), store, nil, nil, 0)
+	ctx := context.Background()
+
+	if err := svc.Record(ctx, Event{
+		DeviceID:  "dev-1",
+		Component: "motion:0",
+		Event:     "motion.detected",
+		Severity:  "info",
+		// Ts deliberately zero
+	}); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	evts, err := store.Query(ctx, Query{DeviceID: "dev-1"})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(evts) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(evts))
+	}
+	if evts[0].Ts == 0 {
+		t.Error("Ts must not be zero after Record; expected it to be defaulted to ReceivedAt")
+	}
+	if evts[0].Ts != evts[0].ReceivedAt {
+		t.Errorf("Ts (%v) should equal ReceivedAt (%v) when Ts was not set by caller", evts[0].Ts, evts[0].ReceivedAt)
+	}
+}


### PR DESCRIPTION
## Summary
Cherry-picks bugfix commits from `main` that fix correctness issues in features already present on `v0.10.x`:

- 8311787 fix(events): default Ts to ReceivedAt when caller omits it
- d117d62 fix(blu): canonical device id, receive timestamp, and Data payload in events
- 95a46f4 fix(gen2): attribute shelly-blu relay events to the BLU sensor, not the relay device
- 26f9187 fix(blu-listener): defer BLU events during KVS reload instead of dropping them
- 4ab6812 fix(ci): harden KVS-reload test against timing (test-only hunk from bc760fa, isolated from that commit's unrelated proxy/sfr coverage additions and `.coverage-min` bump)

Not included:
- `fix(watchdog): extract PrometheusMetrics...` (#268) — already backported as `d75fdb1`.
- 3 Beem Energy fixup commits — that feature doesn't exist on `v0.10.x` (`pkg/beem` absent).
- `fix(event-log): merge device id under name, cap expanded data height` — patches a different main-line event-log UI implementation (`d97b6b3`) that was never ported to `v0.10.x`; `v0.10.x` has its own simpler UI (`8badbc7`) that doesn't exhibit either bug this fix addresses.
- `fix(mcp): add myhome-local.sh to bootstrap gen artifacts before mcp server` (#279) — local dev-tooling fix for `.mcp.json`/Claude Code MCP bootstrap, not applicable to a release branch.

## Test plan
- [x] `make test` passes on the resulting branch
- [x] `TestBluListener_KVSReloadPicksUpNewFollow` re-run 5x to confirm reliability before/after the timing hardening<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(events): default Ts to ReceivedAt when caller omits it ([8311787](https://github.com/asnowfix/home-automation/commit/83117875b33cdea52c22409c56d91bbf33f89f38))
- fix(blu): canonical device id, receive timestamp, and Data payload in events ([d117d62](https://github.com/asnowfix/home-automation/commit/d117d6298f2da87882f5559dfbb37771c967371a))
- fix(gen2): attribute shelly-blu relay events to the BLU sensor, not the relay device ([95a46f4](https://github.com/asnowfix/home-automation/commit/95a46f4ad96fccd21546452370b50dfc12509f4a))
- fix(blu-listener): defer BLU events during KVS reload instead of dropping them ([26f9187](https://github.com/asnowfix/home-automation/commit/26f9187062e2a432077262cf9de2ab1aa85e4fe2))
- fix(ci): harden KVS-reload test against timing ([4ab6812](https://github.com/asnowfix/home-automation/commit/4ab68126ced242be7862beddf9ecb3052209ef2e))
- fix(mcp): add myhome-local.sh to bootstrap gen artifacts before mcp server (#279) ([332de1c](https://github.com/asnowfix/home-automation/commit/332de1cd4a448e44f42c068370a470e3ff2c88f1))
<!-- END-AUTO-GENERATED-COMMITS -->