### PR TITLE
test(cli): make temperature CLI testable via injected client + pure functions

### DIFF
--- a/internal/myhome/fake_client.go
+++ b/internal/myhome/fake_client.go
@@ -1,0 +1,72 @@
+package myhome
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/asnowfix/home-automation/pkg/devices"
+)
+
+// FakeCall records a single CallE invocation made against a FakeClient.
+type FakeCall struct {
+	Method Verb
+	Params any
+}
+
+// FakeClient is a test double for Client. It records every CallE invocation
+// and returns a canned result or error configured per Verb via SetResult and
+// SetError, so CLI command tests can assert which RPC verb and params a
+// command issued without a real MQTT transport.
+type FakeClient struct {
+	Calls   []FakeCall
+	results map[Verb]any
+	errs    map[Verb]error
+}
+
+// NewFakeClient returns a FakeClient ready for use.
+func NewFakeClient() *FakeClient {
+	return &FakeClient{
+		results: make(map[Verb]any),
+		errs:    make(map[Verb]error),
+	}
+}
+
+// SetResult configures CallE to return result for method (and clears any
+// previously configured error for that method).
+func (f *FakeClient) SetResult(method Verb, result any) {
+	f.results[method] = result
+	delete(f.errs, method)
+}
+
+// SetError configures CallE to return err for method (and clears any
+// previously configured result for that method).
+func (f *FakeClient) SetError(method Verb, err error) {
+	f.errs[method] = err
+	delete(f.results, method)
+}
+
+// CallE implements Client. It records the call and returns whatever was
+// configured via SetResult/SetError; if nothing was configured for method it
+// returns an error naming the unconfigured verb.
+func (f *FakeClient) CallE(ctx context.Context, method Verb, params any) (any, error) {
+	f.Calls = append(f.Calls, FakeCall{Method: method, Params: params})
+	if err, ok := f.errs[method]; ok {
+		return nil, err
+	}
+	if result, ok := f.results[method]; ok {
+		return result, nil
+	}
+	return nil, fmt.Errorf("FakeClient: no result configured for method %s", method)
+}
+
+// LookupDevices implements Client. Not used by CLI command tests today;
+// configure via a wrapper/embedding if a future test needs it.
+func (f *FakeClient) LookupDevices(ctx context.Context, name string) (*[]devices.Device, error) {
+	return nil, fmt.Errorf("FakeClient.LookupDevices not implemented")
+}
+
+// ForgetDevices implements Client. Not used by CLI command tests today;
+// configure via a wrapper/embedding if a future test needs it.
+func (f *FakeClient) ForgetDevices(ctx context.Context, name string) error {
+	return fmt.Errorf("FakeClient.ForgetDevices not implemented")
+}

