### PR TITLE
fix(shelly): avoid panic when Foreach encounters a device with no ID yet

### DIFF
--- a/pkg/shelly/device.go
+++ b/pkg/shelly/device.go
@@ -628,6 +628,9 @@ func NewDeviceFromMqttId(ctx context.Context, log logr.Logger, id string) (devic
 }
 
 func NewDeviceFromSummary(ctx context.Context, log logr.Logger, summary devices.Device) (devices.Device, error) {
+	if summary.Id() == "" {
+		return nil, fmt.Errorf("device summary has empty ID (name=%q, host=%q)", summary.Name(), summary.Host())
+	}
 	d := &Device{
 		// info: &shelly.DeviceInfo{
 		// 	Name:    summary.Name(),
@@ -780,6 +783,13 @@ func Foreach(ctx context.Context, log logr.Logger, deviceList []devices.Device, 
 		wg.Add(1)
 		go func(devSummary devices.Device) {
 			defer wg.Done()
+
+			// Skip devices whose ID is not yet known (partially discovered)
+			if devSummary.Id() == "" {
+				log.V(1).Info("Skipping device with no ID yet", "name", devSummary.Name(), "host", devSummary.Host())
+				results <- DeviceResult{Device: devSummary, Error: nil}
+				return
+			}
 
 			// Skip Gen1 devices - they cannot receive commands or run scripts
 			if IsGen1Device(devSummary.Id()) {

--- a/pkg/shelly/device_test.go
+++ b/pkg/shelly/device_test.go
@@ -1,0 +1,197 @@
+package shelly
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/asnowfix/home-automation/pkg/devices"
+	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/go-logr/logr"
+)
+
+// stubDevice is a minimal devices.Device for tests.
+type stubDevice struct {
+	id   string
+	name string
+	host string
+}
+
+func (s stubDevice) Manufacturer() string      { return "shelly" }
+func (s stubDevice) Id() string                { return s.id }
+func (s stubDevice) Name() string              { return s.name }
+func (s stubDevice) Host() string              { return s.host }
+func (s stubDevice) Ip() net.IP               { return net.ParseIP(s.host) }
+func (s stubDevice) Mac() net.HardwareAddr    { return nil }
+
+func TestNewDeviceFromSummary_EmptyId_ReturnsError(t *testing.T) {
+	_, err := NewDeviceFromSummary(context.Background(), logr.Discard(), stubDevice{id: "", name: "unknown", host: "192.168.1.99"})
+	if err == nil {
+		t.Fatal("expected error for empty device ID, got nil")
+	}
+}
+
+func TestNewDeviceFromSummary_ValidId_Succeeds(t *testing.T) {
+	d, err := NewDeviceFromSummary(context.Background(), logr.Discard(), stubDevice{id: "shellyplus1pm-aabbccddeeff", name: "test", host: "192.168.1.50"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Id() != "shellyplus1pm-aabbccddeeff" {
+		t.Errorf("expected id shellyplus1pm-aabbccddeeff, got %q", d.Id())
+	}
+}
+
+func TestForeach_SkipsEmptyIdDevice(t *testing.T) {
+	called := false
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+		called = true
+		return nil, nil
+	}
+
+	deviceList := []devices.Device{
+		stubDevice{id: "", name: "partial", host: "192.168.1.10"},
+	}
+
+	_, err := Foreach(context.Background(), logr.Discard(), deviceList, types.ChannelDefault, do, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("do function should not be called for a device with empty ID")
+	}
+}
+
+func TestForeach_SkipsGen1Device(t *testing.T) {
+	called := false
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+		called = true
+		return nil, nil
+	}
+
+	deviceList := []devices.Device{
+		stubDevice{id: "shellyht-aabbccddeeff"},
+	}
+
+	_, err := Foreach(context.Background(), logr.Discard(), deviceList, types.ChannelDefault, do, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("do function should not be called for a Gen1 device")
+	}
+}
+
+func TestForeach_SkipsBluDevice(t *testing.T) {
+	called := false
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+		called = true
+		return nil, nil
+	}
+
+	deviceList := []devices.Device{
+		stubDevice{id: "shellybluht3-aabbccddeeff"},
+	}
+
+	_, err := Foreach(context.Background(), logr.Discard(), deviceList, types.ChannelDefault, do, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called {
+		t.Error("do function should not be called for a BLU device")
+	}
+}
+
+func TestForeach_EmptyList(t *testing.T) {
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+		return nil, nil
+	}
+	_, err := Foreach(context.Background(), logr.Discard(), nil, types.ChannelDefault, do, nil)
+	if err != nil {
+		t.Fatalf("unexpected error on empty device list: %v", err)
+	}
+}
+
+func TestIsGen1Device(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"shellyht-aabbccddeeff", true},
+		{"shellyflood-aabbccddeeff", true},
+		{"shelly1-aabbccddeeff", true},
+		{"shelly1pm-aabbccddeeff", true},
+		{"shelly25-aabbccddeeff", true},
+		{"shellyplus1pm-aabbccddeeff", false},
+		{"shellyplug-aabbccddeeff", true},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := IsGen1Device(c.id)
+		if got != c.want {
+			t.Errorf("IsGen1Device(%q) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
+func TestIsBluDevice(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"shellyblu-aabbccddeeff", true},
+		{"shellybluht3-aabbccddeeff", true},
+		{"shellybludoorwindow2-aabbccddeeff", true},
+		{"shellyblumotion1-aabbccddeeff", true},
+		{"shellyblubutton1-aabbccddeeff", true},
+		{"sbht-aabbccddeeff", true},
+		{"shellyplus1pm-aabbccddeeff", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := IsBluDevice(c.id)
+		if got != c.want {
+			t.Errorf("IsBluDevice(%q) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
+func TestMacFromShellyID(t *testing.T) {
+	mac := MacFromShellyID("shellyplus1pm-aabbccddeeff")
+	if mac == nil {
+		t.Fatal("expected non-nil MAC for valid device ID")
+	}
+
+	if MacFromShellyID("nohyphen") != nil {
+		t.Error("expected nil MAC for ID with no hyphen")
+	}
+	if MacFromShellyID("shellyplus1pm-short") != nil {
+		t.Error("expected nil MAC for ID with short suffix")
+	}
+	if MacFromShellyID("shellyplus1pm-zzzzzzzzzzzz") != nil {
+		t.Error("expected nil MAC for ID with non-hex suffix")
+	}
+}
+
+func TestNewDeviceFromMqttId_Empty(t *testing.T) {
+	_, err := NewDeviceFromMqttId(context.Background(), logr.Discard(), "")
+	if err == nil {
+		t.Fatal("expected error for empty MQTT device ID")
+	}
+}
+
+func TestNewDeviceFromMqttId_NilString(t *testing.T) {
+	_, err := NewDeviceFromMqttId(context.Background(), logr.Discard(), "<nil>")
+	if err == nil {
+		t.Fatal("expected error for <nil> MQTT device ID")
+	}
+}
+
+func TestNewDeviceFromMqttId_Valid(t *testing.T) {
+	d, err := NewDeviceFromMqttId(context.Background(), logr.Discard(), "shellyplus1pm-aabbccddeeff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.Id() != "shellyplus1pm-aabbccddeeff" {
+		t.Errorf("unexpected id: %q", d.Id())
+	}
+}


### PR DESCRIPTION
## Summary

- `Foreach` now skips devices whose ID is empty (partially-discovered), logging at V(1) instead of crashing
- `NewDeviceFromSummary` returns an error for empty IDs instead of letting `UpdateId` panic
- New `pkg/shelly/device_test.go` covers both fixed paths plus `IsGen1Device`, `IsBluDevice`, `MacFromShellyID`, and `NewDeviceFromMqttId`

## Root cause

`go run ./myhome ctl shelly mqtt config '*' -B 192.168.1.2` panicked because the device list returned by `LookupDevices` can include entries whose ID has not been resolved yet. `Foreach` passed them straight to `NewDeviceFromSummary` → `UpdateId("")` → `panic("invalid device id: ")`.

## Test plan

- [ ] `make test` passes
- [ ] `go run ./myhome ctl shelly mqtt config '*' -B 192.168.1.2` no longer panics<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(shelly): avoid panic when Foreach encounters a device with no ID yet ([54dc6c1](https://github.com/asnowfix/home-automation/commit/54dc6c19fb9e93ef86766734fa0e52f6997eeee3))
<!-- END-AUTO-GENERATED-COMMITS -->