### PR TITLE
test(shelly): extract pure config/schedule logic from pool + heater scripts

### DIFF
--- a/internal/myhome/shelly/script/heater.go
+++ b/internal/myhome/shelly/script/heater.go
@@ -92,7 +92,6 @@ func (s *HeaterService) HandleGetConfig(ctx context.Context, params *myhome.Heat
 	}
 
 	// Use ChannelDefault to let the device dynamically select the best available channel
-	config := &myhome.HeaterConfig{}
 	via := types.ChannelDefault
 
 	// Batch fetch prefixed keys with KVS.GetMany (reduces 7 calls to 1)
@@ -100,13 +99,36 @@ func (s *HeaterService) HandleGetConfig(ctx context.Context, params *myhome.Heat
 	if err != nil {
 		s.log.V(1).Info("Failed to get prefixed KVS values", "error", err)
 	}
+	var items map[string]any
+	if prefixedValues != nil {
+		items = prefixedValues.Items
+	}
 
-	// Helper to get value from GetMany response
+	// Fetch unprefixed keys individually (only 2 calls)
+	var roomID, normallyClosed *string
+	if val, err := kvs.GetValue(ctx, s.log, via, sd, string(myhome.RoomIdKey)); err == nil && val != nil {
+		roomID = &val.Value
+	}
+	if val, err := kvs.GetValue(ctx, s.log, via, sd, string(myhome.NormallyClosedKey)); err == nil && val != nil {
+		normallyClosed = &val.Value
+	}
+
+	result.Config = parseHeaterConfig(items, roomID, normallyClosed)
+	return result, nil
+}
+
+// parseHeaterConfig turns the raw KVS values fetched for a device's
+// heater.js script into a typed HeaterConfig. items is the prefixed
+// "script/heater/*" batch (nil-safe); roomID/normallyClosed are the two
+// unprefixed keys fetched individually, nil when unavailable.
+func parseHeaterConfig(items map[string]any, roomID *string, normallyClosed *string) *myhome.HeaterConfig {
+	config := &myhome.HeaterConfig{}
+
 	getValue := func(key string) string {
-		if prefixedValues == nil || prefixedValues.Items == nil {
+		if items == nil {
 			return ""
 		}
-		if v, ok := prefixedValues.Items[key]; ok {
+		if v, ok := items[key]; ok {
 			if s, ok := v.(string); ok {
 				return s
 			}
@@ -114,7 +136,6 @@ func (s *HeaterService) HandleGetConfig(ctx context.Context, params *myhome.Heat
 		return ""
 	}
 
-	// Parse prefixed values
 	if v := getValue("script/heater/enable-logging"); v != "" {
 		config.EnableLogging = v == "true"
 	}
@@ -145,16 +166,68 @@ func (s *HeaterService) HandleGetConfig(ctx context.Context, params *myhome.Heat
 		config.ExternalTemperatureTopic = v
 	}
 
-	// Fetch unprefixed keys individually (only 2 calls)
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, string(myhome.RoomIdKey)); err == nil && val != nil {
-		config.RoomID = val.Value
+	if roomID != nil {
+		config.RoomID = *roomID
 	}
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, string(myhome.NormallyClosedKey)); err == nil && val != nil {
-		config.NormallyClosed = val.Value == "true"
+	if normallyClosed != nil {
+		config.NormallyClosed = *normallyClosed == "true"
 	}
 
-	result.Config = config
-	return result, nil
+	return config
+}
+
+// heaterKVSWrite pairs a KVS key with the value to write for one heater
+// config field; Field is the human-readable name used in error messages.
+type heaterKVSWrite struct {
+	Field string
+	Key   string
+	Value string
+}
+
+// buildHeaterKVSWrites decides which KVS writes HandleSetConfig must issue
+// for the fields the caller explicitly set, in the same order they were
+// written before this was extracted (enable_logging, room_id, cheap hours,
+// poll interval, preheat hours, normally_closed, temperature topics).
+func buildHeaterKVSWrites(params *myhome.HeaterSetConfigParams) []heaterKVSWrite {
+	var writes []heaterKVSWrite
+
+	if params.EnableLogging != nil {
+		val := "false"
+		if *params.EnableLogging {
+			val = "true"
+		}
+		writes = append(writes, heaterKVSWrite{"enable_logging", HeaterKVSKeys["enable_logging"], val})
+	}
+	if params.RoomID != nil {
+		writes = append(writes, heaterKVSWrite{"room_id", HeaterKVSKeys["room_id"], *params.RoomID})
+	}
+	if params.CheapStartHour != nil {
+		writes = append(writes, heaterKVSWrite{"cheap_start_hour", HeaterKVSKeys["cheap_start_hour"], fmt.Sprintf("%d", *params.CheapStartHour)})
+	}
+	if params.CheapEndHour != nil {
+		writes = append(writes, heaterKVSWrite{"cheap_end_hour", HeaterKVSKeys["cheap_end_hour"], fmt.Sprintf("%d", *params.CheapEndHour)})
+	}
+	if params.PollIntervalMs != nil {
+		writes = append(writes, heaterKVSWrite{"poll_interval_ms", HeaterKVSKeys["poll_interval_ms"], fmt.Sprintf("%d", *params.PollIntervalMs)})
+	}
+	if params.PreheatHours != nil {
+		writes = append(writes, heaterKVSWrite{"preheat_hours", HeaterKVSKeys["preheat_hours"], fmt.Sprintf("%d", *params.PreheatHours)})
+	}
+	if params.NormallyClosed != nil {
+		val := "false"
+		if *params.NormallyClosed {
+			val = "true"
+		}
+		writes = append(writes, heaterKVSWrite{"normally_closed", HeaterKVSKeys["normally_closed"], val})
+	}
+	if params.InternalTemperatureTopic != nil {
+		writes = append(writes, heaterKVSWrite{"internal_temperature_topic", HeaterKVSKeys["internal_temperature_topic"], *params.InternalTemperatureTopic})
+	}
+	if params.ExternalTemperatureTopic != nil {
+		writes = append(writes, heaterKVSWrite{"external_temperature_topic", HeaterKVSKeys["external_temperature_topic"], *params.ExternalTemperatureTopic})
+	}
+
+	return writes
 }
 
 // HandleSetConfig sets the heater configuration for a device
@@ -175,66 +248,10 @@ func (s *HeaterService) HandleSetConfig(ctx context.Context, params *myhome.Heat
 	// This allows automatic fallback to MQTT if HTTP fails mid-operation
 	via := types.ChannelDefault
 
-	// Set each provided value
-	if params.EnableLogging != nil {
-		val := "false"
-		if *params.EnableLogging {
-			val = "true"
-		}
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["enable_logging"], val); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set enable_logging: " + err.Error()}, nil
-		}
-	}
-
-	if params.RoomID != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["room_id"], *params.RoomID); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set room_id: " + err.Error()}, nil
-		}
-	}
-
-	if params.CheapStartHour != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["cheap_start_hour"], fmt.Sprintf("%d", *params.CheapStartHour)); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set cheap_start_hour: " + err.Error()}, nil
-		}
-	}
-
-	if params.CheapEndHour != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["cheap_end_hour"], fmt.Sprintf("%d", *params.CheapEndHour)); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set cheap_end_hour: " + err.Error()}, nil
-		}
-	}
-
-	if params.PollIntervalMs != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["poll_interval_ms"], fmt.Sprintf("%d", *params.PollIntervalMs)); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set poll_interval_ms: " + err.Error()}, nil
-		}
-	}
-
-	if params.PreheatHours != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["preheat_hours"], fmt.Sprintf("%d", *params.PreheatHours)); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set preheat_hours: " + err.Error()}, nil
-		}
-	}
-
-	if params.NormallyClosed != nil {
-		val := "false"
-		if *params.NormallyClosed {
-			val = "true"
-		}
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["normally_closed"], val); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set normally_closed: " + err.Error()}, nil
-		}
-	}
-
-	if params.InternalTemperatureTopic != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["internal_temperature_topic"], *params.InternalTemperatureTopic); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set internal_temperature_topic: " + err.Error()}, nil
-		}
-	}
-
-	if params.ExternalTemperatureTopic != nil {
-		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, HeaterKVSKeys["external_temperature_topic"], *params.ExternalTemperatureTopic); err != nil {
-			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set external_temperature_topic: " + err.Error()}, nil
+	// Write each provided value, stopping at the first failure.
+	for _, w := range buildHeaterKVSWrites(params) {
+		if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, w.Key, w.Value); err != nil {
+			return &myhome.HeaterSetConfigResult{Success: false, Message: "failed to set " + w.Field + ": " + err.Error()}, nil
 		}
 	}
 

