### PR TITLE
feat(garden): differentiated watering cadence by zone group

### DIFF
--- a/docs/garden-differentiated-cadence-plan.md
+++ b/docs/garden-differentiated-cadence-plan.md
@@ -1,0 +1,220 @@
+# Garden Sprinklers — Differentiated Cadence by Group (implementation plan)
+
+> **Status:** Implemented and verified live on `arrosage` (2026-06-20). This is a self-contained
+> handover doc — a coding agent should be able to execute it end to end without further context.
+> **Branch/worktree:** `feature+differentiated-sprinklers`.
+> **Prerequisite reading:** `docs/garden-sprinklers-plan.md` (the original controller design),
+> `CLAUDE.md` + `AGENTS.md` (Shelly JS / Espruino ES5 rules, KVS key limits, Pro3 limits).
+>
+> **Post-deployment tuning (2026-06-21):** the body below documents the *original* design
+> (`massifs` `intervalDays: 7`). After reviewing the actual plant list in the massifs bed —
+> rosemary, society garlic, boxwood, Phormium, abelia, feijoa (true mediterranean, happy weekly)
+> mixed with lemon, orange, Strelitzia, Agapanthus, daylily, Carex (want water more often in peak
+> summer heat) — the shipped default was retuned to **`intervalDays: 4`** as a compromise. See the
+> plant-list comment above `ZONE_DEFAULTS` in `garden.js` and `docs/garden-sprinklers-plan.md` §11.
+> Treat `7` below as historical context for *why* a per-group interval exists, not the current value.
+
+---
+
+## 1. Context & motivation
+
+`internal/shelly/scripts/garden.js` runs on the Pro3 device **`arrosage`**
+(`shellypro3-34987a48c26c`, `192.168.1.83`) and drives 3 valves, one at a time:
+
+| Switch | Zone | Type | Kc | triggerMm |
+|---|---|---|---|---|
+| `switch:0` | `pelouse-maison` | lawn (2 pop-up heads) | 0.8 | 12 |
+| `switch:1` | `massifs` | mediterranean beds (drip) | 0.6 | 8 |
+| `switch:2` | `pelouse-barriere` | lawn (2 pop-up heads) | 0.8 | 12 |
+
+**Today** the controller waters each zone purely by its **own ET₀ soil-water deficit**. Daily at
+00:30 `handlePlan()` calls `updateDeficits()` (adds `ET₀·Kc − rain` to `deficit/<id>` in
+`Script.storage`), then `computeZonePlan()` waters any zone whose `deficit ≥ triggerMm`. There is
+**no group concept and no day cadence** — only the per-zone deficit gate.
+
+**Problem this solves:**
+- `switch:0` + `switch:2` are two halves of the **same lawn**; they should always water on the
+  **same days** (today they only coincide because their config is identical — nothing enforces it).
+- `switch:1` (massifs, drought-tolerant) should water **infrequently / weekly**, not whenever its
+  deficit crosses 8 mm (~every 2 days in peak summer).
+- A future **`pots`** ("plantes en pot") group is anticipated but has no hardware channel yet.
+
+**Goal:** add a lightweight **group** abstraction with a **per-group minimum interval (days)** that
+gates the existing deficit logic. The ET₀-computed water *amount* (especially for grass) is unchanged.
+
+### Confirmed product decisions
+1. **Cadence = minimum interval in days** (still subject to deficit/rain/frost gating), **not** fixed
+   calendar weekdays.
+2. **Massifs default = weekly** (`intervalDays = 7`); lawn = `1` (effectively unconstrained). Both
+   tunable at runtime via KVS.
+3. **Lawn zones 0 & 2 fire together**: when the lawn group is due and *any* member's deficit crosses
+   its trigger, **both** enabled members water that day, each with its own ET₀-computed minutes.
+
+---
+
+## 2. Design
+
+Add two per-zone config fields plus a per-group "last watered" tracker.
+
+- **`group`** (string): `"lawn"` for zones 0 & 2, `"beds"` for zone 1. A future pots zone just uses
+  `"pots"` — no code change needed to add a group, only config.
+- **`intervalDays`** (number): minimum days between waterings for that zone's group (lawn `1`, beds `7`).
+- A group's **effective interval** = `min(intervalDays among its enabled members)`.
+- **`group-last/<name>`** in `Script.storage`: a local-aligned **day number** (not a date string) of
+  the group's last actual watering. Default to a large-negative sentinel so the first run is always
+  eligible.
+
+**When is `group-last` written?** Only when a member of the group **actually completes** watering
+(in the `tickWatering` zone-complete branch), **not** at plan time. This ensures a quiet-window or
+rain abort does not wrongly advance the cadence and skip a week.
+
+**Planner gate** (inside the daily plan):
+1. `updateDeficits()` runs unchanged — deficits keep accumulating while a group "rests," so massifs
+   builds up a deep weekly soak (clamped to `maxDeficitMm = 25`).
+2. Group the enabled zones by `group`.
+3. A group is **eligible** iff `todayDayNumber() − loadGroupLastDay(group) ≥ groupInterval`.
+4. An eligible group **fires** iff *any* enabled member has `deficit ≥ triggerMm`.
+5. When a group fires, add **every** enabled member whose computed minutes ≥ 1 (this is what makes
+   the lawn "fire together"). Minutes math is unchanged:
+   `min(deficit, maxDeficitMm) / appRateMmH * 60`, capped by `maxMin`, rounded, must be ≥ 1.
+6. Ineligible / non-firing groups contribute nothing that day.
+
+Whole-cycle **rain-holdoff** and **frost** guards stay as-is (they skip the entire day's cycle).
+The **fallback planner** (offline, no forecast) keeps watering all enabled zones and **ignores
+cadence by design** — document this with a one-line comment.
+
+### Day-number helper
+**Confirmed on-device:** Espruino's `Date` has no `getTimezoneOffset()` — calling it throws
+`Uncaught Error: Function "getTimezoneOffset" not found!` and crashes the script (caught live
+during verification on `arrosage`, see §4). Use plain UTC day number via `Date.now()` instead
+(already used elsewhere in the script, e.g. `WATERING_START_MS = Date.now()`):
+```js
+function todayDayNumber() {
+  return Math.floor(Date.now() / 86400000);
+}
+```
+This is coarse by design — watering always runs near the same local hour, so a few hours of zone
+offset near the UTC day boundary don't meaningfully affect "every N days" gating.
+
+---
+
+## 3. Exact changes
+
+### 3.1 `internal/shelly/scripts/garden.js`  (Espruino ES5 — `var` only, no hoisting, define before use)
+
+1. **`ZONE_DEFAULTS`** (~line 103) — add `group` + `intervalDays` to each entry:
+   ```js
+   {id: 0, name: "pelouse-maison",   appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8,  group: "lawn", intervalDays: 1, enabled: true},
+   {id: 1, name: "massifs",          appRateMmH:  18.0, kc: 0.6, triggerMm:  8.0, maxMin: 30, fallbackMin: 15, group: "beds", intervalDays: 7, enabled: true},
+   {id: 2, name: "pelouse-barriere", appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8,  group: "lawn", intervalDays: 1, enabled: true}
+   ```
+2. **`ZONE_KEY_SPECS`** (~line 123) — add two specs (KVS suffixes `zone1-group` = 11, `zone1-interval`
+   = 14 chars; both within the ≤18-suffix / ≤32-total budget):
+   ```js
+   {field: "group",        key: "group",     type: "string"},
+   {field: "intervalDays", key: "interval",  type: "number"}
+   ```
+3. **`initZones()`** (~line 133) — copy `group` and `intervalDays` into each runtime `ZONES` entry.
+4. **New helpers** near the deficit helpers (~line 530): `todayDayNumber()` (above),
+   `groupLastKey(name)` → `"group-last/" + name`, `loadGroupLastDay(name)` (returns a large-negative
+   sentinel, e.g. `-99999`, when unset), `saveGroupLastDay(name)` → stores `todayDayNumber()`.
+   Define all of these **before** any function that references them.
+5. **`computeZonePlan()`** (~line 572) — restructure:
+   - Build a map of `group → enabled members`.
+   - For each group: compute `groupInterval = min(member.intervalDays)`; if
+     `todayDayNumber() - loadGroupLastDay(group) < groupInterval`, `log("group " + group + " not due
+     (" + n + " < " + groupInterval + " d)")` and skip the whole group.
+   - Else compute each member's minutes; if **any** member has `deficit ≥ triggerMm`, push **all**
+     members with `minutes ≥ 1` to the plan (fire-together). If no member crosses trigger, skip.
+   - Preserve existing per-member logging.
+   - Espruino has no `Array.prototype` niceties — iterate with `for` loops; build the group map with a
+     plain object keyed by group name and a parallel array of names (no `Object.keys` reliance issues;
+     use `for (k in obj)`).
+6. **`tickWatering()` zone-complete branch** (~line 930, right after `incrementRunCount(entry.id)`):
+   call `saveGroupLastDay(zone.group)` and add a best-effort KVS mirror (fire-and-forget, exactly like
+   the runs mirror in `incrementRunCount`):
+   ```js
+   Shelly.call("KVS.Set", {key: CONFIG_KEY_PREFIX + "group/" + zone.group + "-last", value: String(todayDayNumber())},
+     function(r, e) { if (e && false) {} });
+   ```
+   (`zone` is already resolved from `ZONES` earlier in `tickWatering`; `zone.group` exists after
+   step 3.)
+7. **`runFallbackPlanner()`** (~line 1061) — add a one-line comment that the offline fallback
+   intentionally ignores group cadence and waters all enabled zones.
+
+> ⚠️ Espruino guard-rails (crashes if violated): `var` not `let/const`; no function hoisting (define
+> before reference, including callbacks); max 2–3 nested anon functions; never an empty `catch` — use
+> `catch (e) { if (e && false) {} }`; property checks via `"prop" in obj`; no `Array.shift/unshift`;
+> per-script limits 5 timers / 5 event-subs / 5 concurrent RPC. KVS keys lowercase, hyphens/slashes,
+> ≤42 chars. Upload with `--no-minify` while debugging.
+
+### 3.2 `tools/extract-garden-defaults/main.go`
+Zone defaults are a **hardcoded literal inside `outputTemplate`** (they are NOT parsed from the JS;
+only the global scalars are). Update the template's `ZoneDefault` struct and `defaultZoneDefaults`:
+- Add fields `group string` and `intervalDays int` to the `ZoneDefault` struct text.
+- Set them in the three literal rows (`lawn`/`1`, `beds`/`7`, `lawn`/`1`).
+Global-scalar extraction (`extractDefaults`) and `tools/extract-garden-defaults/main_test.go` are
+**unaffected** (the test only checks global scalars). Then run `make generate` to regenerate
+`myhome/ctl/garden/garden_defaults_generated.go`.
+
+### 3.3 `myhome/ctl/garden/setup.go`
+In `defaultZoneKVS()` (~line 57), inside the per-zone loop, add:
+```go
+m[pfx+"group"]    = z.group
+m[pfx+"interval"] = fmt.Sprintf("%d", z.intervalDays)
+```
+(`z` is a `ZoneDefault`; the new fields come from §3.2.)
+
+### 3.4 `myhome/ctl/garden/status.go`  (minor, optional but recommended)
+The new keys already arrive via the existing 4 `KVS.GetMany` prefix calls. Add a short **"Cadence"**
+section that prints, per zone, `zoneN-group` + `zoneN-interval`, plus any `group/<name>-last` entries,
+so operators can see cadence state without the daemon.
+
+### 3.5 `docs/garden-sprinklers-plan.md`
+Add a **"Phase 7 — Differentiated cadence by group"** section: the group model, the two new KVS keys,
+weekly-massifs default, lawn fire-together rule; extend the per-zone KVS table with `zone<z>-group`
+and `zone<z>-interval`. Mark this plan file as its companion.
+
+### New KVS keys summary (prefix `script/garden/`)
+| Key | Example | Meaning |
+|---|---|---|
+| `zone<z>-group` | `lawn` / `beds` | group membership |
+| `zone<z>-interval` | `1` / `7` | min days between waterings for the zone's group |
+| `group/<name>-last` | `group/beds-last = 20259` | day-number of group's last actual watering (script-written, read-only for CLI) |
+
+---
+
+## 4. Verification
+
+1. **Build/test:** `make generate && make build && make test` (canonical; covers all `go.work`
+   submodules — never bare `go test ./...`).
+2. **JS sanity on device:**
+   `go run ./myhome ctl shelly script upload arrosage internal/shelly/scripts/garden.js --no-minify`
+   then `go run ./myhome ctl shelly script debug arrosage true` and watch the log for parse/runtime errors.
+3. **Write & inspect new config:** `go run ./myhome ctl garden setup arrosage` then
+   `go run ./myhome ctl garden status arrosage` — confirm `zone0-group=lawn`, `zone2-group=lawn`,
+   `zone1-group=beds`, `zone1-interval=7`, `zone0-interval=1`.
+4. **Cadence gate** (MCP `shelly_call` / `Script.Eval` on `arrosage`):
+   - Seed `deficit/1` above 8 and `group-last/beds = todayDayNumber()`, run `handlePlan()` →
+     `garden.plan` / `last-plan-zones` **excludes** zone 1, log shows "beds not due".
+   - Set `group-last/beds` to `todayDayNumber() - 7`, run `handlePlan()` → zone 1 **included**.
+5. **Lawn fire-together:** seed `deficit/0` above 12 and `deficit/2` just below 12, ensure
+   `group-last/lawn` is ≥1 day old, run `handlePlan()` → **both** 0 and 2 appear in `last-plan-zones`.
+6. **`group-last` advances only on real watering:** run `handleWateringStart()` for one zone outside a
+   quiet window; after `garden.zone_stop`, confirm `Script.storage` `group-last/<name>` and the KVS
+   mirror `group/<name>-last` updated to today's day number; confirm a quiet-window abort leaves them
+   unchanged.
+
+---
+
+## 5. Out of scope / notes
+- No new daemon config option (config lives in device KVS), so the `options.go`/`run.go`/
+  `docs/configuration.md`/`myhome-example.yaml` 4-file rule does **not** apply.
+- `pots` group: no hardware channel yet — supported by config only once a switch exists.
+- Massifs amount stays ET₀-deficit-driven (capped by `maxMin`); tune `appRateMmH`/`maxMin`/
+  `maxDeficitMm` later if weekly delivery is insufficient.
+- All logic stays on-device (resilience: internet-optional, daemon-optional per device).
+- **Manual runs (confirmed out of scope, asked of user):** button/external `Switch.Set` starts
+  remain uncounted, apply no deficit credit, and do **not** advance `group-last` — only the existing
+  `garden.manual` event records them. `incrementRunCount` and `saveGroupLastDay` stay solely in the
+  automated `tickWatering` completion branch (§3.1 step 6). Do not wire manual starts into either.

--- a/docs/garden-sprinklers-plan.md
+++ b/docs/garden-sprinklers-plan.md
@@ -278,8 +278,11 @@ suffixes ≤ 18 chars** (prefix is 14; hard limit 42).
 | triggerDeficitMm | `zone<z>-trigger-mm` | `12` / `8` / `12` | number |
 | maxRunMinutes | `zone<z>-max-min` | `15` / `30` / `15` | number |
 | fallbackRunMinutes | `zone<z>-fallback-min` | `8` / `15` / `8` | number |
+| group | `zone<z>-group` | `lawn` / `beds` / `lawn` | string |
+| intervalDays | `zone<z>-interval` | `1` / `4` / `1` | number |
 | enabled | `zone<z>-enabled` | `true` | bool |
 | run count (read-only) | `zone<z>-runs` | — | number | written by script, read by CLI |
+| group last-watered (read-only) | `group/<name>-last` | — | number | day-number, written by script (§12) |
 
 ---
 
@@ -361,7 +364,42 @@ Commands:
 
 ---
 
-## 11. Assumptions & out of scope
+## 11. Phase 7 — Differentiated cadence by group
+
+> **Status:** implemented. See `docs/garden-differentiated-cadence-plan.md` for the full design
+> rationale and verification checklist (this section summarizes the shipped result).
+
+The per-zone ET₀ deficit model alone doesn't let zones with the same deficit profile diverge in
+*how often* they run. Each zone now carries a **`group`** (string) and **`intervalDays`** (minimum
+days between waterings for that group, effective interval = `min` across enabled members):
+
+- `pelouse-maison` (0) and `pelouse-barriere` (2) → `group: "lawn"`, `intervalDays: 1` — they fire
+  **together**: whenever the lawn group is due and *any* enabled member's deficit crosses its
+  trigger, both water that day, each with its own ET₀-computed minutes.
+- `massifs` (1) → `group: "beds"`, `intervalDays: 4` — waters at most every 4 days, even though its
+  own deficit may cross `triggerMm` sooner; the deficit keeps accumulating (capped at
+  `maxDeficitMm`) during the "rest" days. **Tuned 2026-06-21** (was 7 at initial ship): this bed
+  mixes true-mediterranean plants (rosemary, society garlic, boxwood, Phormium, abelia, feijoa —
+  happy with a weekly soak) with thirstier ones (lemon, orange, Strelitzia, Agapanthus, daylily,
+  Carex) that stress without water for a full week in peak summer heat. 4 days is the compromise;
+  see plant list in `ZONE_DEFAULTS` comment in `garden.js`.
+- A future `pots` ("plantes en pot") group needs no script changes — just a new `group` string once
+  a hardware channel exists.
+
+`computeZonePlan()` groups enabled zones by `group`, gates each group by
+`todayDayNumber() - group-last/<name> >= groupInterval` (day-number tracked in `Script.storage`,
+mirrored to KVS key `group/<name>-last`), and only updates `group-last` when a member **actually
+completes** watering (in `tickWatering()`, not at plan time) — so a quiet-window or rain abort never
+wrongly skips a week. The offline fallback planner intentionally ignores cadence (resilience over
+schedule fidelity).
+
+**Manual runs** (button / external `Switch.Set`) remain uncounted and do not affect deficits or
+group cadence — by design, to keep the model simple; only the existing `garden.manual` event
+records them.
+
+---
+
+## 12. Assumptions & out of scope
 
 - **Forecast-only** — no physical rain/soil-moisture sensor assumed on Pro3 inputs.
 - Liters/volume reporting is informational only (no per-zone area model unless added later).

--- a/internal/shelly/scripts/garden.js
+++ b/internal/shelly/scripts/garden.js
@@ -1,10 +1,10 @@
 // garden.js — ET₀ water-balance garden sprinkler controller
 // Target device: Shelly Pro3 (device named "arrosage", 192.168.1.83)
 //
-// Zone mapping:
-//   switch:0  pelouse-maison   (lawn, house side)
-//   switch:1  massifs          (flower beds)
-//   switch:2  pelouse-barriere (lawn, fence side)
+// Zone mapping (group: zones sharing a group water on the same days):
+//   switch:0  pelouse-maison   (lawn, house side)   group=lawn, interval=1d
+//   switch:1  massifs          (flower beds)        group=beds, interval=4d
+//   switch:2  pelouse-barriere (lawn, fence side)    group=lawn, interval=1d
 //
 // Power supply supports ONE valve at a time — enforced in hardware and software.
 // All logic runs on-device; no daemon dependency (resilience per CLAUDE.md).
@@ -93,6 +93,12 @@ var CONFIG_SCHEMA = {
 //   Grass zones (0, 2): 2 pop-up heads per zone, each measured at 96 mm/h (8 mm/5 min),
 //   covering the same ground simultaneously → 192 mm/h.
 //   Massifs zone (1): drip pipe — set after measuring or via KVS.
+// massifs (zone 1) plant list — true mediterranean, low-water (rosemary/Romarin,
+//   society garlic/Tulbaghia, boxwood/Buis, NZ flax/Phormium, Abelia, feijoa) mixed
+//   with thirstier plants (lemon/Citronnier, orange/Oranger de Chine, bird-of-paradise/
+//   Strelitzia, Agapanthus, daylily/Hémérocalle, Carex/Laîche). intervalDays=4 below
+//   is the watering-cadence compromise between these two groups (see docs/garden-
+//   sprinklers-plan.md §11 for the full per-plant water-need rationale).
 // kc: crop coefficient — ET0 multiplier. Lawn 0.8, ornamental beds 0.6.
 // triggerMm: water when deficit reaches this depth (deep-infrequent irrigation).
 //   Grass: 12 mm ≈ 2.5 days of peak-summer ETc (ET0=6 mm/d × kc=0.8).
@@ -100,10 +106,18 @@ var CONFIG_SCHEMA = {
 // fallbackMin: used when no forecast is available (internet outage).
 //   Grass: 8 min delivers ~25.6 mm ≈ 5-day peak-summer deficit.
 // maxMin: hard cap per session; 15 min @ 192 mm/h = 48 mm (more than maxDeficitMm=25).
+// group: zones sharing a group water on the same days, gated by intervalDays
+//   (minimum days between waterings for that group; effective interval is the
+//   min across the group's enabled members). lawn zones fire together; massifs
+//   waters at most every 4 days regardless of how quickly its own deficit
+//   crosses trigger — a compromise between the bed's true-mediterranean plants
+//   (rosemary, society garlic, boxwood — happy with a weekly soak) and its
+//   citrus (lemon, orange) and Strelitzia/Agapanthus/daylily/Carex, which want
+//   water more often in peak summer heat.
 var ZONE_DEFAULTS = [
-  {id: 0, name: "pelouse-maison",   appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8, enabled: true},
-  {id: 1, name: "massifs",          appRateMmH:  18.0, kc: 0.6, triggerMm:  8.0, maxMin: 30, fallbackMin: 15, enabled: true},
-  {id: 2, name: "pelouse-barriere", appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8, enabled: true}
+  {id: 0, name: "pelouse-maison",   appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8,  group: "lawn", intervalDays: 1, enabled: true},
+  {id: 1, name: "massifs",          appRateMmH:  18.0, kc: 0.6, triggerMm:  8.0, maxMin: 30, fallbackMin: 15, group: "beds", intervalDays: 4, enabled: true},
+  {id: 2, name: "pelouse-barriere", appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8,  group: "lawn", intervalDays: 1, enabled: true}
 ];
 
 // Runtime config — populated from defaults then overridden by KVS at startup
@@ -121,27 +135,31 @@ var ZONES = [];
 
 // KVS key specs for a single zone (key suffix applied after "zoneN-")
 var ZONE_KEY_SPECS = [
-  {field: "name",        key: "name",         type: "string"},
-  {field: "appRateMmH",  key: "app-rate",      type: "number"},
-  {field: "kc",          key: "kc",            type: "number"},
-  {field: "triggerMm",   key: "trigger-mm",    type: "number"},
-  {field: "maxMin",      key: "max-min",       type: "number"},
-  {field: "fallbackMin", key: "fallback-min",  type: "number"},
-  {field: "enabled",     key: "enabled",       type: "boolean"}
+  {field: "name",         key: "name",         type: "string"},
+  {field: "appRateMmH",   key: "app-rate",     type: "number"},
+  {field: "kc",           key: "kc",           type: "number"},
+  {field: "triggerMm",    key: "trigger-mm",   type: "number"},
+  {field: "maxMin",       key: "max-min",      type: "number"},
+  {field: "fallbackMin",  key: "fallback-min", type: "number"},
+  {field: "group",        key: "group",        type: "string"},
+  {field: "intervalDays", key: "interval",     type: "number"},
+  {field: "enabled",      key: "enabled",      type: "boolean"}
 ];
 
 function initZones() {
   for (var i = 0; i < ZONE_DEFAULTS.length; i++) {
     var d = ZONE_DEFAULTS[i];
     ZONES.push({
-      id:          d.id,
-      name:        d.name,
-      appRateMmH:  d.appRateMmH,
-      kc:          d.kc,
-      triggerMm:   d.triggerMm,
-      maxMin:      d.maxMin,
-      fallbackMin: d.fallbackMin,
-      enabled:     d.enabled
+      id:           d.id,
+      name:         d.name,
+      appRateMmH:   d.appRateMmH,
+      kc:           d.kc,
+      triggerMm:    d.triggerMm,
+      maxMin:       d.maxMin,
+      fallbackMin:  d.fallbackMin,
+      group:        d.group,
+      intervalDays: d.intervalDays,
+      enabled:      d.enabled
     });
   }
   ZONE_DEFAULTS = null; // free — not needed after copy
@@ -546,6 +564,35 @@ function saveDeficit(zoneId, value) {
   // KVS mirror is done in bulk by commitPlan() to avoid concurrent RPC limit
 }
 
+// === PER-GROUP CADENCE (Script.storage, survives reboot) ===
+// UTC day number (Espruino's Date has no getTimezoneOffset()). Coarse by design:
+// watering always runs near the same local hour, so a few hours of zone offset
+// near the UTC day boundary doesn't affect "every N days" gating.
+function todayDayNumber() {
+  return Math.floor(Date.now() / 86400000);
+}
+
+function groupLastKey(name) {
+  return "group-last/" + name;
+}
+
+function loadGroupLastDay(name) {
+  var v = loadStorageValue(groupLastKey(name));
+  if (v === null) return -99999; // never watered — always eligible
+  var n = Number(v);
+  return isNaN(n) ? -99999 : n;
+}
+
+// Sets the in-memory/Script.storage value AND mirrors to KVS (fire-and-forget,
+// like incrementRunCount's runs mirror) — called only when a zone actually
+// finishes watering, never at plan time, so aborted cycles don't skip a week.
+function saveGroupLastDay(name) {
+  var today = todayDayNumber();
+  storeStorageValue(groupLastKey(name), today);
+  Shelly.call("KVS.Set", {key: CONFIG_KEY_PREFIX + "group/" + name + "-last", value: String(today)},
+    function(r, e) { if (e && false) {} });
+}
+
 // === ET0 DEFICIT UPDATE ===
 function updateDeficits() {
   var et0 = STATE.forecastEt0Yesterday;
@@ -568,24 +615,59 @@ function updateDeficits() {
 }
 
 // === ZONE PLAN COMPUTATION ===
-// Returns [{id, minutes}] for zones whose deficit >= trigger
+// Groups enabled zones by `group`, gates each group by its minimum cadence
+// (effective interval = min intervalDays among enabled members), and fires
+// every enabled member of a due group whose deficit yields >= 1 minute
+// (this is what makes lawn zones 0/2 water together). Returns [{id, minutes}].
 function computeZonePlan() {
-  var plan = [];
+  var groupNames = [];
+  var groupZones = {};
   for (var i = 0; i < ZONES.length; i++) {
     var z = ZONES[i];
     if (!z.enabled) continue;
-    var deficit = loadDeficit(z.id);
-    if (deficit < z.triggerMm) {
-      log("Zone " + z.id + ": deficit " + Math.round(deficit * 10) / 10 + " mm < trigger " + z.triggerMm + " mm, skip");
+    if (!(z.group in groupZones)) {
+      groupZones[z.group] = [];
+      groupNames.push(z.group);
+    }
+    groupZones[z.group].push(z);
+  }
+
+  var plan = [];
+  for (var gi = 0; gi < groupNames.length; gi++) {
+    var gname = groupNames[gi];
+    var members = groupZones[gname];
+
+    var groupInterval = members[0].intervalDays;
+    for (var mi = 1; mi < members.length; mi++) {
+      if (members[mi].intervalDays < groupInterval) groupInterval = members[mi].intervalDays;
+    }
+
+    var daysSince = todayDayNumber() - loadGroupLastDay(gname);
+    if (daysSince < groupInterval) {
+      log("Group " + gname + " not due (" + daysSince + " < " + groupInterval + " d)");
       continue;
     }
-    var depthMm = deficit < CONFIG.maxDeficitMm ? deficit : CONFIG.maxDeficitMm;
-    var minutes = depthMm / z.appRateMmH * 60;
-    if (minutes > z.maxMin) minutes = z.maxMin;
-    minutes = Math.round(minutes);
-    if (minutes < 1) continue;
-    plan.push({id: z.id, minutes: minutes});
-    log("Zone " + z.id + ": water " + minutes + " min (deficit=" + Math.round(deficit * 10) / 10 + " mm)");
+
+    var anyDue = false;
+    for (var di = 0; di < members.length; di++) {
+      if (loadDeficit(members[di].id) >= members[di].triggerMm) { anyDue = true; break; }
+    }
+    if (!anyDue) {
+      log("Group " + gname + " due but no member over trigger, skip");
+      continue;
+    }
+
+    for (var fi = 0; fi < members.length; fi++) {
+      var zone = members[fi];
+      var deficit = loadDeficit(zone.id);
+      var depthMm = deficit < CONFIG.maxDeficitMm ? deficit : CONFIG.maxDeficitMm;
+      var minutes = depthMm / zone.appRateMmH * 60;
+      if (minutes > zone.maxMin) minutes = zone.maxMin;
+      minutes = Math.round(minutes);
+      if (minutes < 1) continue;
+      plan.push({id: zone.id, minutes: minutes});
+      log("Zone " + zone.id + " (" + gname + "): water " + minutes + " min (deficit=" + Math.round(deficit * 10) / 10 + " mm)");
+    }
   }
   return plan;
 }
@@ -942,6 +1024,7 @@ function tickWatering() {
       deficit_mm:  Math.round(deficit * 10) / 10
     });
     incrementRunCount(entry.id);
+    saveGroupLastDay(zone.group);
     log("Zone " + entry.id + " done. Applied " + Math.round(appliedMm * 10) / 10 +
         " mm. Deficit now " + Math.round(deficit * 10) / 10 + " mm");
     Shelly.call("Switch.Set", {id: entry.id, on: false}, function(r, e) { if (e && false) {} });
@@ -1058,6 +1141,8 @@ function commitFallback(queue, fallbackH) {
 }
 
 // === DAILY PLANNER ===
+// Offline fallback intentionally ignores group cadence — waters every enabled
+// zone at its fallbackMin. Internet-outage resilience takes priority over cadence.
 function runFallbackPlanner() {
   log("Using fallback plan (no forecast data)");
   var queue = [];

--- a/internal/shelly/scripts/garden_test.go
+++ b/internal/shelly/scripts/garden_test.go
@@ -1,0 +1,164 @@
+package scripts
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+const gardenScriptPath = "garden.js"
+
+// gardenVM loads garden.js into a fresh goja runtime with the minimal stubs
+// needed for its top-level (synchronous) code to run to completion: a Shelly
+// object whose call()/addEventHandler() are no-ops, so the async
+// loadConfig()->loadZones()->continueInit()->handlePlan() chain kicked off by
+// the trailing init() call fires exactly one Shelly.call and then halts
+// (its callback is never invoked) instead of reaching the network — and a
+// Script.storage backed by an in-memory map so loadDeficit/saveGroupLastDay
+// etc. work when invoked directly by tests below.
+//
+// This intentionally bypasses init()'s async KVS/forecast machinery (already
+// exercised end-to-end by TestSmokeAllScripts and by live device testing) in
+// order to unit-test the synchronous group-cadence algorithm in
+// computeZonePlan() in isolation, with deterministic inputs. Zone config
+// comes from the script's own ZONE_DEFAULTS (loaded synchronously by
+// initZones() at module load time), not from KVS.
+func gardenVM(t *testing.T) *goja.Runtime {
+	t.Helper()
+
+	buf, err := os.ReadFile(gardenScriptPath)
+	if err != nil {
+		t.Fatalf("failed to read garden.js: %v", err)
+	}
+
+	vm := goja.New()
+
+	shellyObj := vm.NewObject()
+	shellyObj.Set("call", func(call goja.FunctionCall) goja.Value { return goja.Undefined() })
+	shellyObj.Set("addEventHandler", func(call goja.FunctionCall) goja.Value { return goja.Undefined() })
+	vm.Set("Shelly", shellyObj)
+
+	vm.Set("print", func(call goja.FunctionCall) goja.Value { return goja.Undefined() })
+
+	storage := make(map[string]string)
+	storageObj := vm.NewObject()
+	storageObj.Set("getItem", func(call goja.FunctionCall) goja.Value {
+		if v, ok := storage[call.Argument(0).String()]; ok {
+			return vm.ToValue(v)
+		}
+		return goja.Null()
+	})
+	storageObj.Set("setItem", func(call goja.FunctionCall) goja.Value {
+		storage[call.Argument(0).String()] = call.Argument(1).String()
+		return goja.Undefined()
+	})
+	scriptObj := vm.NewObject()
+	scriptObj.Set("storage", storageObj)
+	vm.Set("Script", scriptObj)
+
+	if _, err := vm.RunString(string(buf)); err != nil {
+		t.Fatalf("garden.js failed to load: %v", err)
+	}
+
+	return vm
+}
+
+func mustEval(t *testing.T, vm *goja.Runtime, code string) goja.Value {
+	t.Helper()
+	v, err := vm.RunString(code)
+	if err != nil {
+		t.Fatalf("eval %q: %v", code, err)
+	}
+	return v
+}
+
+func zonePlanIDs(t *testing.T, raw string) map[int]int {
+	t.Helper()
+	var plan []struct {
+		ID      int `json:"id"`
+		Minutes int `json:"minutes"`
+	}
+	if err := json.Unmarshal([]byte(raw), &plan); err != nil {
+		t.Fatalf("unmarshal plan %q: %v", raw, err)
+	}
+	got := make(map[int]int, len(plan))
+	for _, p := range plan {
+		got[p.ID] = p.Minutes
+	}
+	return got
+}
+
+// TestGarden_LawnFiresTogetherBedsIndependent verifies the core grouping
+// behaviour added for differentiated cadence: lawn zones (0 and 2, group
+// "lawn") water together as soon as either crosses its trigger, while massifs
+// (zone 1, group "beds") is gated independently by its own trigger.
+func TestGarden_LawnFiresTogetherBedsIndependent(t *testing.T) {
+	vm := gardenVM(t)
+
+	// Zone 0 above its 12mm trigger, zone 2 below it (but in the same "lawn"
+	// group as zone 0), zone 1 (massifs) below its 8mm trigger.
+	mustEval(t, vm, `storeStorageValue(deficitKey(0), 15);`)
+	mustEval(t, vm, `storeStorageValue(deficitKey(1), 3);`)
+	mustEval(t, vm, `storeStorageValue(deficitKey(2), 9);`)
+
+	raw := mustEval(t, vm, `JSON.stringify(computeZonePlan())`).String()
+	plan := zonePlanIDs(t, raw)
+
+	if _, ok := plan[0]; !ok {
+		t.Errorf("expected zone 0 (over trigger) in plan, got %v", plan)
+	}
+	if _, ok := plan[2]; !ok {
+		t.Errorf("expected lawn zone 2 to fire together with zone 0, got %v", plan)
+	}
+	if _, ok := plan[1]; ok {
+		t.Errorf("expected massifs (zone 1, below its trigger) to stay excluded, got %v", plan)
+	}
+}
+
+// TestGarden_GroupCadenceGate verifies that a group already watered within
+// its intervalDays window is excluded regardless of deficit, and becomes
+// eligible again once enough days have passed. It reads bedsInterval from the
+// live ZONES config rather than hardcoding it, so the test tracks whatever
+// the script's current default is instead of silently going stale.
+func TestGarden_GroupCadenceGate(t *testing.T) {
+	vm := gardenVM(t)
+
+	// All zones comfortably over trigger so deficit never gates the result —
+	// only the group-cadence check should determine inclusion/exclusion.
+	mustEval(t, vm, `storeStorageValue(deficitKey(0), 25);`)
+	mustEval(t, vm, `storeStorageValue(deficitKey(1), 25);`)
+	mustEval(t, vm, `storeStorageValue(deficitKey(2), 25);`)
+
+	bedsInterval := mustEval(t, vm, `ZONES[1].intervalDays`).ToInteger()
+	if bedsInterval < 1 {
+		t.Fatalf("unexpected beds intervalDays: %d", bedsInterval)
+	}
+
+	// Mark both groups watered "today" — both groups must be excluded.
+	mustEval(t, vm, `saveGroupLastDay('lawn'); saveGroupLastDay('beds');`)
+	if raw := mustEval(t, vm, `JSON.stringify(computeZonePlan())`).String(); raw != "[]" {
+		t.Fatalf("expected empty plan right after both groups watered, got %s", raw)
+	}
+
+	// Roll beds back exactly far enough to become due again; lawn
+	// (intervalDays=1) is still "watered today" so it must stay excluded even
+	// though beds reappears in the plan.
+	mustEval(t, vm, fmt.Sprintf(
+		`storeStorageValue(groupLastKey('beds'), todayDayNumber() - %d);`, bedsInterval))
+
+	raw := mustEval(t, vm, `JSON.stringify(computeZonePlan())`).String()
+	plan := zonePlanIDs(t, raw)
+
+	if _, ok := plan[0]; ok {
+		t.Errorf("lawn zone 0 should still be gated (watered today), got %v", plan)
+	}
+	if _, ok := plan[2]; ok {
+		t.Errorf("lawn zone 2 should still be gated (watered today), got %v", plan)
+	}
+	if _, ok := plan[1]; !ok {
+		t.Errorf("expected massifs (zone 1) to be due again, got %v", plan)
+	}
+}

--- a/internal/shelly/scripts/go.mod
+++ b/internal/shelly/scripts/go.mod
@@ -5,5 +5,6 @@ go 1.25.0
 require (
 	github.com/asnowfix/home-automation/pkg/shelly v0.0.0-00010101000000-000000000000
 	github.com/asnowfix/home-automation/pkg/shelly/types v0.0.0-00010101000000-000000000000
+	github.com/dop251/goja v0.0.0-20251103141225-af2ceb9156d7
 	github.com/go-logr/logr v1.4.3
 )

--- a/myhome/ctl/garden/setup.go
+++ b/myhome/ctl/garden/setup.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
+	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
-	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 
 	"github.com/go-logr/logr"
@@ -19,22 +19,22 @@ import (
 )
 
 const scriptName = "garden.js"
-const kvsPrefix  = "script/garden/"
+const kvsPrefix = "script/garden/"
 
 // gardenKVSKeys maps logical field names to KVS keys.
 // All keys: prefix (14) + suffix ≤18 chars = ≤32 chars total.
 var gardenKVSKeys = map[string]string{
-	"logging":        kvsPrefix + "logging",
-	"mqtt-topic":     kvsPrefix + "mqtt-topic",
-	"earliest-start": kvsPrefix + "earliest-start",
-	"lunch-start":    kvsPrefix + "lunch-start",
-	"lunch-end":      kvsPrefix + "lunch-end",
-	"evening-start":  kvsPrefix + "evening-start",
-	"evening-end":    kvsPrefix + "evening-end",
-	"fallback-start": kvsPrefix + "fallback-start",
-	"frost-cutoff-c": kvsPrefix + "frost-cutoff-c",
+	"logging":         kvsPrefix + "logging",
+	"mqtt-topic":      kvsPrefix + "mqtt-topic",
+	"earliest-start":  kvsPrefix + "earliest-start",
+	"lunch-start":     kvsPrefix + "lunch-start",
+	"lunch-end":       kvsPrefix + "lunch-end",
+	"evening-start":   kvsPrefix + "evening-start",
+	"evening-end":     kvsPrefix + "evening-end",
+	"fallback-start":  kvsPrefix + "fallback-start",
+	"frost-cutoff-c":  kvsPrefix + "frost-cutoff-c",
 	"rain-holdoff-mm": kvsPrefix + "rain-holdoff-mm",
-	"max-deficit-mm": kvsPrefix + "max-deficit-mm",
+	"max-deficit-mm":  kvsPrefix + "max-deficit-mm",
 }
 
 // defaultGlobalKVS holds the initial KVS values to write on setup.
@@ -58,13 +58,15 @@ func defaultZoneKVS() map[string]string {
 	m := make(map[string]string)
 	for i, z := range defaultZoneDefaults {
 		pfx := kvsPrefix + fmt.Sprintf("zone%d-", i)
-		m[pfx+"name"]         = z.name
-		m[pfx+"app-rate"]     = fmt.Sprintf("%.1f", z.appRateMmH)
-		m[pfx+"kc"]           = fmt.Sprintf("%.2f", z.kc)
-		m[pfx+"trigger-mm"]   = fmt.Sprintf("%.1f", z.triggerMm)
-		m[pfx+"max-min"]      = fmt.Sprintf("%d", z.maxMin)
+		m[pfx+"name"] = z.name
+		m[pfx+"app-rate"] = fmt.Sprintf("%.1f", z.appRateMmH)
+		m[pfx+"kc"] = fmt.Sprintf("%.2f", z.kc)
+		m[pfx+"trigger-mm"] = fmt.Sprintf("%.1f", z.triggerMm)
+		m[pfx+"max-min"] = fmt.Sprintf("%d", z.maxMin)
 		m[pfx+"fallback-min"] = fmt.Sprintf("%d", z.fallbackMin)
-		m[pfx+"enabled"]      = fmt.Sprintf("%t", z.enabled)
+		m[pfx+"group"] = z.group
+		m[pfx+"interval"] = fmt.Sprintf("%d", z.intervalDays)
+		m[pfx+"enabled"] = fmt.Sprintf("%t", z.enabled)
 	}
 	return m
 }
@@ -128,7 +130,7 @@ to reflect real coverage.`,
 		identifier := args[0]
 
 		noMinify, _ := cmd.Flags().GetBool("no-minify")
-		force, _    := cmd.Flags().GetBool("force")
+		force, _ := cmd.Flags().GetBool("force")
 
 		_, sd, err := getDeviceByAny(ctx, identifier)
 		if err != nil {

--- a/myhome/ctl/garden/setup_test.go
+++ b/myhome/ctl/garden/setup_test.go
@@ -1,0 +1,56 @@
+package garden
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestDefaultZoneKVS verifies that defaultZoneKVS() emits the differentiated-
+// cadence keys (zoneN-group, zoneN-interval) added alongside ZONE_DEFAULTS in
+// garden.js, with the expected lawn/beds grouping and intervalDays values.
+func TestDefaultZoneKVS(t *testing.T) {
+	m := defaultZoneKVS()
+
+	want := map[string]string{
+		kvsPrefix + "zone0-group":    "lawn",
+		kvsPrefix + "zone0-interval": "1",
+		kvsPrefix + "zone1-group":    "beds",
+		kvsPrefix + "zone1-interval": "4",
+		kvsPrefix + "zone2-group":    "lawn",
+		kvsPrefix + "zone2-interval": "1",
+	}
+	for k, wantV := range want {
+		gotV, ok := m[k]
+		if !ok {
+			t.Errorf("defaultZoneKVS() missing key %q", k)
+			continue
+		}
+		if gotV != wantV {
+			t.Errorf("defaultZoneKVS()[%q] = %q, want %q", k, gotV, wantV)
+		}
+	}
+
+	// Every zone must define both group and interval — garden.js's group
+	// cadence gating silently treats a missing group as its own singleton
+	// group, so a dropped key here would fail quietly on-device.
+	for i := range defaultZoneDefaults {
+		for _, suffix := range []string{"group", "interval"} {
+			key := kvsPrefix + fmt.Sprintf("zone%d-%s", i, suffix)
+			if _, ok := m[key]; !ok {
+				t.Errorf("defaultZoneKVS() missing %q for zone %d", suffix, i)
+			}
+		}
+	}
+}
+
+// TestDefaultZoneKVS_KeyLengthBudget guards the KVS key length budget
+// documented above gardenKVSKeys ("prefix (14) + suffix <=18 chars = <=32
+// chars total"). Exceeding it risks hitting Shelly's hard KVS key limit.
+func TestDefaultZoneKVS_KeyLengthBudget(t *testing.T) {
+	const maxTotal = 32
+	for k := range defaultZoneKVS() {
+		if len(k) > maxTotal {
+			t.Errorf("KVS key %q is %d chars, exceeds the %d-char budget", k, len(k), maxTotal)
+		}
+	}
+}

--- a/myhome/ctl/garden/status.go
+++ b/myhome/ctl/garden/status.go
@@ -78,6 +78,14 @@ per-zone water deficits, today's planned watering, and active state.`,
 			}
 		}
 
+		fmt.Println("\nCadence:")
+		for _, e := range entries {
+			if strings.HasSuffix(e.k, "-group") || strings.HasSuffix(e.k, "-interval") ||
+				strings.HasSuffix(e.k, "-last") {
+				fmt.Printf("  %-32s  %s\n", e.k, e.v)
+			}
+		}
+
 		fmt.Println("\nAll KVS entries:")
 		for _, e := range entries {
 			fmt.Printf("  %-32s  %s\n", e.k, e.v)

--- a/tools/extract-garden-defaults/main.go
+++ b/tools/extract-garden-defaults/main.go
@@ -44,22 +44,32 @@ const (
 
 // ZoneDefault holds initial per-zone configuration values.
 type ZoneDefault struct {
-	name        string
-	appRateMmH  float64
-	kc          float64
-	triggerMm   float64
-	maxMin      int
-	fallbackMin int
-	enabled     bool
+	name         string
+	appRateMmH   float64
+	kc           float64
+	triggerMm    float64
+	maxMin       int
+	fallbackMin  int
+	group        string
+	intervalDays int
+	enabled      bool
 }
 
 // defaultZoneDefaults mirrors ZONE_DEFAULTS from garden.js.
 // Grass zones (0,2): 192 mm/h = 2 pop-up heads × 96 mm/h each (measured: 8 mm/5 min).
 // Massifs zone (1): drip pipe — update appRateMmH after measuring with catch-cups.
+// massifs (zone 1) plant list — true mediterranean, low-water (rosemary/Romarin,
+// society garlic/Tulbaghia, boxwood/Buis, NZ flax/Phormium, Abelia, feijoa) mixed
+// with thirstier plants (lemon/Citronnier, orange/Oranger de Chine, bird-of-paradise/
+// Strelitzia, Agapanthus, daylily/Hémérocalle, Carex/Laîche).
+// group/intervalDays: zones sharing a group water on the same days, gated by the
+// minimum interval (days) across the group's enabled members. Lawn fires together
+// daily-eligible; massifs intervalDays=4 is the watering-cadence compromise between
+// the two plant groups above (see docs/garden-sprinklers-plan.md §11 for rationale).
 var defaultZoneDefaults = []ZoneDefault{
-	{name: "pelouse-maison",   appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8, enabled: true},
-	{name: "massifs",          appRateMmH:  18.0, kc: 0.6, triggerMm:  8.0, maxMin: 30, fallbackMin: 15, enabled: true},
-	{name: "pelouse-barriere", appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8, enabled: true},
+	{name: "pelouse-maison",   appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8,  group: "lawn", intervalDays: 1, enabled: true},
+	{name: "massifs",          appRateMmH:  18.0, kc: 0.6, triggerMm:  8.0, maxMin: 30, fallbackMin: 15, group: "beds", intervalDays: 4, enabled: true},
+	{name: "pelouse-barriere", appRateMmH: 192.0, kc: 0.8, triggerMm: 12.0, maxMin: 15, fallbackMin: 8,  group: "lawn", intervalDays: 1, enabled: true},
 }
 `
 
@@ -69,7 +79,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	inputFile  := os.Args[1]
+	inputFile := os.Args[1]
 	outputFile := os.Args[2]
 
 	content, err := os.ReadFile(inputFile)

--- a/tools/extract-garden-defaults/main_test.go
+++ b/tools/extract-garden-defaults/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -88,5 +89,28 @@ func TestExtractFloatDefault_NotFound(t *testing.T) {
 	_, err := extractFloatDefault("nothing here", "bar")
 	if err == nil {
 		t.Fatal("expected error for missing field")
+	}
+}
+
+// TestOutputTemplate_ZoneDefaultsGroupingAndInterval guards the hardcoded
+// per-zone group/intervalDays literal in outputTemplate (defaultZoneDefaults
+// is not parsed from garden.js — see the comment above outputTemplate).
+// Catches a typo'd group name or a forgotten intervalDays update next time
+// these defaults are retuned (as happened going from beds intervalDays 7->4).
+func TestOutputTemplate_ZoneDefaultsGroupingAndInterval(t *testing.T) {
+	want := []string{
+		`group: "lawn", intervalDays: 1`,
+		`group: "beds", intervalDays: 4`,
+	}
+	for _, w := range want {
+		if !strings.Contains(outputTemplate, w) {
+			t.Errorf("outputTemplate missing expected zone default %q", w)
+		}
+	}
+	if n := strings.Count(outputTemplate, `group: "lawn"`); n != 2 {
+		t.Errorf("expected 2 zones in group \"lawn\", found %d", n)
+	}
+	if n := strings.Count(outputTemplate, `group: "beds"`); n != 1 {
+		t.Errorf("expected 1 zone in group \"beds\", found %d", n)
 	}
 }


### PR DESCRIPTION
## Summary
- Lawn zones (switch:0/2) fire together on a 1-day group interval; massifs (switch:1) is gated to a 4-day minimum interval, balancing its mixed planting (mediterranean low-water plants alongside citrus/Strelitzia/Agapanthus that want water more often in summer).
- `group-last` only advances on a real automated watering completion (never at plan time), so quiet-window/rain aborts can't skip a cycle.
- Fixes a real crash found during live device verification: Espruino's `Date` has no `getTimezoneOffset()` — the day-number helper now uses `Date.now()` instead.
- Adds test coverage: isolated goja unit tests for the new group-gating logic in `garden.js`, plus Go tests for `defaultZoneKVS()` and the extractor's zone-defaults template (previously untested).

## Test plan
- [x] `make build && make test` (full canonical suite, all go.work submodules) — green
- [x] Live verification on device `arrosage`: uploaded, confirmed KVS `zoneN-group`/`zoneN-interval` load correctly, confirmed lawn fire-together, beds independent gating, and weekly→4-day retune via `Script.Eval` against real production deficits
- [x] Confirmed real overnight automated cycle completed successfully with the new cadence logic (run counters incremented, `group-last` recorded via genuine `tickWatering()` completion path)
- [x] New unit tests: `internal/shelly/scripts/garden_test.go`, `myhome/ctl/garden/setup_test.go`, `tools/extract-garden-defaults/main_test.go`<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(garden): differentiated watering cadence by zone group ([cb8605d](https://github.com/asnowfix/home-automation/commit/cb8605d0552c2aa10c1cf4adf4676a2a47fe7325))
- test(garden): cover differentiated-cadence logic and zone KVS generation ([fadb7a4](https://github.com/asnowfix/home-automation/commit/fadb7a4a1687cb6ac0ab3999fe54f19d31f73d94))
<!-- END-AUTO-GENERATED-COMMITS -->