### PR TITLE
fix(beem): accept any 2xx status from the login endpoint

### DIFF
--- a/pkg/beem/client.go
+++ b/pkg/beem/client.go
@@ -81,7 +81,7 @@ func (c *Client) login(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("beem: login failed with status %d: %s", resp.StatusCode, string(data))
 	}

--- a/pkg/beem/client_test.go
+++ b/pkg/beem/client_test.go
@@ -3,6 +3,7 @@ package beem
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -195,5 +196,41 @@ func TestTokenProactiveRefresh(t *testing.T) {
 	}
 	if c.token != "tok-proactive" {
 		t.Errorf("token = %q, want \"tok-proactive\"", c.token)
+	}
+}
+
+// realWorldLoginBody is a redacted copy of an actual Beem API login response:
+// HTTP 201 Created (not 200 OK), a raft of account fields the client doesn't
+// model, and no "expiresIn" field at all.
+const realWorldLoginBody = `{"lastname":"DOE","firstname":"Jane","email":"jane.doe@example.com","userId":50969,"journeyStatus":"house_filled","countryCode":"FR","toggles":[],"isVerified":true,"accessToken":"tok-real-world","phoneNumber":"+33600000000","birthday":null,"civility":"sir","motivationForBeem":"energySelfSufficient"}`
+
+// TestLogin_201CreatedRealWorldPayload verifies that login succeeds against
+// the actual shape of a Beem API response: status 201 (not 200), and a body
+// containing many account fields the client doesn't care about, decoded via
+// loginResponse which only extracts accessToken/expiresIn.
+func TestLogin_201CreatedRealWorldPayload(t *testing.T) {
+	loginHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		io.WriteString(w, realWorldLoginBody)
+	}
+
+	srv := buildTestServer(t, loginHandler, summaryOK(100, 200, 300))
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{Email: "u@example.com", Password: "pw"})
+	c.http = *srv.Client()
+
+	origLogin, origSummary := loginURL, summaryURL
+	loginURL = srv.URL + "/beemapp/user/login"
+	summaryURL = srv.URL + "/beemapp/box/summary"
+	defer func() { loginURL = origLogin; summaryURL = origSummary }()
+
+	ctx := context.Background()
+	if _, err := c.PollSummary(ctx); err != nil {
+		t.Fatalf("PollSummary returned unexpected error: %v", err)
+	}
+	if c.token != "tok-real-world" {
+		t.Errorf("token = %q, want \"tok-real-world\"", c.token)
 	}
 }


### PR DESCRIPTION
## Summary

- The real Beem API returns `201 Created` on login, not `200 OK`. `pkg/beem/client.go`'s `login()` only accepted `http.StatusOK`, so every login attempt failed with `beem: login failed with status 201: ...` even though the response body contained a valid `accessToken`.
- This left the Accounts UI permanently showing Beem Energy as "Failed", and every poll cycle re-ran a doomed login.
- Fix: accept any 2xx status code (`resp.StatusCode < 200 || resp.StatusCode >= 300`) instead of requiring exactly 200.
- Added `TestLogin_201CreatedRealWorldPayload`, built from an actual (redacted) Beem login response — 201 status, a bunch of account fields the client doesn't model, and notably no `expiresIn` field.

## Test plan

- [x] `make generate`
- [x] `make test` — all packages pass
- [x] New test `TestLogin_201CreatedRealWorldPayload` fails against the old `!= http.StatusOK` check and passes with the fix<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(beem): accept any 2xx status from the login endpoint ([2066231](https://github.com/asnowfix/home-automation/commit/2066231c7f1fbaef0e191b297fa43a07e1259cdb))
<!-- END-AUTO-GENERATED-COMMITS -->