--- a/internal/myhome/shelly/script/heater_test.go
+++ b/internal/myhome/shelly/script/heater_test.go
@@ -1,0 +1,150 @@
+package script
+
+import (
+	"testing"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+)
+
+func TestParseHeaterConfig(t *testing.T) {
+	t.Run("nil items and nil pointers: zero value", func(t *testing.T) {
+		got := parseHeaterConfig(nil, nil, nil)
+		if got.EnableLogging || got.RoomID != "" || got.NormallyClosed {
+			t.Errorf("expected zero-value config, got %+v", got)
+		}
+	})
+
+	t.Run("all prefixed fields parsed", func(t *testing.T) {
+		items := map[string]any{
+			"script/heater/enable-logging":             "true",
+			"script/heater/cheap-start-hour":           "22",
+			"script/heater/cheap-end-hour":             "6",
+			"script/heater/poll-interval-ms":           "5000",
+			"script/heater/preheat-hours":              "2",
+			"script/heater/internal-temperature-topic": "sensors/inside",
+			"script/heater/external-temperature-topic": "sensors/outside",
+		}
+		got := parseHeaterConfig(items, nil, nil)
+
+		if !got.EnableLogging {
+			t.Error("expected EnableLogging true")
+		}
+		if got.CheapStartHour != 22 || got.CheapEndHour != 6 {
+			t.Errorf("expected cheap hours 22/6, got %d/%d", got.CheapStartHour, got.CheapEndHour)
+		}
+		if got.PollIntervalMs != 5000 {
+			t.Errorf("expected PollIntervalMs 5000, got %d", got.PollIntervalMs)
+		}
+		if got.PreheatHours != 2 {
+			t.Errorf("expected PreheatHours 2, got %d", got.PreheatHours)
+		}
+		if got.InternalTemperatureTopic != "sensors/inside" || got.ExternalTemperatureTopic != "sensors/outside" {
+			t.Errorf("unexpected topics: %+v", got)
+		}
+	})
+
+	t.Run("room id and normally closed applied", func(t *testing.T) {
+		roomID := "salon"
+		normallyClosed := "true"
+		got := parseHeaterConfig(nil, &roomID, &normallyClosed)
+		if got.RoomID != "salon" {
+			t.Errorf("expected RoomID 'salon', got %q", got.RoomID)
+		}
+		if !got.NormallyClosed {
+			t.Error("expected NormallyClosed true")
+		}
+	})
+
+	t.Run("unparseable int field left at zero", func(t *testing.T) {
+		items := map[string]any{"script/heater/cheap-start-hour": "not-a-number"}
+		got := parseHeaterConfig(items, nil, nil)
+		if got.CheapStartHour != 0 {
+			t.Errorf("expected CheapStartHour 0 on parse failure, got %d", got.CheapStartHour)
+		}
+	})
+
+	t.Run("non-string item value ignored", func(t *testing.T) {
+		items := map[string]any{"script/heater/enable-logging": 42}
+		got := parseHeaterConfig(items, nil, nil)
+		if got.EnableLogging {
+			t.Error("expected EnableLogging false when stored value isn't a string")
+		}
+	})
+}
+
+func TestBuildHeaterKVSWrites(t *testing.T) {
+	t.Run("no fields set: no writes", func(t *testing.T) {
+		writes := buildHeaterKVSWrites(&myhome.HeaterSetConfigParams{})
+		if len(writes) != 0 {
+			t.Fatalf("expected no writes, got %+v", writes)
+		}
+	})
+
+	t.Run("only fields explicitly set are written", func(t *testing.T) {
+		roomID := "salon"
+		enableLogging := true
+		writes := buildHeaterKVSWrites(&myhome.HeaterSetConfigParams{
+			RoomID:        &roomID,
+			EnableLogging: &enableLogging,
+		})
+		if len(writes) != 2 {
+			t.Fatalf("expected 2 writes, got %d: %+v", len(writes), writes)
+		}
+		byField := make(map[string]heaterKVSWrite)
+		for _, w := range writes {
+			byField[w.Field] = w
+		}
+		if w, ok := byField["enable_logging"]; !ok || w.Value != "true" {
+			t.Errorf("expected enable_logging write with value 'true', got %+v", byField["enable_logging"])
+		}
+		if w, ok := byField["room_id"]; !ok || w.Value != "salon" {
+			t.Errorf("expected room_id write with value 'salon', got %+v", byField["room_id"])
+		}
+	})
+
+	t.Run("bool false is written as the string false", func(t *testing.T) {
+		normallyClosed := false
+		writes := buildHeaterKVSWrites(&myhome.HeaterSetConfigParams{NormallyClosed: &normallyClosed})
+		if len(writes) != 1 || writes[0].Value != "false" {
+			t.Fatalf("expected a single normally_closed write with value 'false', got %+v", writes)
+		}
+	})
+
+	t.Run("int fields formatted as decimal", func(t *testing.T) {
+		cheapStart, pollMs := 22, 5000
+		writes := buildHeaterKVSWrites(&myhome.HeaterSetConfigParams{
+			CheapStartHour: &cheapStart,
+			PollIntervalMs: &pollMs,
+		})
+		byField := make(map[string]string)
+		for _, w := range writes {
+			byField[w.Field] = w.Value
+		}
+		if byField["cheap_start_hour"] != "22" {
+			t.Errorf("expected cheap_start_hour '22', got %q", byField["cheap_start_hour"])
+		}
+		if byField["poll_interval_ms"] != "5000" {
+			t.Errorf("expected poll_interval_ms '5000', got %q", byField["poll_interval_ms"])
+		}
+	})
+
+	t.Run("writes preserve original field order", func(t *testing.T) {
+		roomID := "salon"
+		externalTopic := "sensors/outside"
+		enableLogging := true
+		writes := buildHeaterKVSWrites(&myhome.HeaterSetConfigParams{
+			ExternalTemperatureTopic: &externalTopic,
+			EnableLogging:            &enableLogging,
+			RoomID:                   &roomID,
+		})
+		wantOrder := []string{"enable_logging", "room_id", "external_temperature_topic"}
+		if len(writes) != len(wantOrder) {
+			t.Fatalf("expected %d writes, got %d", len(wantOrder), len(writes))
+		}
+		for i, want := range wantOrder {
+			if writes[i].Field != want {
+				t.Errorf("writes[%d].Field: expected %q, got %q", i, want, writes[i].Field)
+			}
+		}
+	})
+}