--- a/myhome/ctl/temperature/temperature.go
+++ b/myhome/ctl/temperature/temperature.go
@@ -136,38 +136,9 @@ Examples:
 		isNewRoom := len(matchingRooms) == 0 && !strings.Contains(pattern, "*")
 
 		if isNewRoom {
-			// Creating new room - require all fields
-			if !nameSet {
-				return fmt.Errorf("--name is required for new room")
-			}
-			if !kindsSet {
-				return fmt.Errorf("--kinds is required for new room (room kinds: bedroom, office, living-room, kitchen, other)")
-			}
-			if !ecoSet {
-				return fmt.Errorf("--eco is required for new room (it's the default temperature level)")
-			}
-
-			// Parse kinds
-			kinds := parseKinds(kindsStr)
-			if len(kinds) == 0 {
-				return fmt.Errorf("invalid kinds: %s", kindsStr)
-			}
-
-			// Build levels map
-			levels := make(map[string]float64)
-			levels["eco"] = eco
-			if comfortSet && comfort > 0 {
-				levels["comfort"] = comfort
-			}
-			if awaySet && away > 0 {
-				levels["away"] = away
-			}
-
-			params := &myhome.TemperatureSetParams{
-				RoomID: pattern,
-				Name:   name,
-				Kinds:  kinds,
-				Levels: levels,
+			params, err := buildNewRoomParams(pattern, name, nameSet, kindsStr, kindsSet, eco, ecoSet, comfortSet, comfort, awaySet, away)
+			if err != nil {
+				return err
 			}
 
 			result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
@@ -191,50 +162,12 @@ Examples:
 
 		updatedCount := 0
 		for roomID, existingConfig := range matchingRooms {
-			// Build update params - start with existing values
-			updateName := existingConfig.Name
-			updateKinds := existingConfig.Kinds
-			updateLevels := make(map[string]float64)
-			for k, v := range existingConfig.Levels {
-				updateLevels[k] = v
+			params, err := buildUpdatedRoomParams(roomID, existingConfig, name, nameSet, kindsStr, kindsSet, eco, ecoSet, comfortSet, comfort, awaySet, away)
+			if err != nil {
+				return err
 			}
 
-			// Apply only the flags that were set
-			if nameSet {
-				updateName = name
-			}
-			if kindsSet {
-				updateKinds = parseKinds(kindsStr)
-				if len(updateKinds) == 0 {
-					return fmt.Errorf("invalid kinds: %s", kindsStr)
-				}
-			}
-			if ecoSet {
-				updateLevels["eco"] = eco
-			}
-			if comfortSet {
-				if comfort > 0 {
-					updateLevels["comfort"] = comfort
-				} else {
-					delete(updateLevels, "comfort")
-				}
-			}
-			if awaySet {
-				if away > 0 {
-					updateLevels["away"] = away
-				} else {
-					delete(updateLevels, "away")
-				}
-			}
-
-			params := &myhome.TemperatureSetParams{
-				RoomID: roomID,
-				Name:   updateName,
-				Kinds:  updateKinds,
-				Levels: updateLevels,
-			}
-
-			_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
+			_, err = myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
 			if err != nil {
 				fmt.Printf("✗ Failed to update room %s: %v\n", roomID, err)
 				continue
@@ -642,6 +575,88 @@ func init() {
 	// Kind schedule list flags
 	kindScheduleListCmd.Flags().String("kind", "", "Filter by room kind (bedroom, office, living-room, kitchen, other)")
 	kindScheduleListCmd.Flags().String("day-type", "", "Filter by day-type (work-day, day-off)")
+}
+
+// buildNewRoomParams validates flags and builds the TemperatureSetParams
+// needed to create a brand-new room. name/kinds/eco are required for a new
+// room; comfort/away are only included when explicitly set and positive.
+func buildNewRoomParams(pattern, name string, nameSet bool, kindsStr string, kindsSet bool, eco float64, ecoSet bool, comfortSet bool, comfort float64, awaySet bool, away float64) (*myhome.TemperatureSetParams, error) {
+	if !nameSet {
+		return nil, fmt.Errorf("--name is required for new room")
+	}
+	if !kindsSet {
+		return nil, fmt.Errorf("--kinds is required for new room (room kinds: bedroom, office, living-room, kitchen, other)")
+	}
+	if !ecoSet {
+		return nil, fmt.Errorf("--eco is required for new room (it's the default temperature level)")
+	}
+
+	kinds := parseKinds(kindsStr)
+	if len(kinds) == 0 {
+		return nil, fmt.Errorf("invalid kinds: %s", kindsStr)
+	}
+
+	levels := make(map[string]float64)
+	levels["eco"] = eco
+	if comfortSet && comfort > 0 {
+		levels["comfort"] = comfort
+	}
+	if awaySet && away > 0 {
+		levels["away"] = away
+	}
+
+	return &myhome.TemperatureSetParams{
+		RoomID: pattern,
+		Name:   name,
+		Kinds:  kinds,
+		Levels: levels,
+	}, nil
+}
+
+// buildUpdatedRoomParams merges only the explicitly-set flags onto an
+// existing room's configuration, leaving unspecified values unchanged.
+// A comfort/away value set to <= 0 removes that level from the room.
+func buildUpdatedRoomParams(roomID string, existing *myhome.TemperatureRoomConfig, name string, nameSet bool, kindsStr string, kindsSet bool, eco float64, ecoSet bool, comfortSet bool, comfort float64, awaySet bool, away float64) (*myhome.TemperatureSetParams, error) {
+	updateName := existing.Name
+	updateKinds := existing.Kinds
+	updateLevels := make(map[string]float64, len(existing.Levels))
+	for k, v := range existing.Levels {
+		updateLevels[k] = v
+	}
+
+	if nameSet {
+		updateName = name
+	}
+	if kindsSet {
+		updateKinds = parseKinds(kindsStr)
+		if len(updateKinds) == 0 {
+			return nil, fmt.Errorf("invalid kinds: %s", kindsStr)
+		}
+	}
+	if ecoSet {
+		updateLevels["eco"] = eco
+	}
+	if comfortSet {
+		if comfort > 0 {
+			updateLevels["comfort"] = comfort
+		} else {
+			delete(updateLevels, "comfort")
+		}
+	}
+	if awaySet {
+		if away > 0 {
+			updateLevels["away"] = away
+		} else {
+			delete(updateLevels, "away")
+		}
+	}
+
+	return &myhome.TemperatureSetParams{
+		RoomID: roomID,
+		Name:   updateName,
+		Kinds:  updateKinds,
+		Levels: updateLevels,
+	}, nil
 }
 
 func matchRoomPattern(pattern string, rooms myhome.TemperatureRoomList) map[string]*myhome.TemperatureRoomConfig {

--- a/myhome/ctl/temperature/temperature_test.go
+++ b/myhome/ctl/temperature/temperature_test.go
@@ -1,0 +1,422 @@
+package temperature
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+)
+
+// withFakeClient installs a FakeClient as myhome.TheClient for the duration
+// of the test and restores the previous value on cleanup. myhome.TheClient
+// is a package-level global shared across the whole test binary, so tests
+// using it must not run in parallel.
+func withFakeClient(t *testing.T) *myhome.FakeClient {
+	t.Helper()
+	prev := myhome.TheClient
+	fake := myhome.NewFakeClient()
+	myhome.TheClient = fake
+	t.Cleanup(func() {
+		myhome.TheClient = prev
+	})
+	return fake
+}
+
+// --- CLI-level tests: client injection via myhome.TheClient / FakeClient ---
+
+func TestGetCmd_HappyPath(t *testing.T) {
+	fake := withFakeClient(t)
+	fake.SetResult(myhome.TemperatureGet, &myhome.TemperatureRoomConfig{
+		RoomID: "salon",
+		Name:   "Salon",
+		Kinds:  []myhome.RoomKind{myhome.RoomKindLivingRoom},
+		Levels: map[string]float64{"eco": 17},
+	})
+
+	getCmd.SetContext(context.Background())
+	err := getCmd.RunE(getCmd, []string{"salon"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(fake.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.Calls))
+	}
+	if fake.Calls[0].Method != myhome.TemperatureGet {
+		t.Errorf("expected verb %s, got %s", myhome.TemperatureGet, fake.Calls[0].Method)
+	}
+	params, ok := fake.Calls[0].Params.(*myhome.TemperatureGetParams)
+	if !ok {
+		t.Fatalf("expected *TemperatureGetParams, got %T", fake.Calls[0].Params)
+	}
+	if params.RoomID != "salon" {
+		t.Errorf("expected room_id 'salon', got %q", params.RoomID)
+	}
+}
+
+func TestGetCmd_PropagatesClientError(t *testing.T) {
+	fake := withFakeClient(t)
+	wantErr := errors.New("device unreachable")
+	fake.SetError(myhome.TemperatureGet, wantErr)
+
+	getCmd.SetContext(context.Background())
+	err := getCmd.RunE(getCmd, []string{"salon"})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, err)
+	}
+}
+
+func TestGetCmd_UnexpectedResultType(t *testing.T) {
+	fake := withFakeClient(t)
+	fake.SetResult(myhome.TemperatureGet, "not-a-config")
+
+	getCmd.SetContext(context.Background())
+	err := getCmd.RunE(getCmd, []string{"salon"})
+	if err == nil {
+		t.Fatal("expected an error for unexpected result type, got nil")
+	}
+}
+
+func TestListCmd_HappyPath(t *testing.T) {
+	fake := withFakeClient(t)
+	rooms := myhome.TemperatureRoomList{
+		"salon": {RoomID: "salon", Name: "Salon", Levels: map[string]float64{"eco": 17}},
+	}
+	fake.SetResult(myhome.TemperatureList, &rooms)
+
+	listCmd.SetContext(context.Background())
+	err := listCmd.RunE(listCmd, []string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.Calls) != 1 || fake.Calls[0].Method != myhome.TemperatureList {
+		t.Fatalf("expected a single TemperatureList call, got %+v", fake.Calls)
+	}
+}
+
+func TestListCmd_Empty(t *testing.T) {
+	fake := withFakeClient(t)
+	empty := myhome.TemperatureRoomList{}
+	fake.SetResult(myhome.TemperatureList, &empty)
+
+	listCmd.SetContext(context.Background())
+	if err := listCmd.RunE(listCmd, []string{}); err != nil {
+		t.Fatalf("unexpected error on empty list: %v", err)
+	}
+}
+
+func TestDeleteCmd_HappyPath(t *testing.T) {
+	fake := withFakeClient(t)
+	fake.SetResult(myhome.TemperatureDelete, &myhome.TemperatureDeleteResult{RoomID: "salon", Status: "deleted"})
+
+	deleteCmd.SetContext(context.Background())
+	err := deleteCmd.RunE(deleteCmd, []string{"salon"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	params, ok := fake.Calls[0].Params.(*myhome.TemperatureDeleteParams)
+	if !ok {
+		t.Fatalf("expected *TemperatureDeleteParams, got %T", fake.Calls[0].Params)
+	}
+	if params.RoomID != "salon" {
+		t.Errorf("expected room_id 'salon', got %q", params.RoomID)
+	}
+}
+
+// --- Pure function tests: extracted decision logic ---
+
+func TestBuildNewRoomParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		nameSet    bool
+		kindsStr   string
+		kindsSet   bool
+		eco        float64
+		ecoSet     bool
+		comfortSet bool
+		comfort    float64
+		awaySet    bool
+		away       float64
+		wantErr    bool
+		wantLevels map[string]float64
+	}{
+		{
+			name: "missing name", nameSet: false, kindsSet: true, ecoSet: true, wantErr: true,
+		},
+		{
+			name: "missing kinds", nameSet: true, kindsSet: false, ecoSet: true, wantErr: true,
+		},
+		{
+			name: "missing eco", nameSet: true, kindsSet: true, ecoSet: false, wantErr: true,
+		},
+		{
+			name: "invalid kinds string", nameSet: true, kindsStr: "", kindsSet: true, ecoSet: true, eco: 17, wantErr: true,
+		},
+		{
+			name: "eco only", nameSet: true, kindsStr: "bedroom", kindsSet: true, eco: 17, ecoSet: true,
+			wantLevels: map[string]float64{"eco": 17},
+		},
+		{
+			name: "eco+comfort+away", nameSet: true, kindsStr: "bedroom", kindsSet: true, eco: 17, ecoSet: true,
+			comfortSet: true, comfort: 21, awaySet: true, away: 14,
+			wantLevels: map[string]float64{"eco": 17, "comfort": 21, "away": 14},
+		},
+		{
+			name: "comfort set but non-positive is dropped", nameSet: true, kindsStr: "bedroom", kindsSet: true, eco: 17, ecoSet: true,
+			comfortSet: true, comfort: 0,
+			wantLevels: map[string]float64{"eco": 17},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params, err := buildNewRoomParams("living-room", "Living Room", tt.nameSet, tt.kindsStr, tt.kindsSet, tt.eco, tt.ecoSet, tt.comfortSet, tt.comfort, tt.awaySet, tt.away)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if params.RoomID != "living-room" || params.Name != "Living Room" {
+				t.Errorf("unexpected room id/name: %+v", params)
+			}
+			if len(params.Levels) != len(tt.wantLevels) {
+				t.Fatalf("expected levels %v, got %v", tt.wantLevels, params.Levels)
+			}
+			for k, v := range tt.wantLevels {
+				if params.Levels[k] != v {
+					t.Errorf("level %s: expected %v, got %v", k, v, params.Levels[k])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildUpdatedRoomParams(t *testing.T) {
+	existing := &myhome.TemperatureRoomConfig{
+		RoomID: "salon",
+		Name:   "Salon",
+		Kinds:  []myhome.RoomKind{myhome.RoomKindLivingRoom},
+		Levels: map[string]float64{"eco": 17, "comfort": 21},
+	}
+
+	t.Run("no flags set: unchanged", func(t *testing.T) {
+		params, err := buildUpdatedRoomParams("salon", existing, "", false, "", false, 0, false, false, 0, false, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if params.Name != "Salon" || len(params.Levels) != 2 {
+			t.Errorf("expected unchanged config, got %+v", params)
+		}
+	})
+
+	t.Run("only away set: added", func(t *testing.T) {
+		params, err := buildUpdatedRoomParams("salon", existing, "", false, "", false, 0, false, false, 0, true, 14)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if params.Levels["away"] != 14 || params.Levels["eco"] != 17 || params.Levels["comfort"] != 21 {
+			t.Errorf("expected away added while eco/comfort preserved, got %+v", params.Levels)
+		}
+	})
+
+	t.Run("comfort set to non-positive: removed", func(t *testing.T) {
+		params, err := buildUpdatedRoomParams("salon", existing, "", false, "", false, 0, false, true, 0, false, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, ok := params.Levels["comfort"]; ok {
+			t.Errorf("expected comfort removed, got %+v", params.Levels)
+		}
+		if params.Levels["eco"] != 17 {
+			t.Errorf("expected eco preserved, got %+v", params.Levels)
+		}
+	})
+
+	t.Run("invalid kinds string errors", func(t *testing.T) {
+		_, err := buildUpdatedRoomParams("salon", existing, "", false, "", true, 0, false, false, 0, false, 0)
+		if err == nil {
+			t.Fatal("expected an error for empty kinds string when kindsSet=true")
+		}
+	})
+
+	t.Run("name and kinds overridden", func(t *testing.T) {
+		params, err := buildUpdatedRoomParams("salon", existing, "New Name", true, "office,kitchen", true, 0, false, false, 0, false, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if params.Name != "New Name" {
+			t.Errorf("expected name overridden, got %q", params.Name)
+		}
+		if len(params.Kinds) != 2 || params.Kinds[0] != myhome.RoomKindOffice {
+			t.Errorf("expected kinds [office kitchen], got %v", params.Kinds)
+		}
+	})
+}
+
+// --- Pure function tests: pre-existing helpers ---
+
+func TestMatchRoomPattern(t *testing.T) {
+	rooms := myhome.TemperatureRoomList{
+		"salon":         {RoomID: "salon"},
+		"chambre-ado":   {RoomID: "chambre-ado"},
+		"chambre-bebe":  {RoomID: "chambre-bebe"},
+		"salle-de-bain": {RoomID: "salle-de-bain"},
+	}
+
+	tests := []struct {
+		pattern string
+		want    []string
+	}{
+		{"*", []string{"salon", "chambre-ado", "chambre-bebe", "salle-de-bain"}},
+		{"chambre*", []string{"chambre-ado", "chambre-bebe"}},
+		{"*bain", []string{"salle-de-bain"}},
+		{"salon", []string{"salon"}},
+		{"nope", []string{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern, func(t *testing.T) {
+			got := matchRoomPattern(tt.pattern, rooms)
+			if len(got) != len(tt.want) {
+				t.Fatalf("pattern %q: expected %d matches, got %d (%v)", tt.pattern, len(tt.want), len(got), got)
+			}
+			for _, id := range tt.want {
+				if _, ok := got[id]; !ok {
+					t.Errorf("pattern %q: expected match for %q", tt.pattern, id)
+				}
+			}
+		})
+	}
+}
+
+func TestParseKinds(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []myhome.RoomKind
+	}{
+		{"", nil},
+		{"bedroom", []myhome.RoomKind{myhome.RoomKindBedroom}},
+		{"bedroom,office", []myhome.RoomKind{myhome.RoomKindBedroom, myhome.RoomKindOffice}},
+		{" bedroom , office ", []myhome.RoomKind{myhome.RoomKindBedroom, myhome.RoomKindOffice}},
+	}
+	for _, tt := range tests {
+		got := parseKinds(tt.in)
+		if len(got) != len(tt.want) {
+			t.Fatalf("parseKinds(%q): expected %v, got %v", tt.in, tt.want, got)
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("parseKinds(%q)[%d]: expected %v, got %v", tt.in, i, tt.want[i], got[i])
+			}
+		}
+	}
+}
+
+func TestFormatKinds(t *testing.T) {
+	if got := formatKinds(nil); got != "(none)" {
+		t.Errorf("expected '(none)', got %q", got)
+	}
+	if got := formatKinds([]myhome.RoomKind{myhome.RoomKindBedroom}); got != "bedroom" {
+		t.Errorf("expected 'bedroom', got %q", got)
+	}
+	if got := formatKinds([]myhome.RoomKind{myhome.RoomKindBedroom, myhome.RoomKindOffice}); got != "bedroom, office" {
+		t.Errorf("expected 'bedroom, office', got %q", got)
+	}
+}
+
+func TestFormatLevels(t *testing.T) {
+	if got := formatLevels(nil); got != "(none)" {
+		t.Errorf("expected '(none)', got %q", got)
+	}
+	if got := formatLevels(map[string]float64{"eco": 17}); got != "eco:17.0" {
+		t.Errorf("expected 'eco:17.0', got %q", got)
+	}
+	got := formatLevels(map[string]float64{"eco": 17, "comfort": 21})
+	if !strings.Contains(got, "eco:17.0") || !strings.Contains(got, "comfort:21.0") {
+		t.Errorf("expected both levels present, got %q", got)
+	}
+}
+
+func TestParseScheduleString(t *testing.T) {
+	if got := parseScheduleString(""); len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", got)
+	}
+	got := parseScheduleString("08:00-18:00, 20:00-22:00")
+	want := []string{"08:00-18:00", "20:00-22:00"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: expected %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestFormatTimeRanges(t *testing.T) {
+	if got := formatTimeRanges(nil); got != "(always eco)" {
+		t.Errorf("expected '(always eco)', got %q", got)
+	}
+	got := formatTimeRanges([]myhome.TemperatureTimeRange{{Start: 480, End: 1080}})
+	if got != "08:00-18:00" {
+		t.Errorf("expected '08:00-18:00', got %q", got)
+	}
+}
+
+func TestFormatMinutes(t *testing.T) {
+	tests := []struct {
+		in   int
+		want string
+	}{
+		{0, "00:00"},
+		{60, "01:00"},
+		{90, "01:30"},
+		{1439, "23:59"},
+	}
+	for _, tt := range tests {
+		if got := formatMinutes(tt.in); got != tt.want {
+			t.Errorf("formatMinutes(%d): expected %q, got %q", tt.in, tt.want, got)
+		}
+	}
+}
+
+func TestFormatWeekday(t *testing.T) {
+	if got := formatWeekday(0); got != "Sunday" {
+		t.Errorf("expected 'Sunday', got %q", got)
+	}
+	if got := formatWeekday(6); got != "Saturday" {
+		t.Errorf("expected 'Saturday', got %q", got)
+	}
+	if got := formatWeekday(7); !strings.Contains(got, "Invalid") {
+		t.Errorf("expected an Invalid(...) marker, got %q", got)
+	}
+}
+
+func TestGetDefaultDayType(t *testing.T) {
+	weekend := map[int]bool{0: true, 6: true}
+	for d := 0; d <= 6; d++ {
+		got := getDefaultDayType(d)
+		if weekend[d] && got != myhome.DayTypeDayOff {
+			t.Errorf("day %d: expected day-off, got %v", d, got)
+		}
+		if !weekend[d] && got != myhome.DayTypeWorkDay {
+			t.Errorf("day %d: expected work-day, got %v", d, got)
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	kinds := []myhome.RoomKind{myhome.RoomKindBedroom, myhome.RoomKindOffice}
+	if !contains(kinds, myhome.RoomKindBedroom) {
+		t.Error("expected bedroom to be found")
+	}
+	if contains(kinds, myhome.RoomKindKitchen) {
+		t.Error("expected kitchen to be absent")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `myhome.FakeClient` (`internal/myhome/fake_client.go`), a recording test double for the existing `myhome.Client` interface, following the same pattern as `myhome/mqtt/mock.go`'s `RecordingMockClient`. It records every `CallE` invocation and returns canned results/errors configured per `Verb`.
- Extract the two decision blocks inside `myhome/ctl/temperature/temperature.go`'s `set` command (`buildNewRoomParams`, `buildUpdatedRoomParams`) into standalone, pure functions — no behavior change, just testable without cobra/RPC.
- Add `myhome/ctl/temperature/temperature_test.go`: table-driven tests for the extracted builder functions and every pre-existing pure helper (`matchRoomPattern`, `parseKinds`, `formatKinds`, `formatLevels`, `parseScheduleString`, `formatTimeRanges`, `formatMinutes`, `formatWeekday`, `getDefaultDayType`, `contains`), plus CLI-level tests for `get`/`list`/`delete` that swap `myhome.TheClient` for a `FakeClient` and assert the issued RPC verb/params and error propagation.

`myhome/ctl/temperature/` goes from 0% to covered on its core logic.

## Scope note

Issue #304 also mentioned `myhome/ctl/shelly/script/` as a pilot target, but that package doesn't use `myhome.TheClient` at all — it talks to devices directly via `pkg/shelly`, a different dependency shape. Left out of this PR to keep it focused; worth a separate, smaller follow-up.

## Test plan

- [x] `go test ./myhome/ctl/temperature/...` — all new and existing tests pass
- [x] `go build ./...` at repo root and `go build ./internal/myhome/...` — no breakage from the new `FakeClient`
- [x] `make test` — full workspace suite green

Part of epic #311.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- test(cli): make temperature CLI testable via injected client + pure functions ([da9e7cf](https://github.com/asnowfix/home-automation/commit/da9e7cffc74bc9d6ee291d97b4e09a8fd41ced53))
<!-- END-AUTO-GENERATED-COMMITS -->