### PR TITLE
fix(ci): add missing go generate for pool/garden in goreleaser (v0.11.x)

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -177,6 +177,8 @@ jobs:
       - name: Run go generate
         run: |
           go generate -v ./internal/myhome/ui/...
+          go generate -v ./myhome/ctl/pool
+          go generate -v ./myhome/ctl/garden
           go generate -v ./...
           if (Test-Path internal/myhome/ui/static/bulma.min.css) { ls internal/myhome/ui/static/bulma.min.css } else { Write-Host "bulma.min.css not found!" }
       - id: build

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,8 @@ project_name: myhome
 before:
   hooks:
     - go generate ./internal/myhome/ui/...
+    - go generate ./myhome/ctl/pool
+    - go generate ./myhome/ctl/garden
     - go generate ./...
 builds:
   - env: [CGO_ENABLED=0]


### PR DESCRIPTION
Backport of d276f2c to fix the v0.11.1 package-release build failure.

GoReleaser on v0.11.x was missing explicit `go generate` calls for `myhome/ctl/pool` and `myhome/ctl/garden` — the workspace root `go generate ./...` does not recurse into sub-modules, causing "undefined: DefaultXxx" compile errors at release time.

This was fixed on main in d276f2c; this PR brings that fix to v0.11.x so the next patch release succeeds.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(ci): add missing go generate for pool and garden sub-modules in goreleaser and MSI job ([98bbe00](https://github.com/asnowfix/home-automation/commit/98bbe0003458655afe593907caa0fec3b9f3cb92))
<!-- END-AUTO-GENERATED-COMMITS -->