--- a/internal/myhome/shelly/script/pool.go
+++ b/internal/myhome/shelly/script/pool.go
@@ -577,32 +577,40 @@ type speedMappings struct {
 	High int
 }
 
+// defaultSpeedMappings are the eco/mid/high switch indices used when a
+// controller has no speed mapping configured in KVS yet.
+var defaultSpeedMappings = speedMappings{Eco: 0, Mid: 1, High: 2}
+
+// parseSpeedMappings turns up to three raw KVS string values into a
+// speedMappings, falling back to defaultSpeedMappings for any value that's
+// missing (nil) or fails to parse as an integer.
+func parseSpeedMappings(ecoRaw, midRaw, highRaw *string) *speedMappings {
+	mappings := defaultSpeedMappings
+	if ecoRaw != nil {
+		fmt.Sscanf(*ecoRaw, "%d", &mappings.Eco)
+	}
+	if midRaw != nil {
+		fmt.Sscanf(*midRaw, "%d", &mappings.Mid)
+	}
+	if highRaw != nil {
+		fmt.Sscanf(*highRaw, "%d", &mappings.High)
+	}
+	return &mappings
+}
+
 // getSpeedMappings retrieves speed-to-switch mappings from controller's KVS
 func (s *PoolService) getSpeedMappings(ctx context.Context, sd *shelly.Device, via types.Channel) (*speedMappings, error) {
-	mappings := &speedMappings{
-		Eco:  0, // defaults
-		Mid:  1,
-		High: 2,
-	}
-
-	// Try to load from KVS
+	var eco, mid, high *string
 	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["eco_speed"]); err == nil && val != nil {
-		if _, err := fmt.Sscanf(val.Value, "%d", &mappings.Eco); err != nil {
-			s.log.V(1).Info("Failed to parse eco_speed, using default", "error", err)
-		}
+		eco = &val.Value
 	}
 	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["mid_speed"]); err == nil && val != nil {
-		if _, err := fmt.Sscanf(val.Value, "%d", &mappings.Mid); err != nil {
-			s.log.V(1).Info("Failed to parse mid_speed, using default", "error", err)
-		}
+		mid = &val.Value
 	}
 	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["high_speed"]); err == nil && val != nil {
-		if _, err := fmt.Sscanf(val.Value, "%d", &mappings.High); err != nil {
-			s.log.V(1).Info("Failed to parse high_speed, using default", "error", err)
-		}
+		high = &val.Value
 	}
