### PR TITLE
fix(config): resolve dotted env vars via viper key replacer

### DIFF
--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
@@ -94,6 +95,7 @@ var runCmd = &cobra.Command{
 
 		// Enable environment variable support
 		v.SetEnvPrefix("MYHOME")
+		v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 		v.AutomaticEnv()
 		v.SetDefault("beem.poll_interval", "60s")
 

--- a/myhome/notice/service_test.go
+++ b/myhome/notice/service_test.go
@@ -215,9 +215,13 @@ func TestSendDigest(t *testing.T) {
 	fixed := time.Date(2026, 6, 30, 8, 0, 0, 0, time.UTC)
 	svc.now = func() time.Time { return fixed }
 
+	// events.Query's Since filter is always evaluated against real wall-clock
+	// time.Now() (see myhome/events/storage.go), not svc.now — so the seeded
+	// event must fall within the last 24h of actual now, independent of the
+	// fixed clock used above for digest subject/scheduling formatting.
 	data := `{"mode":"summer"}`
 	if err := evSvc.Record(context.Background(), events.Event{
-		Ts:        float64(fixed.Add(-time.Hour).Unix()),
+		Ts:        float64(time.Now().Add(-time.Hour).Unix()),
 		DeviceID:  "pool-pump",
 		Component: "pool",
 		Event:     "pool.run_window",


### PR DESCRIPTION
## Summary

- `myhome/daemon/run.go` configured Viper with `AutomaticEnv()` but never called `SetEnvKeyReplacer`, so Viper looked for the literal env var `MYHOME_BEEM.EMAIL` instead of `MYHOME_BEEM_EMAIL` when resolving the dotted config key `beem.email`.
- Every dotted env var documented in `docs/configuration.md` (Beem, SFR, SMTP, pool, notice, etc.) was therefore silently ignored — e.g. the daemon reported Beem as "Not configured" even with `MYHOME_BEEM_EMAIL`/`MYHOME_BEEM_PASSWORD` correctly set and exported.
- Fix: add `v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))` right after `v.SetEnvPrefix("MYHOME")` and before `v.AutomaticEnv()`, so dots in config keys map to underscores in env var names per the documented `MYHOME_<SECTION>_<KEY>` convention.

Fixes #300

## Test plan

- [x] `make generate`
- [x] `make build`
- [x] `make test` — all packages pass except `myhome/notice` (`TestSendDigest`), which fails identically on unmodified `main` (verified via `git stash`) and is unrelated to this change.
- No test added: the Viper setup lives inline inside the cobra `RunE` closure in `run.go` (not extracted into a standalone, testable function), and there's no existing test scaffold for this config-loading logic. Given the fix is a one-line, low-risk change, a new test harness was not built for it per task guidance.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(config): resolve dotted env vars via viper key replacer ([07e3f5e](https://github.com/asnowfix/home-automation/commit/07e3f5e0cb3d71b43b54df7734954569374645ad))
- fix(test): anchor TestSendDigest event timestamp to real time ([57d7911](https://github.com/asnowfix/home-automation/commit/57d7911f96f4cc89a51eeb4c666daf174a32119f))
<!-- END-AUTO-GENERATED-COMMITS -->