### PR TITLE
fix(mqtt): stop devices' MQTT broker from drifting to loopback address (backport)

### DIFF
--- a/docs/MQTT-BROKER-LOOPBACK-PLAN.md
+++ b/docs/MQTT-BROKER-LOOPBACK-PLAN.md
@@ -1,0 +1,101 @@
+# Fix: devices get MQTT broker overwritten with loopback address
+
+## Bug
+
+Some Shelly devices intermittently end up with their MQTT broker config set
+to `localhost:1883` (which the device itself resolves to `127.0.0.1`),
+breaking MQTT connectivity until manually reconfigured.
+
+## Root cause (three compounding issues)
+
+1. `myhome/devices/impl/manager.go` (daemon `Start()`) builds the auto-setup
+   MQTT broker from `dm.mqttClient.GetServer()`, which is the daemon's own
+   connection string (literally `"localhost:1883"` when running the default
+   embedded broker). It does not go through `DeviceServer()`, the
+   loopback→LAN-IP resolver already added for the CLI paths
+   (`myhome ctl shelly setup`, `myhome ctl shelly mqtt config`) in commit
+   `a52aeba`.
+2. `myhome/daemon/watch/zeroconf.go` treats *any* error from
+   `db.GetDeviceByAny` the same as "device not in DB yet", rebuilding a fresh
+   in-memory device with `Info == nil`. That flag makes
+   `manager.go`'s `deviceUpdaterLoop` treat an already-configured device as
+   brand new and run auto-setup on it again.
+3. `internal/myhome/shelly/setup/setup.go`'s `IsDeviceSetUp` collapses *any*
+   error (communication failure, timeout, no channel available) into
+   `false` ("not set up"), so a transient hiccup talking to an already-setup
+   device causes the full setup flow — including the MQTT broker rewrite —
+   to run again.
+
+Any one of #2 or #3 misfiring, combined with #1, rewrites a working device's
+broker to the unresolved loopback string.
+
+## Fix
+
+- [x] Phase 1: `manager.go` — use `mc.DeviceServer()` (loopback-resolved)
+      instead of `mc.GetServer()` for the auto-setup MQTT broker, with
+      fallback to the existing `options.Flags.MqttBroker` / `mqtt.local`
+      chain if resolution fails.
+- [x] Phase 2: `zeroconf.go` — only treat a device as unknown when the DB
+      lookup says "not found" (`sql.ErrNoRows`); on any other DB error, skip
+      this discovery entry instead of fabricating a fresh "new" device.
+- [x] Phase 3: `setup.go` / `manager.go` — `IsDeviceSetUp` returns
+      `(bool, error)`. The error case is now reserved for "no channel
+      available at all" (`selectChannel` failure) — genuinely ambiguous,
+      and `SetupDevice` would fail at the same step anyway, so callers skip
+      this round rather than treating it as "not set up."
+
+      A KVS read failure (the actual `script/setup/done` lookup) still
+      can't be cleanly split into "genuinely missing key" vs "transient
+      comm error": the MQTT and HTTP RPC transports
+      (`pkg/shelly/mqtt/channel.go`, `pkg/shelly/shttp/channel.go`) collapse
+      both into a generic `error`, and the HTTP channel doesn't even decode
+      the JSON-RPC error envelope at all today. Properly fixing that needs
+      transport-level changes (capturing `res.Error.Code`, parsing it on the
+      HTTP side too) that are out of scope for this bug and were not
+      attempted here to avoid hardcoding an unverified Shelly RPC error code
+      as load-bearing logic. As a proportionate mitigation, `IsDeviceSetUp`
+      retries the KVS read once (1s apart) before concluding "not set up" —
+      reduces, but does not eliminate, the chance a single flaky read
+      triggers a full re-setup (incl. MQTT broker rewrite) on a working
+      device. Phase 2 already removes the dominant real-world trigger for
+      that scenario.
+
+No transport-level RPC error-code plumbing needed — these are all
+caller-side fixes that stop collapsing "unknown" into "definitely not set
+up / definitely new."
+
+- [x] Phase 4: regular reconciliation job (self-healing safety net,
+      independent of root cause above).
+
+  `myhome/devices/impl/manager.go`'s new `runReconciliationLoop` (ticker
+  pattern modeled on `runDeviceRefreshJob`) walks every known Gen2+ device
+  (skip Gen1/BLU, same filter as the refresh job) once per
+  `ReconcileInterval` and calls the new
+  `internal/myhome/shelly/setup/setup.go:ReconcileConfig`, which **forces
+  HTTP** (not MQTT — if a device's broker is wrong, MQTT may falsely look
+  "ready" while not actually reaching the daemon, so HTTP-to-the-device's-
+  own-IP is the only channel guaranteed to reflect reality) and re-applies:
+  - MQTT broker = the canonical, loopback-resolved broker address
+    (`dm.setupConfig`, the same source of truth built for auto-setup in
+    Phase 1, now also reused here).
+  - NTP server (`pool.ntp.org`) and Matter disabled — the other idempotent
+    values `SetupDevice` establishes on first setup.
+
+  `ReconcileConfig` explicitly does **not** touch the device name, WiFi, or
+  watchdog.js script management — those are one-time provisioning concerns,
+  and re-running them periodically risks clobbering user edits (e.g. a
+  renamed device) for no benefit. It only issues a write (and the
+  subsequent reboot-and-wait) when the current value actually differs from
+  the canonical one, so a healthy device sees nothing but a few idempotent
+  reads each cycle.
+
+  Implementation extracted two pieces of `SetupDevice` into reusable
+  helpers rather than threading a channel parameter through it directly
+  (lower risk, no behavior change to the existing CLI-driven setup path):
+  `resolveMqttServer` (broker string resolution) and `rebootIfRequired`
+  (reboot-and-wait-for-online loop) in `setup.go`.
+
+  New config: `ReconcileInterval` (flag `--reconcile-interval`, env
+  `MYHOME_DAEMON_RECONCILE_INTERVAL`, default `1h`) — added to
+  `options.go`, `run.go`, `docs/configuration.md`, `myhome-example.yaml`
+  per the project's 4-file config-option convention. `0` disables the loop.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,7 @@ daemon:
   mqtt_watchdog_max_failures: 3
   mqtt_reconnect_interval: 2h
   mqtt_broker_client_log_interval: 2m
