### PR TITLE
Backport: fix(packaging) dpkg conflict with prometheus-mqtt-exporter (#261)

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -112,11 +112,14 @@ jobs:
           cp linux/systemd/update.sh .debpkg/usr/share/myhome/update.sh
           cp linux/systemd/myhome-db-backup.sh .debpkg/usr/share/myhome/myhome-db-backup.sh
           cp myhome-example.yaml .debpkg/usr/share/myhome/myhome-example.yaml
+          cp linux/prometheus/mqtt-exporter.yaml.sample .debpkg/usr/share/myhome/prometheus-mqtt-exporter.yaml.sample
           chmod +x .debpkg/usr/share/myhome/*.sh
 
-          # Prometheus MQTT Exporter configuration
-          mkdir -p .debpkg/etc/prometheus
-          cp linux/prometheus/mqtt-exporter.yaml .debpkg/etc/prometheus/mqtt-exporter.yaml
+          # Prometheus MQTT Exporter: systemd drop-in pointing it at our own
+          # config path, instead of /etc/prometheus/mqtt-exporter.yaml (owned
+          # by the upstream prometheus-mqtt-exporter package — see #261)
+          mkdir -p .debpkg/lib/systemd/system/prometheus-mqtt-exporter.service.d
+          cp linux/prometheus/myhome.conf .debpkg/lib/systemd/system/prometheus-mqtt-exporter.service.d/myhome.conf
 
           # DEBIAN maintainer scripts
           mkdir -p .debpkg/DEBIAN

--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,13 @@ debpkg: build
 	cp linux/systemd/update.sh $(DEBPKG_DIR)/usr/share/myhome/update.sh
 	cp linux/systemd/myhome-db-backup.sh $(DEBPKG_DIR)/usr/share/myhome/myhome-db-backup.sh
 	cp myhome-example.yaml $(DEBPKG_DIR)/usr/share/myhome/myhome-example.yaml
+	cp linux/prometheus/mqtt-exporter.yaml.sample $(DEBPKG_DIR)/usr/share/myhome/prometheus-mqtt-exporter.yaml.sample
 	chmod +x $(DEBPKG_DIR)/usr/share/myhome/*.sh
-	@# Prometheus MQTT Exporter configuration
-	mkdir -p $(DEBPKG_DIR)/etc/prometheus
-	cp linux/prometheus/mqtt-exporter.yaml $(DEBPKG_DIR)/etc/prometheus/mqtt-exporter.yaml
+	@# Prometheus MQTT Exporter: systemd drop-in pointing it at our own config
+	@# path, instead of /etc/prometheus/mqtt-exporter.yaml (owned by the
+	@# upstream prometheus-mqtt-exporter package — see #261)
+	mkdir -p $(DEBPKG_DIR)/lib/systemd/system/prometheus-mqtt-exporter.service.d
+	cp linux/prometheus/myhome.conf $(DEBPKG_DIR)/lib/systemd/system/prometheus-mqtt-exporter.service.d/myhome.conf
 	@# DEBIAN maintainer scripts
 	mkdir -p $(DEBPKG_DIR)/DEBIAN
 	cp linux/debian/postinst.sh $(DEBPKG_DIR)/DEBIAN/postinst

--- a/docs/PROMETHEUS-PACKAGING-CONFLICT-PLAN.md
+++ b/docs/PROMETHEUS-PACKAGING-CONFLICT-PLAN.md
@@ -1,0 +1,55 @@
+# Fix: myhome .deb conflicts with prometheus-mqtt-exporter (#261)
+
+## Root cause
+
+`myhome` ships `/etc/prometheus/mqtt-exporter.yaml`, a path already owned (as a
+conffile) by the upstream Debian package `prometheus-mqtt-exporter`
+(`hikhvar/mqtt2prometheus` upstream). dpkg refuses to install when both
+packages claim the same path.
+
+## Findings
+
+- `prometheus-mqtt-exporter` (confirmed on the NAS, v0.1.7-1+b4) only accepts
+  a single config file via `-config <path>` (default
+  `/etc/prometheus/mqtt-exporter.yaml`). It has no conf.d/include mechanism,
+  so we cannot "drop in" a fragment at the exporter-config level.
+- systemd unit drop-ins (`<unit>.service.d/*.conf`) are a package-agnostic
+  override mechanism that works regardless of what the exporter itself
+  supports. We can use this to repoint `-config` at a myhome-owned file
+  without ever touching anything `prometheus-mqtt-exporter` owns.
+
+## Approach
+
+Ship our config under our own namespace and override the exporter's
+`ExecStart` via a drop-in, instead of claiming the upstream's path:
+
+1. `linux/prometheus/mqtt-exporter.yaml` → renamed to
+   `mqtt-exporter.yaml.sample`, installed to
+   `/usr/share/myhome/prometheus-mqtt-exporter.yaml.sample`.
+2. `postinst.sh` copies the sample to `/etc/myhome/prometheus-mqtt-exporter.yaml`
+   if missing — same pattern already used for `myhome.yaml`.
+3. New `linux/prometheus/myhome.conf` systemd drop-in, installed to
+   `/lib/systemd/system/prometheus-mqtt-exporter.service.d/myhome.conf`,
+   overriding `ExecStart` to pass `-config /etc/myhome/prometheus-mqtt-exporter.yaml`.
+4. `postinst.sh` already does `systemctl daemon-reload` + conditional restart
+   of `prometheus-mqtt-exporter` if installed and active — this now also
+   picks up the new drop-in.
+5. `postrm.sh` gets a matching conditional restart on remove/purge so the
+   exporter reverts to its own default config once our drop-in is gone
+   (dpkg removes `/lib/systemd/system/.../myhome.conf` automatically since
+   it's a plain package file, not a conffile).
+
+No `Conflicts:`/`Replaces:` needed, no `--force-overwrite` workaround. myhome
+never owns a path belonging to `prometheus-mqtt-exporter`, so future upstream
+changes to that package can't reintroduce the conflict.
+
+## Phases
+
+- [x] Phase 1 — plan (this file)
+- [x] Phase 2 — rename yaml to `.sample`, add systemd drop-in unit file
+- [x] Phase 3 — update `Makefile` `debpkg` target
+- [x] Phase 4 — update `.github/workflows/package-release.yml`
+- [x] Phase 5 — update `postinst.sh`
+- [x] Phase 6 — update `postrm.sh`
+- [x] Phase 7 — update `docs/prometheus-mqtt-exporter.md`
+- [x] Phase 8 — validate (shell syntax, yaml lint, `make test`)

--- a/docs/prometheus-mqtt-exporter.md
+++ b/docs/prometheus-mqtt-exporter.md
@@ -100,29 +100,57 @@ Where `{mac}` is the BLU device MAC address (e.g., `e8:e0:7e:d0:f9:89`).
 
 ## Configuration File
 
-The configuration file should be installed as `/etc/prometheus/mqtt-exporter.yaml` and will override the default configuration from the Debian `prometheus-mqtt-exporter` package.
+The Debian `prometheus-mqtt-exporter` package owns `/etc/prometheus/mqtt-exporter.yaml`
+as a conffile, so myhome never installs anything at that path (doing so used
+to conflict at `dpkg -i` time — see [#261](https://github.com/asnowfix/home-automation/issues/261)).
+Instead, myhome ships its own config under `/etc/myhome/` and uses a systemd
+unit drop-in to point the exporter at it:
+
+- `linux/prometheus/mqtt-exporter.yaml.sample` is installed to
+  `/usr/share/myhome/prometheus-mqtt-exporter.yaml.sample`. The package's
+  `postinst` copies it to `/etc/myhome/prometheus-mqtt-exporter.yaml` on
+  first install, only if that file doesn't already exist (same pattern as
+  `myhome.yaml`/`myhome-example.yaml`).
+- `linux/prometheus/myhome.conf` is installed to
+  `/lib/systemd/system/prometheus-mqtt-exporter.service.d/myhome.conf`. It
+  overrides the unit's `ExecStart` to pass
+  `-config /etc/myhome/prometheus-mqtt-exporter.yaml`, since the exporter
+  itself only accepts a single `-config` flag and has no conf.d/include
+  mechanism of its own.
+
+myhome never touches `/etc/prometheus/mqtt-exporter.yaml` or any other file
+owned by `prometheus-mqtt-exporter`, so the two packages can coexist without
+`Conflicts:`/`Replaces:` or `dpkg --force-overwrite`.
 
 ### Location
 
 ```
-/Users/fix/Desktop/GIT/home-automation/linux/prometheus/mqtt-exporter.yaml
+linux/prometheus/mqtt-exporter.yaml.sample
+linux/prometheus/myhome.conf
 ```
 
 ### Installation
 
+Installed automatically by the `myhome` `.deb` package's `postinst`/`debpkg`
+build (see `Makefile`'s `debpkg` target). To apply manually on a system
+where `myhome` is already installed:
+
 ```bash
-# Copy the configuration file to the system location
-sudo cp linux/prometheus/mqtt-exporter.yaml /etc/prometheus/mqtt-exporter.yaml
+# Edit myhome's own copy of the exporter config
+sudo vi /etc/myhome/prometheus-mqtt-exporter.yaml
 
 # Reload systemd daemon and restart the service
 sudo systemctl daemon-reload
 sudo systemctl restart prometheus-mqtt-exporter
 
-# Verify the service is running
+# Verify the service is running, and that it picked up myhome's config
 sudo systemctl status prometheus-mqtt-exporter
+sudo systemctl cat prometheus-mqtt-exporter | grep ExecStart
 ```
 
-**Note**: The service automatically reads `/etc/prometheus/mqtt-exporter.yaml` on startup. A simple restart is sufficient to apply configuration changes.
+**Note**: Editing `/etc/myhome/prometheus-mqtt-exporter.yaml` only needs a
+service restart (no `daemon-reload`) to take effect. `daemon-reload` is only
+needed when the drop-in unit file itself changes.
 
 ### Configuration Structure
 
@@ -296,6 +324,6 @@ monitoredSwitches: ["switch:0", "switch:1"]
 
 ## References
 
-- [mqtt-prometheus-exporter GitHub](https://github.com/torilabs/mqtt-prometheus-exporter)
+- [mqtt2prometheus GitHub](https://github.com/hikhvar/mqtt2prometheus) (upstream of the Debian `prometheus-mqtt-exporter` package)
 - [Prometheus Documentation](https://prometheus.io/docs/)
 - [HiveMQ MQTT CLI](https://hivemq.github.io/mqtt-cli/)

--- a/linux/debian/postinst.sh
+++ b/linux/debian/postinst.sh
@@ -5,6 +5,8 @@ SERVICE="myhome"
 CONFIG_DIR="/etc/$SERVICE"
 CONFIG_FILE="$CONFIG_DIR/myhome.yaml"
 EXAMPLE_CONFIG="/usr/share/$SERVICE/myhome-example.yaml"
+PROM_CONFIG_FILE="$CONFIG_DIR/prometheus-mqtt-exporter.yaml"
+PROM_EXAMPLE_CONFIG="/usr/share/$SERVICE/prometheus-mqtt-exporter.yaml.sample"
 
 # All systemd units to manage
 SERVICES="${SERVICE}.service"
@@ -28,6 +30,22 @@ if [ ! -f "$CONFIG_FILE" ]; then
     fi
 else
     echo "Configuration file already exists at $CONFIG_FILE"
+fi
+
+# Create default Prometheus MQTT exporter configuration if it doesn't exist.
+# Lives under /etc/myhome (not /etc/prometheus) to avoid clashing with the
+# upstream prometheus-mqtt-exporter package's own conffile (see #261); the
+# systemd drop-in shipped alongside it points the exporter here.
+if [ ! -f "$PROM_CONFIG_FILE" ]; then
+    if [ -f "$PROM_EXAMPLE_CONFIG" ]; then
+        echo "Creating default Prometheus MQTT exporter configuration at $PROM_CONFIG_FILE..."
+        cp "$PROM_EXAMPLE_CONFIG" "$PROM_CONFIG_FILE"
+        chmod 644 "$PROM_CONFIG_FILE"
+    else
+        echo "Warning: Example Prometheus MQTT exporter configuration not found at $PROM_EXAMPLE_CONFIG"
+    fi
+else
+    echo "Prometheus MQTT exporter configuration already exists at $PROM_CONFIG_FILE"
 fi
 
 # Check if the script is being run during package installation

--- a/linux/debian/postrm.sh
+++ b/linux/debian/postrm.sh
@@ -23,6 +23,13 @@ if [ "$1" = "purge" ]; then
     # Reload systemd
     systemctl daemon-reload
 
+    # dpkg already removed our prometheus-mqtt-exporter.service.d drop-in;
+    # restart so the exporter reverts to its own default configuration
+    if systemctl is-active --quiet prometheus-mqtt-exporter 2>/dev/null; then
+        echo "Restarting prometheus-mqtt-exporter to drop myhome's configuration override..."
+        systemctl restart prometheus-mqtt-exporter 2>/dev/null || true
+    fi
+
     # Optionally remove data directory (commented out for safety)
     # rm -rf /var/lib/$SERVICE
 fi
@@ -41,6 +48,13 @@ if [ "$1" = "remove" ]; then
 
     # Reload systemd
     systemctl daemon-reload
+
+    # dpkg already removed our prometheus-mqtt-exporter.service.d drop-in;
+    # restart so the exporter reverts to its own default configuration
+    if systemctl is-active --quiet prometheus-mqtt-exporter 2>/dev/null; then
+        echo "Restarting prometheus-mqtt-exporter to drop myhome's configuration override..."
+        systemctl restart prometheus-mqtt-exporter 2>/dev/null || true
+    fi
 fi
 
 # Exit successfully

--- a/linux/prometheus/mqtt-exporter.yaml.sample
+++ b/linux/prometheus/mqtt-exporter.yaml.sample
@@ -1,5 +1,9 @@
-# Prometheus MQTT Exporter Configuration
-# This file should be installed as /etc/prometheus/mqtt-exporter.yaml
+# Prometheus MQTT Exporter Configuration (myhome sample)
+# Installed by myhome's postinst as /etc/myhome/prometheus-mqtt-exporter.yaml
+# (only if that file doesn't already exist), and pointed to by the
+# prometheus-mqtt-exporter.service systemd drop-in shipped alongside it.
+# This avoids clashing with /etc/prometheus/mqtt-exporter.yaml, which is
+# owned by the upstream prometheus-mqtt-exporter Debian package (see #261).
 # It configures the exporter to consume metrics published by Shelly watchdog.js scripts
 #
 # The watchdog.js script publishes individual metrics as JSON to topics like:

--- a/linux/prometheus/myhome.conf
+++ b/linux/prometheus/myhome.conf
@@ -1,0 +1,10 @@
+# systemd drop-in for prometheus-mqtt-exporter.service
+# Installed by myhome at /lib/systemd/system/prometheus-mqtt-exporter.service.d/myhome.conf
+#
+# Repoints the exporter at myhome's own config file instead of
+# /etc/prometheus/mqtt-exporter.yaml, which is owned by the upstream
+# prometheus-mqtt-exporter Debian package (see #261). The empty ExecStart=
+# clears the unit's original ExecStart before the override below replaces it.
+[Service]
+ExecStart=
+ExecStart=/usr/bin/prometheus-mqtt-exporter -config /etc/myhome/prometheus-mqtt-exporter.yaml


### PR DESCRIPTION
## Summary
Cherry-picks the issue #261 packaging fix from `main` (af3688f, cherry-picked from 864bced) onto `v0.10.x`:

- myhome no longer ships `/etc/prometheus/mqtt-exporter.yaml` (owned by the upstream `prometheus-mqtt-exporter` Debian package, causing a `dpkg -i` conflict).
- Config now ships as a sample under `/usr/share/myhome/`, materialized to `/etc/myhome/prometheus-mqtt-exporter.yaml` by `postinst`.
- A systemd drop-in (`prometheus-mqtt-exporter.service.d/myhome.conf`) repoints the exporter's `-config` flag at that file instead.
- `postrm` restarts the exporter on remove/purge so it reverts to defaults.

The cherry-pick applied cleanly — `linux/debian/postinst.sh`, `postrm.sh`, `.github/workflows/package-release.yml`, `docs/prometheus-mqtt-exporter.md`, and `linux/prometheus/mqtt-exporter.yaml` were byte-identical between `v0.10.x` and `main` pre-fix; only `Makefile` needed an auto-merge (unrelated `cover`/garden-generate hunks present on `main` but not `v0.10.x` didn't overlap with the `debpkg` target this fix touches).

## Test plan
- [x] `make generate && make test` passes on `v0.10.x` with this commit applied
- [ ] Build and install the `.deb` on the NAS alongside `prometheus-mqtt-exporter` 0.1.7-1+b4 to confirm no dpkg conflict<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(packaging): avoid dpkg conflict with prometheus-mqtt-exporter (#261) ([af3688f](https://github.com/asnowfix/home-automation/commit/af3688fa50cc2807fe472cc058a353eff2da0bde))
<!-- END-AUTO-GENERATED-COMMITS -->