-
-	return mappings, nil
+	return parseSpeedMappings(eco, mid, high), nil
 }
 
 // Start starts the pool pump at the specified speed
@@ -1057,6 +1065,96 @@ func (s *PoolService) getDeviceStatus(ctx context.Context, deviceID string) (Dev
 	return status, nil
 }
 
+// environmentKVSFields lists the PoolKVSKeys names read by getEnvironmentStatus,
+// in fetch order.
+var environmentKVSFields = []string{
+	"temperature_threshold", "eco_speed", "mid_speed", "high_speed",
+	"pool_volume", "turnover", "max_flow_rate", "max_rpm", "eco_rpm", "mid_rpm", "high_rpm",
+	"max_temp", "mqtt_topic_prefix",
+}
+
+// applyEnvironmentKVSValues parses the raw KVS string values successfully
+// fetched for controllerID (keyed by the same names as environmentKVSFields)
+// and assigns them onto env. Missing keys and unparseable values are left
+// untouched, matching the original fetch-and-best-effort-parse behavior.
+func applyEnvironmentKVSValues(env *Environment, raw map[string]string) {
+	if v, ok := raw["temperature_threshold"]; ok {
+		var threshold float64
+		if _, err := fmt.Sscanf(v, "%f", &threshold); err == nil {
+			env.TemperatureThreshold = threshold
+		}
+	}
+	if v, ok := raw["eco_speed"]; ok {
+		var speed int
+		if _, err := fmt.Sscanf(v, "%d", &speed); err == nil {
+			env.EcoSpeed = &speed
+		}
+	}
+	if v, ok := raw["mid_speed"]; ok {
+		var speed int
+		if _, err := fmt.Sscanf(v, "%d", &speed); err == nil {
+			env.MidSpeed = &speed
+		}
+	}
+	if v, ok := raw["high_speed"]; ok {
+		var speed int
+		if _, err := fmt.Sscanf(v, "%d", &speed); err == nil {
+			env.HighSpeed = &speed
+		}
+	}
+	if v, ok := raw["pool_volume"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.PoolVolume = i
+		}
+	}
+	if v, ok := raw["turnover"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.Turnover = i
+		}
+	}
+	if v, ok := raw["max_flow_rate"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.MaxFlowRate = i
+		}
+	}
+	if v, ok := raw["max_rpm"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.MaxRpm = i
+		}
+	}
+	if v, ok := raw["eco_rpm"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.EcoRpm = i
+		}
+	}
+	if v, ok := raw["mid_rpm"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.MidRpm = i
+		}
+	}
+	if v, ok := raw["high_rpm"]; ok {
+		var i int
+		if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			env.HighRpm = i
+		}
+	}
+	if v, ok := raw["max_temp"]; ok {
+		var f float64
+		if _, err := fmt.Sscanf(v, "%f", &f); err == nil {
+			env.MaxTemp = f
+		}
+	}
+	if v, ok := raw["mqtt_topic_prefix"]; ok {
+		env.MqttTopicPrefix = v
+	}
+}
+
 func (s *PoolService) getEnvironmentStatus(ctx context.Context, controllerID string, env *Environment) error {
 	device, err := s.provider.GetDeviceByAny(ctx, controllerID)
 	if err != nil {
@@ -1070,97 +1168,13 @@ func (s *PoolService) getEnvironmentStatus(ctx context.Context, controllerID str
 
 	via := types.ChannelMqtt
 
-	// Get schedule configuration from KVS
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["temperature_threshold"]); err == nil && val != nil {
-		var threshold float64
-		if _, err := fmt.Sscanf(val.Value, "%f", &threshold); err == nil {
-			env.TemperatureThreshold = threshold
+	raw := make(map[string]string)
+	for _, key := range environmentKVSFields {
+		if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys[key]); err == nil && val != nil {
+			raw[key] = val.Value
 		}
 	}
-
-	// Get speed mappings from KVS
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["eco_speed"]); err == nil && val != nil {
-		var speed int
-		if _, err := fmt.Sscanf(val.Value, "%d", &speed); err == nil {
-			env.EcoSpeed = &speed
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["mid_speed"]); err == nil && val != nil {
-		var speed int
-		if _, err := fmt.Sscanf(val.Value, "%d", &speed); err == nil {
-			env.MidSpeed = &speed
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["high_speed"]); err == nil && val != nil {
-		var speed int
-		if _, err := fmt.Sscanf(val.Value, "%d", &speed); err == nil {
-			env.HighSpeed = &speed
-		}
-	}
-
-	// Get temperature-proportional scheduling parameters from KVS
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["pool_volume"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.PoolVolume = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["turnover"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.Turnover = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["max_flow_rate"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.MaxFlowRate = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["max_rpm"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.MaxRpm = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["eco_rpm"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.EcoRpm = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["mid_rpm"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.MidRpm = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["high_rpm"]); err == nil && val != nil {
-		var v int
-		if _, err := fmt.Sscanf(val.Value, "%d", &v); err == nil {
-			env.HighRpm = v
-		}
-	}
-
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["max_temp"]); err == nil && val != nil {
-		var v float64
-		if _, err := fmt.Sscanf(val.Value, "%f", &v); err == nil {
-			env.MaxTemp = v
-		}
-	}
-
-	// Get MQTT configuration from KVS
-	if val, err := kvs.GetValue(ctx, s.log, via, sd, PoolKVSKeys["mqtt_topic_prefix"]); err == nil && val != nil {
-		env.MqttTopicPrefix = val.Value
-	}
+	applyEnvironmentKVSValues(env, raw)
 
 	// Get forecast URL from Script.storage (not KVS)
 	// Note: This is stored in Script.storage, not KVS, so we'd need to call Script.Eval to retrieve it

--- a/internal/myhome/shelly/script/pool_test.go
+++ b/internal/myhome/shelly/script/pool_test.go
@@ -1,0 +1,164 @@
+package script
+
+import "testing"
+
+func TestGetDesiredSchedules(t *testing.T) {
+	defs := getDesiredSchedules(7)
+	if len(defs) != 5 {
+		t.Fatalf("expected 5 schedule definitions, got %d", len(defs))
+	}
+
+	wantCodes := []string{
+		"handleDailyCheck()",
+		"handleMorningStart()",
+		"handleEveningStop()",
+		"handleNightStart()",
+		"handleNightStop()",
+	}
+	for i, want := range wantCodes {
+		if defs[i].Code != want {
+			t.Errorf("defs[%d].Code: expected %q, got %q", i, want, defs[i].Code)
+		}
+	}
+
+	// Morning start and evening stop ship disabled (winter mode); the rest enabled.
+	wantEnabled := []bool{true, false, false, true, true}
+	for i, want := range wantEnabled {
+		if defs[i].Enable != want {
+			t.Errorf("defs[%d].Enable: expected %v, got %v", i, want, defs[i].Enable)
+		}
+	}
+}
+
+func TestBuildJobSpec(t *testing.T) {
+	def := scheduleDefinition{Enable: true, Timespec: "@sunrise * * *", Code: "handleDailyCheck()"}
+	spec := buildJobSpec(42, def)
+
+	if spec.Enable != true || spec.Timespec != "@sunrise * * *" {
+		t.Fatalf("unexpected spec: %+v", spec)
+	}
+	if len(spec.Calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(spec.Calls))
+	}
+	call := spec.Calls[0]
+	if call.Method != "script.eval" {
+		t.Errorf("expected method 'script.eval', got %q", call.Method)
+	}
+	params, ok := call.Params.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected params to be a map, got %T", call.Params)
+	}
+	if params["id"] != 42 {
+		t.Errorf("expected id 42, got %v", params["id"])
+	}
+	if params["code"] != "handleDailyCheck()" {
+		t.Errorf("expected code 'handleDailyCheck()', got %v", params["code"])
+	}
+}
+
+func TestParseSpeedMappings(t *testing.T) {
+	eco, mid, high := "3", "5", "9"
+
+	tests := []struct {
+		name           string
+		eco, mid, high *string
+		want           speedMappings
+	}{
+		{"all missing: defaults", nil, nil, nil, speedMappings{Eco: 0, Mid: 1, High: 2}},
+		{"all present", &eco, &mid, &high, speedMappings{Eco: 3, Mid: 5, High: 9}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSpeedMappings(tt.eco, tt.mid, tt.high)
+			if *got != tt.want {
+				t.Errorf("expected %+v, got %+v", tt.want, *got)
+			}
+		})
+	}
+
+	t.Run("unparseable value keeps default", func(t *testing.T) {
+		bad := "not-a-number"
+		got := parseSpeedMappings(&bad, nil, nil)
+		if got.Eco != 0 {
+			t.Errorf("expected Eco to keep default 0, got %d", got.Eco)
+		}
+		if got.Mid != 1 || got.High != 2 {
+			t.Errorf("expected Mid/High defaults preserved, got %+v", got)
+		}
+	})
+}
+
+func TestApplyEnvironmentKVSValues(t *testing.T) {
+	t.Run("empty raw leaves env untouched", func(t *testing.T) {
+		env := &Environment{PoolVolume: 99}
+		applyEnvironmentKVSValues(env, map[string]string{})
+		if env.PoolVolume != 99 {
+			t.Errorf("expected PoolVolume to remain 99, got %d", env.PoolVolume)
+		}
+		if env.EcoSpeed != nil {
+			t.Errorf("expected EcoSpeed to remain nil, got %v", *env.EcoSpeed)
+		}
+	})
+
+	t.Run("all fields applied", func(t *testing.T) {
+		env := &Environment{}
+		raw := map[string]string{
+			"temperature_threshold": "18.5",
+			"eco_speed":             "1",
+			"mid_speed":             "2",
+			"high_speed":            "3",
+			"pool_volume":           "50000",
+			"turnover":              "4",
+			"max_flow_rate":         "12",
+			"max_rpm":               "2900",
+			"eco_rpm":               "1200",
+			"mid_rpm":               "2000",
+			"high_rpm":              "2900",
+			"max_temp":              "32.5",
+			"mqtt_topic_prefix":     "pool/pump",
+		}
+		applyEnvironmentKVSValues(env, raw)
+
+		if env.TemperatureThreshold != 18.5 {
+			t.Errorf("TemperatureThreshold: expected 18.5, got %v", env.TemperatureThreshold)
+		}
+		if env.EcoSpeed == nil || *env.EcoSpeed != 1 {
+			t.Errorf("EcoSpeed: expected 1, got %v", env.EcoSpeed)
+		}
+		if env.MidSpeed == nil || *env.MidSpeed != 2 {
+			t.Errorf("MidSpeed: expected 2, got %v", env.MidSpeed)
+		}
+		if env.HighSpeed == nil || *env.HighSpeed != 3 {
+			t.Errorf("HighSpeed: expected 3, got %v", env.HighSpeed)
+		}
+		if env.PoolVolume != 50000 {
+			t.Errorf("PoolVolume: expected 50000, got %d", env.PoolVolume)
+		}
+		if env.Turnover != 4 {
+			t.Errorf("Turnover: expected 4, got %d", env.Turnover)
+		}
+		if env.MaxFlowRate != 12 {
+			t.Errorf("MaxFlowRate: expected 12, got %d", env.MaxFlowRate)
+		}
+		if env.MaxRpm != 2900 {
+			t.Errorf("MaxRpm: expected 2900, got %d", env.MaxRpm)
+		}
+		if env.EcoRpm != 1200 || env.MidRpm != 2000 || env.HighRpm != 2900 {
+			t.Errorf("Eco/Mid/HighRpm: expected 1200/2000/2900, got %d/%d/%d", env.EcoRpm, env.MidRpm, env.HighRpm)
+		}
+		if env.MaxTemp != 32.5 {
+			t.Errorf("MaxTemp: expected 32.5, got %v", env.MaxTemp)
+		}
+		if env.MqttTopicPrefix != "pool/pump" {
+			t.Errorf("MqttTopicPrefix: expected 'pool/pump', got %q", env.MqttTopicPrefix)
+		}
+	})
+
+	t.Run("unparseable value leaves field untouched", func(t *testing.T) {
+		env := &Environment{MaxRpm: 42}
+		applyEnvironmentKVSValues(env, map[string]string{"max_rpm": "not-a-number"})
+		if env.MaxRpm != 42 {
+			t.Errorf("expected MaxRpm to remain 42 on parse failure, got %d", env.MaxRpm)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Extracts pure decision/parsing logic out of `internal/myhome/shelly/script/{heater,pool}.go` so it's testable without a device or KVS transport, and adds tests for it. No behavior change.

**heater.go:**
- `parseHeaterConfig(items map[string]any, roomID, normallyClosed *string) *myhome.HeaterConfig` — the KVS-map-to-typed-config parsing previously inlined in `HandleGetConfig`.
- `buildHeaterKVSWrites(params *myhome.HeaterSetConfigParams) []heaterKVSWrite` — the "which KVS keys to write, and with what value" decision previously inlined in `HandleSetConfig`; the adapter loop that actually calls `kvs.SetKeyValue` and stops on first error is now a 5-line loop over the returned writes.

**pool.go:**
- Added tests for the already-pure `getDesiredSchedules`/`buildJobSpec` (free coverage, no refactor needed).
- `parseSpeedMappings(ecoRaw, midRaw, highRaw *string) *speedMappings` — extracted from `getSpeedMappings`, which is now a thin KVS-fetch-then-parse adapter.
- `applyEnvironmentKVSValues(env *Environment, raw map[string]string)` — extracted the ~100-line repetitive fetch-parse-assign block from `getEnvironmentStatus` into one pure function driven by a plain `map[string]string` of already-fetched raw values.

## Scope note: Kind-2 (adapter-loop) tests deferred

Issue #305 also asked for adapter-loop tests (e.g. `reconcileSchedules`, the KVS write loops) via a mock-transport-backed device. While implementing, I found that `PoolService`/`HeaterService` operate on the concrete `*shelly.Device` type, whose `CallE` dispatches through a package-level `Registrar`/`DeviceCaller` seam (`pkg/shelly/registrar.go`, `pkg/shelly/ops.go`) rather than directly through the `types.Device` interface at the call site. Building a safe, reusable fake for that seam (with proper cleanup of the global registrar state) is exactly the scope of issue #307 ("Cover pkg/shelly/* RPC ops via the Device/Channel seam"). Doing it piecemeal here risked being inconsistent with what #307 will build, so I left it out rather than force something fragile — #305's adapter-loop tests should follow once #307 lands a reusable fake.

Also, `reconcileSchedules` has intentional 500ms sleeps between device calls (rate limiting), so testing it end-to-end would be slow even once the seam exists; it's better covered indirectly through its constituent `listSchedules`/`createSchedule`/`deleteSchedule` calls plus the schedule-selection logic now covered here (`getDesiredSchedules`/`buildJobSpec`).

## Test plan

- [x] `go test ./internal/myhome/shelly/script/...` — all new and existing tests pass
- [x] `go build ./internal/myhome/...` — no breakage
- [x] `make test` — full workspace suite green

Part of #311, closes #305.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- test(shelly): extract pure config/schedule logic from pool + heater scripts ([97ce4a5](https://github.com/asnowfix/home-automation/commit/97ce4a552c0b4883a8ee7118ae9885227c1c9a2b))
- Merge branch 'main' into issue-305-script-orchestration ([aac074f](https://github.com/asnowfix/home-automation/commit/aac074fff332ec45d79719a346b21cc9cfd76e85))
<!-- END-AUTO-GENERATED-COMMITS -->