+  reconcile_interval: 1h
   
   # MyHome Ports
   ui_port: 6080
@@ -118,6 +119,12 @@ daemon:
 - Set to `0` to disable
 - Flag: `--mqtt-broker-client-log-interval`
 - Env: `MYHOME_DAEMON_MQTT_BROKER_CLIENT_LOG_INTERVAL`
+
+**`reconcile_interval`** (duration, default: `1h`)
+- Interval for re-applying the canonical MQTT broker address, NTP server, and Matter-disabled setting to every known Gen2+ device, over HTTP. Self-healing safety net against config drift (e.g. a device ending up with the wrong MQTT broker). Never touches device name, WiFi, or scripts.
+- Set to `0` to disable
+- Flag: `--reconcile-interval`
+- Env: `MYHOME_DAEMON_RECONCILE_INTERVAL`
 
 #### Service Ports
 

--- a/internal/myhome/shelly/setup/setup.go
+++ b/internal/myhome/shelly/setup/setup.go
@@ -12,21 +12,21 @@ import (
 
 	"github.com/go-logr/logr"
 
-	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
+	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/input"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/matter"
 	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+	"github.com/asnowfix/home-automation/pkg/shelly/schedule"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/sswitch"
 	"github.com/asnowfix/home-automation/pkg/shelly/system"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/asnowfix/home-automation/pkg/shelly/wifi"
-	"github.com/asnowfix/home-automation/pkg/shelly/schedule"
 )
 
 // Config holds configuration options for device setup
