### PR TITLE
fix(ui): truncate account status errors and prevent card overflow

### DIFF
--- a/internal/myhome/ui/htmx.go
+++ b/internal/myhome/ui/htmx.go
@@ -41,11 +41,12 @@ func NewHTMXHandler(ctx context.Context, log logr.Logger, db *storage.DeviceStor
 // accountRow is the template view for one account's status row, with
 // display fields pre-formatted server-side to keep the template simple.
 type accountRow struct {
-	Name        string
-	StatusClass string // Bulma tag color: is-success / is-danger / is-light
-	StatusText  string
-	LastChecked string
-	LastError   string
+	Name          string
+	StatusClass   string // Bulma tag color: is-success / is-danger / is-light
+	StatusText    string
+	LastChecked   string
+	LastError     string // truncated to maxErrorDisplayLen for display
+	LastErrorFull string // untruncated, shown as a hover tooltip
 }
 
 // accountDisplayNames maps internal account keys (used by Registry.Report)
@@ -57,6 +58,21 @@ var accountDisplayNames = map[string]string{
 	"mqtt": "MQTT Broker",
 }
 
+// maxErrorDisplayLen caps how much of a LastError string is shown on an
+// account status card. Errors like Beem's login failure embed the entire
+// JSON response body, which would otherwise overflow the card.
+const maxErrorDisplayLen = 120
+
+// truncateError shortens s to maxErrorDisplayLen runes, appending an ellipsis
+// if it was cut. The full text is kept separately for a hover tooltip.
+func truncateError(s string) string {
+	r := []rune(s)
+	if len(r) <= maxErrorDisplayLen {
+		return s
+	}
+	return string(r[:maxErrorDisplayLen]) + "…"
+}
+
 func toAccountRows(statuses []accounts.Status) []accountRow {
 	rows := make([]accountRow, len(statuses))
 	for i, s := range statuses {
@@ -64,7 +80,7 @@ func toAccountRows(statuses []accounts.Status) []accountRow {
 		if name == "" {
 			name = s.Name
 		}
-		row := accountRow{Name: name, LastError: s.LastError}
+		row := accountRow{Name: name, LastError: truncateError(s.LastError), LastErrorFull: s.LastError}
 		switch {
 		case !s.Enabled:
 			row.StatusClass = "is-light"
@@ -744,7 +760,7 @@ const accountsPanelTemplate = `
       <p class="is-size-7 has-text-grey">Last checked: {{.LastChecked}}</p>
     {{end}}
     {{if .LastError}}
-      <p class="is-size-7 has-text-danger">{{.LastError}}</p>
+      <p class="is-size-7 has-text-danger" style="overflow-wrap: anywhere;" title="{{.LastErrorFull}}">{{.LastError}}</p>
     {{end}}
   </div>
 </div>

--- a/internal/myhome/ui/htmx_accounts_test.go
+++ b/internal/myhome/ui/htmx_accounts_test.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"bytes"
+	"html/template"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome/accounts"
+)
+
+func TestTruncateError(t *testing.T) {
+	short := "beem: unauthorized"
+	if got := truncateError(short); got != short {
+		t.Errorf("truncateError(%q) = %q, want unchanged", short, got)
+	}
+
+	long := "beem: login failed with status 201: " + strings.Repeat("x", 200)
+	got := truncateError(long)
+	if len([]rune(got)) != maxErrorDisplayLen+1 { // +1 for the trailing ellipsis rune
+		t.Errorf("truncateError(long) len = %d, want %d", len([]rune(got)), maxErrorDisplayLen+1)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncateError(long) = %q, want ellipsis suffix", got)
+	}
+}
+
+// TestToAccountRows_TruncatesLongError verifies that a Beem-style login
+// failure (which embeds the full JSON response body) is truncated for
+// display while the full error is preserved for the hover tooltip.
+func TestToAccountRows_TruncatesLongError(t *testing.T) {
+	longErr := `beem: login failed with status 201: {"lastname":"DOE","firstname":"Jane","email":"jane.doe@example.com","userId":50969,"journeyStatus":"house_filled","countryCode":"FR","toggles":[],"isVerified":true,"accessToken":"tok-real-world","phoneNumber":"+33600000000","birthday":null,"civility":"sir","motivationForBeem":"energySelfSufficient"}`
+
+	rows := toAccountRows([]accounts.Status{
+		{Name: "beem", Enabled: true, LastOK: false, LastAttempt: time.Date(2026, 7, 4, 16, 56, 52, 0, time.UTC), LastError: longErr},
+	})
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.Name != "Beem Energy" {
+		t.Errorf("Name = %q, want \"Beem Energy\"", row.Name)
+	}
+	if row.StatusClass != "is-danger" || row.StatusText != "Failed" {
+		t.Errorf("status = (%q, %q), want (is-danger, Failed)", row.StatusClass, row.StatusText)
+	}
+	if len([]rune(row.LastError)) > maxErrorDisplayLen+1 {
+		t.Errorf("LastError not truncated: len = %d", len([]rune(row.LastError)))
+	}
+	if row.LastErrorFull != longErr {
+		t.Errorf("LastErrorFull = %q, want untruncated original", row.LastErrorFull)
+	}
+
+	var buf bytes.Buffer
+	tmpl := template.Must(template.New("accounts-panel").Parse(accountsPanelTemplate))
+	if err := tmpl.Execute(&buf, rows); err != nil {
+		t.Fatalf("template.Execute: %v", err)
+	}
+	html := buf.String()
+
+	// "energySelfSufficient" sits near the end of the JSON body, well past
+	// maxErrorDisplayLen, so it must only appear inside the (escaped) title
+	// tooltip attribute, never in the visible truncated text.
+	const tailMarker = "energySelfSufficient"
+	if strings.Contains(row.LastError, tailMarker) {
+		t.Errorf("visible LastError not truncated: contains tail marker %q", tailMarker)
+	}
+	if !strings.Contains(html, tailMarker) {
+		t.Errorf("rendered HTML missing full error (tail marker %q) in title tooltip attribute", tailMarker)
+	}
+	if !strings.Contains(html, `title="`) {
+		t.Errorf("rendered HTML missing a title attribute for the error tooltip")
+	}
+	if !strings.Contains(html, "overflow-wrap: anywhere") {
+		t.Errorf("rendered HTML missing overflow-wrap safety style on the error text")
+	}
+}


### PR DESCRIPTION
## Summary

- The Accounts status panel (introduced in #296) rendered `LastError` verbatim in the card. Beem's login failure error embeds the entire JSON response body as one long unbroken line, which overflows past the card's border instead of wrapping.
- Truncate the visible error text to 120 runes with an ellipsis (`truncateError`), while keeping the full error available as a hover tooltip (`title` attribute) via a new `LastErrorFull` field.
- Added `overflow-wrap: anywhere` as a layout safety net for any other long, unbroken error text.

Based on top of #296's branch since the Accounts panel doesn't exist on `main` yet.

## Test plan

- [x] `make generate`
- [x] `make test` — all packages pass
- [x] New tests in `internal/myhome/ui/htmx_accounts_test.go`: `TestTruncateError`, `TestToAccountRows_TruncatesLongError` (asserts the rendered HTML truncates the visible text, keeps the full error in the tooltip, and includes the overflow-wrap safety style)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(ui): truncate account status errors and prevent card overflow ([bdee688](https://github.com/asnowfix/home-automation/commit/bdee6882b401d372cdc8fa9a8415687311084320))
<!-- END-AUTO-GENERATED-COMMITS -->