### PR TITLE
fix(mcp): bootstrap generated artifacts before running mcp server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,8 +2,8 @@
   "mcpServers": {
     "shelly": {
       "type": "stdio",
-      "command": "sh",
-      "args": ["-c", "(test -f internal/myhome/ui/static/alpine.min.js || go generate ./internal/myhome/ui/...) && exec go run ./myhome ctl --mqtt-broker tcp://192.168.1.2:1883 mcp"]
+      "command": "./myhome-local.sh",
+      "args": ["mcp"]
     }
   }
 }

--- a/myhome-local.sh
+++ b/myhome-local.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# myhome-local.sh — Bootstrap and run myhome from a local checkout (main tree or any git worktree).
+#
+# Generates the gitignored assets/code that `go build`/`go run` require (UI static
+# assets, pool/garden defaults) — skipping each step if already present — then execs
+# `go run ./myhome ctl`. Each git worktree has its own untracked files, so a fresh
+# worktree needs these regenerated even if the main checkout already has them.
+#
+# Usage:
+#   ./myhome-local.sh [ctl-args...]
+#   ./myhome-local.sh mcp                          # MCP stdio server (default if no args)
+#   ./myhome-local.sh shelly script upload ...
+#
+#   MYHOME_MQTT_BROKER=tcp://192.168.1.2:1883 ./myhome-local.sh mcp
+#
+# This is the command referenced by .mcp.json so contributors get a working MCP
+# server regardless of whether they're in the main tree or a worktree.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+BROKER="${MYHOME_MQTT_BROKER:-tcp://192.168.1.2:1883}"
+
+[ -f internal/myhome/ui/static/alpine.min.js ] || go generate ./internal/myhome/ui/...
+[ -f myhome/ctl/pool/pool_defaults_generated.go ] || go generate ./myhome/ctl/pool
+[ -f myhome/ctl/garden/garden_defaults_generated.go ] || go generate ./myhome/ctl/garden
+
+if [ "$#" -eq 0 ]; then
+  set -- mcp
+fi
+
+exec go run ./myhome ctl --instance local --mqtt-broker "$BROKER" "$@"


### PR DESCRIPTION
## Summary
- `go run ./myhome ctl mcp` failed when run from a fresh git worktree with `undefined: DefaultEarliestStartHour` / `undefined: DefaultNightRunDuration` compile errors.
- Root cause: `pool_defaults_generated.go` and `garden_defaults_generated.go` are gitignored and only created by `go generate`. Worktrees don't share untracked files, so a fresh worktree lacked them while the main checkout (which had run `make generate` before) already had them. `.mcp.json` only regenerated the UI static assets, not these two files.
- Added `myhome-local.sh` at the repo root: resolves its own location as the repo root (works from the main tree or any worktree), regenerates the three gitignored artifacts only when missing, then execs `go run ./myhome ctl --instance local --mqtt-broker "$BROKER" "$@"` (defaults to the `mcp` subcommand, broker overridable via `MYHOME_MQTT_BROKER`).
- `.mcp.json` now calls `./myhome-local.sh mcp` instead of an inline shell one-liner.

## Test plan
- [x] Removed/missing `pool_defaults_generated.go` / `garden_defaults_generated.go` in a worktree reproduced the original build failure.
- [x] `./myhome-local.sh mcp` runs clean (no compile errors) after the fix, generating missing artifacts on first run.
- [x] Re-running `./myhome-local.sh` with no args is a no-op on generate (files already present) and defaults to the `mcp` subcommand.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(mcp): add myhome-local.sh to bootstrap gen artifacts before mcp server ([7f054df](https://github.com/asnowfix/home-automation/commit/7f054df505e24d538ad9c1b33cef6a5ca8c37057))
<!-- END-AUTO-GENERATED-COMMITS -->