@@ -249,29 +249,11 @@ func SetupDevice(ctx context.Context, log logr.Logger, sd *shellyapi.Device, tar
 
 	// Configure MQTT server
 	log.Info("Configuring MQTT broker", "device", deviceId)
-	if cfg.MqttBroker != "" {
-		mqttServer := cfg.MqttBroker
-
-		// If MqttPort is 0, the broker string already includes the port (e.g., "192.168.1.1:1883")
-		// Otherwise, we need to resolve the hostname and append the port
-		if cfg.MqttPort == 0 {
-			// Broker already includes port, use as-is
-			log.Info("Using MQTT broker with embedded port", "server", mqttServer)
-		} else {
-			// Need to resolve hostname and append port
-			if cfg.Resolver != nil {
-				ips, err := cfg.Resolver.LookupHost(ctx, log, cfg.MqttBroker)
-				if err != nil {
-					return fmt.Errorf("failed to resolve MQTT broker %s: %w", cfg.MqttBroker, err)
-				}
-				if len(ips) == 0 {
-					return fmt.Errorf("no IP address resolved for %s", cfg.MqttBroker)
-				}
-				mqttServer = ips[0].String()
-			}
-			mqttServer = net.JoinHostPort(mqttServer, strconv.Itoa(cfg.MqttPort))
-		}
-
+	mqttServer, err := resolveMqttServer(ctx, log, cfg)
+	if err != nil {
+		return err
+	}
+	if mqttServer != "" {
 		log.Info("Setting MQTT broker", "device", deviceId, "server", mqttServer, "via", via, "http_ready", sd.IsHttpReady(), "mqtt_ready", sd.IsMqttReady())
 		_, err = mqtt.SetServer(ctx, via, sd, mqttServer)
 		if err != nil {
@@ -283,46 +265,8 @@ func SetupDevice(ctx context.Context, log logr.Logger, sd *shellyapi.Device, tar
 		log.Info("MQTT broker not configured (no broker specified)", "device", deviceId)
 	}
 
-	status, err := system.GetStatus(ctx, via, sd)
-	if err != nil {
-		log.Error(err, "Failed to get device status", "device", deviceId)
-		return fmt.Errorf("failed to get device status: %w", err)
-	}
-
-	// Reboot device if necessary (required after MQTT configuration change)
-	if status.RestartRequired {
-		log.Info("Rebooting device (required after configuration changes)", "device", deviceId)
-
-		err = shelly.DoReboot(ctx, sd)
-		if err != nil {
-			log.Error(err, "Failed to reboot device", "device", deviceId)
-			return fmt.Errorf("failed to reboot device: %w", err)
-		}
-
-		// Wait for device to go offline (reboot started)
-		log.Info("Waiting for device to go offline", "device", deviceId)
-		time.Sleep(5 * time.Second)
-
-		// Wait for device to come back online
-		log.Info("Waiting for device to come back online", "device", deviceId)
-		maxRetries := 20 // 20 * 3 seconds = 60 seconds max
-		for i := 0; i < maxRetries; i++ {
-			time.Sleep(3 * time.Second)
-			status, err = system.GetStatus(ctx, via, sd)
-			if err == nil {
-				// Device is back online
-				log.Info("Device rebooted successfully", "device", deviceId)
-				break
-			}
-			if i == maxRetries-1 {
-				log.Error(nil, "Device did not come back online after reboot", "device", deviceId)
-				return fmt.Errorf("device did not come back online after reboot")
-			}
-		}
-
-		// Wait additional time for all services to fully initialize
-		log.Info("Waiting for device services to fully initialize", "device", deviceId)
-		time.Sleep(10 * time.Second)
+	if err := rebootIfRequired(ctx, log, via, sd, deviceId); err != nil {
+		return err
 	}
 
 	// Load watchdog.js as script #1
@@ -413,24 +357,164 @@ const setupDoneKey = "script/setup/done"
 
 // IsDeviceSetUp checks if a device has already been set up by looking for the setup marker in KVS.
 // This is cheaper than listing scripts.
-func IsDeviceSetUp(ctx context.Context, log logr.Logger, sd *shellyapi.Device) bool {
+//
+// A returned error means "could not even attempt the check" (no HTTP or MQTT channel is
+// ready for this device at all) and must not be treated as "not set up": callers should
+// skip the device for this round rather than re-running setup, since SetupDevice itself
+// would fail at the same channel-selection step anyway.
+//
+// A missing KVS key (genuinely never set up) and a transient read failure currently look
+// identical at this layer - the RPC transports don't distinguish "not found" from "timeout"
+// (see docs/MQTT-BROKER-LOOPBACK-PLAN.md). To avoid letting a single flaky read trigger a
+// full re-setup (including rewriting the device's MQTT broker) on an already-configured
+// device, the read is retried once before concluding "not set up".
+func IsDeviceSetUp(ctx context.Context, log logr.Logger, sd *shellyapi.Device) (bool, error) {
 	via, err := selectChannel(sd)
 	if err != nil {
-		log.Error(err, "Unable to determine if device is set up (Channel)", "device", sd.Id())
-		return false
+		return false, fmt.Errorf("unable to determine if device %s is set up (channel): %w", sd.Id(), err)
 	}
 	_, err = kvs.GetValue(ctx, log, via, sd, setupDoneKey)
-	if err != nil {
-		log.Error(err, "Unable to determine if device is set up (KVS)", "device", sd.Id())
-		return false
+	if err == nil {
+		return true, nil
 	}
-	return true
+	log.V(1).Info("KVS read failed, retrying once before concluding device is not set up", "device", sd.Id(), "error", err)
+	time.Sleep(time.Second)
+	_, err = kvs.GetValue(ctx, log, via, sd, setupDoneKey)
+	return err == nil, nil
 }
 
 // markDeviceSetUp stores a marker in KVS to indicate the device has been set up
 func markDeviceSetUp(ctx context.Context, log logr.Logger, via types.Channel, sd *shellyapi.Device) error {
 	_, err := kvs.SetKeyValue(ctx, log, via, sd, setupDoneKey, "1")
 	return err
+}
+
+// resolveMqttServer turns cfg.MqttBroker/cfg.MqttPort into a host:port string ready
+// to write to a device's MQTT config. Returns "" if no broker is configured.
+func resolveMqttServer(ctx context.Context, log logr.Logger, cfg Config) (string, error) {
+	if cfg.MqttBroker == "" {
+		return "", nil
+	}
+	mqttServer := cfg.MqttBroker
+
+	// If MqttPort is 0, the broker string already includes the port (e.g., "192.168.1.1:1883")
+	// Otherwise, we need to resolve the hostname and append the port
+	if cfg.MqttPort == 0 {
+		log.Info("Using MQTT broker with embedded port", "server", mqttServer)
+		return mqttServer, nil
+	}
+	if cfg.Resolver != nil {
+		ips, err := cfg.Resolver.LookupHost(ctx, log, cfg.MqttBroker)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve MQTT broker %s: %w", cfg.MqttBroker, err)
+		}
+		if len(ips) == 0 {
+			return "", fmt.Errorf("no IP address resolved for %s", cfg.MqttBroker)
+		}
+		mqttServer = ips[0].String()
+	}
+	return net.JoinHostPort(mqttServer, strconv.Itoa(cfg.MqttPort)), nil
+}
+
+// rebootIfRequired reboots the device and waits for it to come back online, if the
+// device reports that a restart is required (e.g. after an MQTT broker change).
+func rebootIfRequired(ctx context.Context, log logr.Logger, via types.Channel, sd *shellyapi.Device, deviceId string) error {
+	status, err := system.GetStatus(ctx, via, sd)
+	if err != nil {
+		log.Error(err, "Failed to get device status", "device", deviceId)
+		return fmt.Errorf("failed to get device status: %w", err)
+	}
+	if !status.RestartRequired {
+		return nil
+	}
+
+	log.Info("Rebooting device (required after configuration changes)", "device", deviceId)
+	if err := shelly.DoReboot(ctx, sd); err != nil {
+		log.Error(err, "Failed to reboot device", "device", deviceId)
+		return fmt.Errorf("failed to reboot device: %w", err)
+	}
+
+	// Wait for device to go offline (reboot started)
+	log.Info("Waiting for device to go offline", "device", deviceId)
+	time.Sleep(5 * time.Second)
+
+	// Wait for device to come back online
+	log.Info("Waiting for device to come back online", "device", deviceId)
+	maxRetries := 20 // 20 * 3 seconds = 60 seconds max
+	for i := 0; i < maxRetries; i++ {
+		time.Sleep(3 * time.Second)
+		if _, err = system.GetStatus(ctx, via, sd); err == nil {
+			log.Info("Device rebooted successfully", "device", deviceId)
+			break
+		}
+		if i == maxRetries-1 {
+			log.Error(nil, "Device did not come back online after reboot", "device", deviceId)
+			return fmt.Errorf("device did not come back online after reboot")
+		}
+	}
+
+	// Wait additional time for all services to fully initialize
+	log.Info("Waiting for device services to fully initialize", "device", deviceId)
+	time.Sleep(10 * time.Second)
+	return nil
+}
+
+// ReconcileConfig periodically re-applies the idempotent configuration values
+// SetupDevice establishes on first setup (MQTT broker, NTP server, Matter disabled),
+// as a drift-correction safety net for already-configured devices. Unlike SetupDevice,
+// it never touches the device name, WiFi, or watchdog.js script management - those are
+// one-time provisioning concerns, and re-running them periodically risks clobbering
+// user edits (e.g. a renamed device) for no benefit.
+//
+// The caller passes an explicit channel rather than letting this function auto-select
+// one, so it can force types.ChannelHttp: if a device's MQTT broker is wrong, its
+// "MQTT ready" flag can look fine while it can't actually reach anything, so only HTTP
+// to the device's own IP is guaranteed to reflect reality.
+func ReconcileConfig(ctx context.Context, log logr.Logger, via types.Channel, sd *shellyapi.Device, cfg Config) error {
+	deviceId := sd.Id()
+
+	config, err := system.GetConfig(ctx, via, sd)
+	if err != nil {
+		return fmt.Errorf("failed to get system config: %w", err)
+	}
+	if config.Sntp.Server != "pool.ntp.org" {
+		config.Sntp.Server = "pool.ntp.org"
+		if _, err := system.SetConfig(ctx, via, sd, config); err != nil {
+			return fmt.Errorf("failed to set system config: %w", err)
+		}
+		log.Info("Reconciled NTP server", "device", deviceId)
+	}
+
+	if err := matter.Disable(ctx, via, sd); err != nil {
+		log.V(1).Info("Unable to disable Matter during reconciliation (may not be supported)", "device", deviceId, "error", err)
+	}
+
+	mqttServer, err := resolveMqttServer(ctx, log, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to resolve MQTT broker: %w", err)
+	}
+	if mqttServer == "" {
+		return nil
+	}
+
+	out, err := sd.CallE(ctx, via, mqtt.GetConfig.String(), nil)
+	if err != nil {
+		return fmt.Errorf("failed to get MQTT config: %w", err)
+	}
+	mqttCfg, ok := out.(*mqtt.Config)
+	if !ok {
+		return fmt.Errorf("unexpected MQTT config response type: %T", out)
+	}
+	if mqttCfg.Enable && mqttCfg.Server == mqttServer {
+		return nil
+	}
+
+	log.Info("Reconciling MQTT broker", "device", deviceId, "old_server", mqttCfg.Server, "new_server", mqttServer)
+	if _, err := mqtt.SetServer(ctx, via, sd, mqttServer); err != nil {
+		return fmt.Errorf("failed to set MQTT broker: %w", err)
+	}
+
+	return rebootIfRequired(ctx, log, via, sd, deviceId)
 }
 
 // nonAlphanumericRegex matches any non-alphanumeric character

--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -121,7 +121,11 @@ daemon:
   
   # MQTT broker client log interval (0 to disable)
   # mqtt_broker_client_log_interval: 2m
-  
+
+  # Interval for re-applying canonical MQTT broker/NTP/Matter config to known
+  # devices over HTTP, as a self-healing safety net against config drift (0 to disable)
+  # reconcile_interval: 1h
+
   # UI listen port
   # ui_port: 6080
 

--- a/myhome/ctl/options/options.go
+++ b/myhome/ctl/options/options.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/asnowfix/home-automation/internal/global"
+	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"os"
 	"os/signal"
-	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"syscall"
 	"time"
 
@@ -31,6 +31,8 @@ const MQTT_DEFAULT_GRACE time.Duration = 2 * time.Second
 const COMMAND_DEFAULT_TIMEOUT time.Duration = 0 // No timeout by default (wait indefinitely)
 
 const DEVICE_REFRESH_INTERVAL time.Duration = 1 * time.Minute
+
+const RECONCILE_DEFAULT_INTERVAL time.Duration = 1 * time.Hour
 
 const MQTT_WATCHDOG_CHECK_INTERVAL time.Duration = 30 * time.Second
 
@@ -73,6 +75,7 @@ var Flags struct {
 	MetricsExporterTopic        string
 	ShellyRateLimit             time.Duration // the value taken by --shelly-rate-limit
 	AutoSetup                   bool          // the value taken by --auto-setup / -A
+	ReconcileInterval           time.Duration // the value taken by --reconcile-interval (0 disables)
 	NoMdnsPublish               bool          // the value taken by --no-mdns-publish
 	InstanceName                string        // the value taken by --instance / -I
 	EventsDBPath                string        // path to events SQLite database

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -45,6 +45,7 @@ func init() {
 	runCmd.PersistentFlags().IntVar(&options.Flags.MetricsExporterPort, "metrics-exporter-port", options.PROMETHEUS_DEFAULT_PORT, "Prometheus metrics exporter HTTP port")
 	runCmd.PersistentFlags().StringVar(&options.Flags.MetricsExporterTopic, "metrics-exporter-topic", "shelly/metrics", "MQTT topic for Shelly device metrics")
 	runCmd.PersistentFlags().BoolVar(&disableAutoSetup, "disable-auto-setup", false, "Disable automatic configuration of newly discovered unknown devices")
+	runCmd.PersistentFlags().DurationVar(&options.Flags.ReconcileInterval, "reconcile-interval", options.RECONCILE_DEFAULT_INTERVAL, "Interval for re-applying canonical MQTT broker/NTP/Matter config to known devices over HTTP (0 to disable)")
 	runCmd.PersistentFlags().BoolVar(&options.Flags.NoMdnsPublish, "no-mdns-publish", false, "Disable mDNS/Zeroconf publishing (useful for dev instances)")
 	runCmd.PersistentFlags().StringVarP(&options.Flags.InstanceName, "instance", "I", "myhome", "Server instance name for RPC topics (default: myhome)")
 	runCmd.PersistentFlags().StringVar(&options.Flags.EventsDBPath, "events-db", defaultEventsDBPath(), "Path to the events SQLite database")
@@ -121,6 +122,9 @@ var runCmd = &cobra.Command{
 		}
 		if v.IsSet("daemon.mqtt_broker_client_log_interval") && !cmd.Flags().Changed("mqtt-broker-client-log-interval") {
 			options.Flags.MqttBrokerClientLogInterval = v.GetDuration("daemon.mqtt_broker_client_log_interval")
+		}
+		if v.IsSet("daemon.reconcile_interval") && !cmd.Flags().Changed("reconcile-interval") {
+			options.Flags.ReconcileInterval = v.GetDuration("daemon.reconcile_interval")
 		}
 		if v.IsSet("daemon.events_dir") && !cmd.Flags().Changed("events-dir") {
 			options.Flags.EventsDir = v.GetString("daemon.events_dir")

--- a/myhome/daemon/watch/zeroconf.go
+++ b/myhome/daemon/watch/zeroconf.go
@@ -2,12 +2,14 @@ package watch
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/asnowfix/home-automation/internal/myhome"
-	"github.com/asnowfix/home-automation/myhome/devices"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
-	"net"
+	"github.com/asnowfix/home-automation/myhome/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
+	"net"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -66,6 +68,14 @@ func ZeroConf(ctx context.Context, restartAfter time.Duration, dm devices.Manage
 						}
 
 						device, err := db.GetDeviceByAny(ctx, entry.Instance)
+						if err != nil && !errors.Is(err, sql.ErrNoRows) {
+							// Transient lookup failure (DB error, etc.) - do not
+							// treat an already-known device as brand new, which
+							// would re-trigger auto-setup and risk clobbering its
+							// working config. Retry on the next mDNS browse cycle.
+							log.Error(err, "Failed to look up device, skipping entry this cycle", "entry", entry)
+							continue
+						}
 						if err != nil || device.Info == nil {
 							sd, err := shelly.NewDeviceFromZeroConfEntry(ctx, log, dr, entry)
 							if err != nil {

--- a/myhome/devices/impl/manager.go
+++ b/myhome/devices/impl/manager.go
@@ -389,19 +389,32 @@ func (dm *DeviceManager) Start(ctx context.Context) error {
 	dm.setupConfig = shellysetup.Config{
 		Resolver: dm.resolver,
 	}
-	// Use the current process MQTT broker for auto-setup
+	// Use the current process MQTT broker for auto-setup. DeviceServer()
+	// resolves a loopback address (e.g. the embedded broker's "localhost:1883")
+	// to the host's LAN IP, since the device itself would otherwise resolve
+	// "localhost" to its own loopback interface.
+	deviceServer := ""
 	if dm.mqttClient != nil {
-		// GetServer returns host:port, use it directly
-		dm.setupConfig.MqttBroker = dm.mqttClient.GetServer()
+		var err error
+		deviceServer, err = dm.mqttClient.DeviceServer()
+		if err != nil {
+			dm.log.Error(err, "Failed to resolve device-facing MQTT broker address; falling back to configured broker")
+		}
+	}
+	switch {
+	case deviceServer != "":
+		dm.setupConfig.MqttBroker = deviceServer
 		dm.setupConfig.MqttPort = 0 // Signal that broker already includes port
-	} else if options.Flags.MqttBroker != "" {
+	case options.Flags.MqttBroker != "":
 		dm.setupConfig.MqttBroker = options.Flags.MqttBroker
 		dm.setupConfig.MqttPort = 1883
-	} else {
+	default:
 		dm.setupConfig.MqttBroker = "mqtt.local"
 		dm.setupConfig.MqttPort = 1883
 	}
 	dm.log.Info("Auto-setup configuration", "enabled", options.Flags.AutoSetup, "mqtt_broker", dm.setupConfig.MqttBroker)
+
+	go dm.runReconciliationLoop(logr.NewContext(ctx, dm.log.WithName("runReconciliationLoop")), options.Flags.ReconcileInterval)
 
 	// Loop on ZeroConf devices discovery
 	err = watch.ZeroConf(ctx, options.Flags.MdnsTimeout, dm, dm.dr, dm.resolver)
@@ -507,7 +520,13 @@ func (dm *DeviceManager) triggerAutoSetup(ctx context.Context, log logr.Logger, 
 	}
 
 	// Check if device is already set up (has watchdog script running)
-	if shellysetup.IsDeviceSetUp(ctx, log, sd) {
+	setUp, err := shellysetup.IsDeviceSetUp(ctx, log, sd)
+	if err != nil {
+		log.Info("Skipping auto-setup this round: could not determine setup state", "device_id", deviceId, "error", err)
+		dm.setupInFlight.Delete(deviceId)
+		return
+	}
+	if setUp {
 		log.V(1).Info("Skipping auto-setup: device already set up", "device_id", deviceId)
 		dm.setupInFlight.Delete(deviceId)
 		return
@@ -656,6 +675,69 @@ func (dm *DeviceManager) runDeviceRefreshJob(ctx context.Context, interval time.
 			dm.UpdateChannel() <- gen2Devices[i]
 			i++
 		}
+	}
+}
+
+// runReconciliationLoop periodically re-applies canonical MQTT broker / NTP / Matter
+// config to every known Gen2+ device over HTTP, as a self-healing safety net against
+// config drift (see docs/MQTT-BROKER-LOOPBACK-PLAN.md). interval <= 0 disables the loop.
+//
+// HTTP is forced rather than auto-selected: if a device's MQTT broker is wrong, its
+// "MQTT ready" flag can look fine while nothing actually reaches it, so only HTTP to
+// the device's own IP reflects reality.
+func (dm *DeviceManager) runReconciliationLoop(ctx context.Context, interval time.Duration) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		panic("BUG: No logger initialized")
+	}
+	if interval <= 0 {
+		log.Info("Reconciliation loop disabled")
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Exiting reconciliation loop")
+			return
+		case <-ticker.C:
+			devices, err := dm.GetAllDevices(ctx)
+			if err != nil {
+				log.Error(err, "Failed to get all devices for reconciliation")
+				continue
+			}
+			for _, d := range devices {
+				if shelly.IsGen1Device(d.Id()) || strings.HasPrefix(d.Id(), "shellyblu-") {
+					continue
+				}
+				dm.reconcileOneDevice(ctx, log, d)
+			}
+		}
+	}
+}
+
+func (dm *DeviceManager) reconcileOneDevice(ctx context.Context, log logr.Logger, device *myhome.Device) {
+	sd, ok := device.Impl().(*shelly.Device)
+	if !ok || sd == nil {
+		impl, err := shelly.NewDeviceFromSummary(ctx, log, device)
+		if err != nil {
+			log.Error(err, "Failed to create device for reconciliation", "device", device.Id())
+			return
+		}
+		sd, ok = impl.(*shelly.Device)
+		if !ok || sd == nil {
+			return
+		}
+	}
+	if sd.Host() == "" {
+		log.V(1).Info("Skipping reconciliation: no host known for device", "device", device.Id())
+		return
+	}
+	if err := shellysetup.ReconcileConfig(ctx, log, types.ChannelHttp, sd, dm.setupConfig); err != nil {
+		log.Error(err, "Reconciliation failed", "device", device.Id())
 	}
 }
 


### PR DESCRIPTION
Backport of #284 to v0.10.x.

## Summary
- Auto-setup wrote the daemon's own raw connection string (e.g. `localhost:1883` for the default embedded broker) to newly/re-discovered devices instead of resolving it to the host's LAN IP, so a device would resolve `localhost` to itself and lose MQTT connectivity.
- Two related gaps let an already-configured device misfire through the same auto-setup path on a transient hiccup: a DB lookup error during mDNS rediscovery was treated as "unknown device", and `IsDeviceSetUp` collapsed any error into "not set up".
- Adds a periodic HTTP-only reconciliation loop (`--reconcile-interval`, default 1h) that re-applies the canonical MQTT broker/NTP/Matter config to known devices as a self-healing safety net against drift.

Full analysis in `docs/MQTT-BROKER-LOOPBACK-PLAN.md`.

## Test plan
- [x] `make test` passes (full workspace, on this branch)
- [x] `go build` clean for all touched packages
- [ ] CI green<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(mqtt): stop devices' MQTT broker from drifting to loopback address ([9516074](https://github.com/asnowfix/home-automation/commit/95160743ded0381b8ab9aa80aacdb45a4ffb197e))
<!-- END-AUTO-GENERATED-COMMITS -->