### PR TITLE
fix(myip): stop panicking on network errors, add timeout + tests

### DIFF
--- a/internal/myip/seeip.go
+++ b/internal/myip/seeip.go
@@ -1,21 +1,60 @@
 package myip
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"time"
 )
 
-func SeeIp() string {
-	res, _ := http.Get("https://ipv4.seeip.org/jsonip")
-	ipJson, _ := ioutil.ReadAll(res.Body)
+// seeIPURL is a var so tests can redirect it to a local httptest.Server.
+var seeIPURL = "https://ipv4.seeip.org/jsonip"
+
+// defaultTimeout bounds how long SeeIp waits for the external service, so an
+// unreachable or slow internet connection can't block the caller forever.
+const defaultTimeout = 5 * time.Second
+
+// SeeIp returns the caller's public IPv4 address as seen by an external
+// service. It returns an error rather than panicking if the service is
+// unreachable, times out, or returns an unexpected response.
+func SeeIp(ctx context.Context) (string, error) {
+	return SeeIpWithClient(ctx, http.DefaultClient)
+}
+
+// SeeIpWithClient is like SeeIp but takes an explicit *http.Client, so tests
+// can inject one pointed at a local httptest.Server.
+func SeeIpWithClient(ctx context.Context, client *http.Client) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, seeIPURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("building request: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching public IP: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s", res.StatusCode, seeIPURL)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading response: %w", err)
+	}
+
 	var data struct {
 		Ip string `json:"ip"`
 	}
-	if err := json.Unmarshal([]byte(ipJson), &data); err != nil {
-		panic(err)
+	if err := json.Unmarshal(body, &data); err != nil {
+		return "", fmt.Errorf("parsing response: %w", err)
 	}
-	fmt.Printf("My IPv4 is" + data.Ip)
-	return data.Ip
+
+	return data.Ip, nil
 }

--- a/internal/myip/seeip_test.go
+++ b/internal/myip/seeip_test.go
@@ -1,0 +1,89 @@
+package myip
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// withSeeIPServer starts an httptest.Server, redirects seeIPURL to it for the
+// duration of the test, and restores the original URL in t.Cleanup. seeIPURL
+// is a package-level var, so tests using this must not call t.Parallel().
+func withSeeIPServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	prev := seeIPURL
+	seeIPURL = srv.URL
+	t.Cleanup(func() {
+		srv.Close()
+		seeIPURL = prev
+	})
+	return srv
+}
+
+func TestSeeIp_HappyPath(t *testing.T) {
+	withSeeIPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ip":"203.0.113.42"}`))
+	})
+
+	ip, err := SeeIp(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip != "203.0.113.42" {
+		t.Errorf("expected '203.0.113.42', got %q", ip)
+	}
+}
+
+func TestSeeIp_NonOKStatus(t *testing.T) {
+	withSeeIPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	_, err := SeeIp(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for a non-200 status")
+	}
+}
+
+func TestSeeIp_MalformedJSON(t *testing.T) {
+	withSeeIPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not-json{{{`))
+	})
+
+	_, err := SeeIp(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for malformed JSON")
+	}
+}
+
+func TestSeeIp_Timeout(t *testing.T) {
+	withSeeIPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Write([]byte(`{"ip":"203.0.113.42"}`))
+	})
+
+	client := &http.Client{Timeout: 20 * time.Millisecond}
+	_, err := SeeIpWithClient(context.Background(), client)
+	if err == nil {
+		t.Fatal("expected a timeout error")
+	}
+}
+
+func TestSeeIp_ContextCancelled(t *testing.T) {
+	withSeeIPServer(t, func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.Write([]byte(`{"ip":"203.0.113.42"}`))
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := SeeIp(ctx)
+	if err == nil {
+		t.Fatal("expected an error for an already-cancelled context")
+	}
+}

--- a/myip/main.go
+++ b/myip/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"os"
+
 	"github.com/asnowfix/home-automation/internal/myip"
 )
 
 func main() {
-	ip := myip.SeeIp()
+	ip, err := myip.SeeIp(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get public IP: %v\n", err)
+		os.Exit(1)
+	}
 	fmt.Printf("IPv4: %v", ip)
 }


### PR DESCRIPTION
## Summary

Issue #308 originally targeted `myhome/occupancy/`, `myhome/temperature/` (forecast path), and `internal/myhome/net/resolver.go` for a Clock/HTTP injection seam. After investigation, **none of those actually had the gap the issue assumed** — see "Scope change" below. Instead, this PR fixes and tests the one genuinely un-resilient external HTTP call found in the whole codebase: `internal/myip/seeip.go`.

### `internal/myip/seeip.go` — before

```go
func SeeIp() string {
	res, _ := http.Get("https://ipv4.seeip.org/jsonip")
	ipJson, _ := ioutil.ReadAll(res.Body)
	...
	if err := json.Unmarshal([]byte(ipJson), &data); err != nil {
		panic(err)
	}
	...
}
```

This had no timeout, silently discarded the `http.Get` error (then dereferenced the nil `res.Body` on any network failure — a guaranteed panic when offline or on any request error), and panicked again on a JSON decode failure. This is close to the worst-case violation of CLAUDE.md's "Resilience — internet-optional" rule.

### After

`SeeIp(ctx)` now:
- takes a `context.Context` and applies a 5s timeout internally (`SeeIpWithClient` for test/DI use with a custom `*http.Client`)
- returns `(string, error)` instead of panicking on any failure (network error, non-200 status, malformed JSON)
- has `seeIPURL` as a package var so tests can redirect it to an `httptest.Server`

Its sole caller (`myip/main.go`) is updated to use the new signature.

## Scope change: why the original targets were dropped

- **`myhome/occupancy/`**: `IsOccupied` already reads `time.Now()` against atomic fields set independently; existing tests already exercise this deterministically by setting the atomic fields directly. No Clock seam needed.
- **`myhome/temperature/`**: the actual date-dependent logic, `GetComfortRanges(ctx, roomID, when time.Time)`, already takes time as a parameter — it's already injectable. The two `time.Now()` call sites (`PublishRangesUpdate`) are thin production wrappers around that already-testable function, not a testability gap.
- **`internal/myhome/net/resolver.go`**: already uses `context.WithTimeout`/`ctx.Done()` correctly throughout. Its 0% coverage is because it does real mDNS/zeroconf UDP multicast, which is hard to test deterministically — not because it's missing an injection seam. Filed as a separate, appropriately-scoped follow-up (testing its timeout/cancellation paths without a real network responder) rather than forcing an unrelated Clock abstraction onto it.
- No production Go code makes weather/firmware HTTP calls — those happen on-device in Shelly JS scripts (`pool-pump.js` etc.); the Go side only stores a `forecast_url` config string.

Also checked: no existing `Clock` interface anywhere in the workspace, so nothing was already in place to reuse (per the issue's own instruction to check first) — and per CLAUDE.md's "don't design for hypothetical future requirements," I didn't add a speculative unused `Clock` abstraction just to nominally satisfy the issue title.

## Test plan

- [x] `go test ./internal/myip/...` — happy path, non-200 status, malformed JSON, client timeout, and cancelled-context, all pass
- [x] `go build ./...` — no breakage (verified `myip/main.go`'s updated call site)
- [x] `make test` — full workspace suite green

Part of #311, closes #308.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(myip): stop panicking on network errors, add timeout + tests ([c8fc9f3](https://github.com/asnowfix/home-automation/commit/c8fc9f34fde64acb58f85a2341defdb22039896d))
<!-- END-AUTO-GENERATED-COMMITS -->