### PR TITLE
fix(ci): run make generate before make build in create-branch-on-minor-tag

### DIFF
--- a/.github/workflows/create-branch-on-minor-tag.yml
+++ b/.github/workflows/create-branch-on-minor-tag.yml
@@ -56,8 +56,9 @@ jobs:
           set -euo pipefail
           EXPECTED_TAG="${{ github.ref_name }}"
           
-          # Build the binary
+          # Build the binary (make generate fetches embedded JS/CSS assets)
           cd myhome
+          make generate
           make build
           
           # Get version from binary


### PR DESCRIPTION
## Summary
- The `create-branch-on-minor-tag` workflow was failing at "Validate version command" because `make build` requires embedded JS/CSS assets (alpine.min.js, htmx.min.js, bulma.min.css) that are not committed to the repo
- Adding `make generate` before `make build` fetches those assets in CI before the build runs

## Fixes
https://github.com/asnowfix/home-automation/actions/runs/28294787740

## Test plan
- [ ] Push a new `vMAJOR.MINOR.0` tag and verify the workflow passes the "Validate version command" step<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(ci): run make generate before make build in create-branch-on-minor-tag ([dfbfa62](https://github.com/asnowfix/home-automation/commit/dfbfa626fce10933a85e01cd38b0a8a2c339dd75))
<!-- END-AUTO-GENERATED-COMMITS -->