### PR TITLE
test(devices): extract pure device classification from manager.go

### DIFF
--- a/myhome/devices/impl/manager.go
+++ b/myhome/devices/impl/manager.go
@@ -835,7 +835,13 @@ func (dm *DeviceManager) HandleThermometerList(ctx context.Context) (*myhome.The
 	if err != nil {
 		return nil, fmt.Errorf("failed to get devices: %w", err)
 	}
+	return &myhome.ThermometerListResult{Thermometers: classifyThermometers(devices)}, nil
+}
 
+// classifyThermometers scans devices for Gen1 H&T sensors (by Info.Application
+// or the "shellyht-" id prefix) and BLU sensors advertising a "temperature"
+// BTHome capability, returning one ThermometerInfo per match.
+func classifyThermometers(devices []*myhome.Device) []myhome.ThermometerInfo {
 	thermometers := make([]myhome.ThermometerInfo, 0)
 
 	for _, d := range devices {
@@ -846,8 +852,7 @@ func (dm *DeviceManager) HandleThermometerList(ctx context.Context) (*myhome.The
 				Name:      d.Name(),
 				Type:      "Gen1",
 				MqttTopic: fmt.Sprintf("shellies/%s/sensor/temperature", d.Id()),
-				RoomId:    d.RoomId, // Add this field
-
+				RoomId:    d.RoomId,
 			})
 			continue
 		}
@@ -862,7 +867,7 @@ func (dm *DeviceManager) HandleThermometerList(ctx context.Context) (*myhome.The
 						Name:      d.Name(),
 						Type:      "BLU",
 						MqttTopic: fmt.Sprintf("shelly-blu/events/%s", d.MAC),
-						RoomId:    d.RoomId, // Add this field
+						RoomId:    d.RoomId,
 					})
 					break
 				}
@@ -870,7 +875,7 @@ func (dm *DeviceManager) HandleThermometerList(ctx context.Context) (*myhome.The
 		}
 	}
 
-	return &myhome.ThermometerListResult{Thermometers: thermometers}, nil
+	return thermometers
 }
 
 // HandleDoorList returns a list of devices with window/door sensing capability
@@ -879,7 +884,12 @@ func (dm *DeviceManager) HandleDoorList(ctx context.Context) (*myhome.DoorListRe
 	if err != nil {
 		return nil, fmt.Errorf("failed to get devices: %w", err)
 	}
+	return &myhome.DoorListResult{Doors: classifyDoors(devices)}, nil
+}
 
+// classifyDoors scans devices for BLU sensors advertising a "window" BTHome
+// capability, returning one DoorInfo per match.
+func classifyDoors(devices []*myhome.Device) []myhome.DoorInfo {
 	doors := make([]myhome.DoorInfo, 0)
 
 	for _, d := range devices {
@@ -901,7 +911,7 @@ func (dm *DeviceManager) HandleDoorList(ctx context.Context) (*myhome.DoorListRe
 		}
 	}
 
-	return &myhome.DoorListResult{Doors: doors}, nil
+	return doors
 }
 
 // GetShellyDevice returns a Shelly device for RPC calls (implements script.DeviceProvider)

--- a/myhome/devices/impl/manager_test.go
+++ b/myhome/devices/impl/manager_test.go
@@ -1,0 +1,122 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
+)
+
+func newTestDevice(id, name string) *myhome.Device {
+	d := &myhome.Device{}
+	d.Id_ = id
+	d.Name_ = name
+	return d
+}
+
+func TestClassifyThermometers(t *testing.T) {
+	t.Run("no devices", func(t *testing.T) {
+		got := classifyThermometers(nil)
+		if len(got) != 0 {
+			t.Errorf("expected no thermometers, got %+v", got)
+		}
+	})
+
+	t.Run("gen1 by id prefix", func(t *testing.T) {
+		d := newTestDevice("shellyht-208500", "Bedroom Sensor")
+		got := classifyThermometers([]*myhome.Device{d})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 thermometer, got %+v", got)
+		}
+		if got[0].Type != "Gen1" || got[0].MqttTopic != "shellies/shellyht-208500/sensor/temperature" {
+			t.Errorf("unexpected result: %+v", got[0])
+		}
+	})
+
+	t.Run("gen1 by Info.Application", func(t *testing.T) {
+		d := newTestDevice("some-other-id", "Kitchen Sensor")
+		d.Info = &shelly.DeviceInfo{Product: shelly.Product{Application: "shellyht"}}
+		got := classifyThermometers([]*myhome.Device{d})
+		if len(got) != 1 || got[0].Type != "Gen1" {
+			t.Fatalf("expected 1 Gen1 thermometer, got %+v", got)
+		}
+	})
+
+	t.Run("blu device with temperature capability", func(t *testing.T) {
+		d := newTestDevice("blu-abc123", "BLU Sensor")
+		d.MAC = "AA:BB:CC:DD:EE:FF"
+		d.Info = &shelly.DeviceInfo{BTHome: &shelly.BTHomeInfo{Capabilities: []string{"battery", "temperature"}}}
+		got := classifyThermometers([]*myhome.Device{d})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 thermometer, got %+v", got)
+		}
+		if got[0].Type != "BLU" || got[0].MqttTopic != "shelly-blu/events/AA:BB:CC:DD:EE:FF" {
+			t.Errorf("unexpected result: %+v", got[0])
+		}
+	})
+
+	t.Run("blu device without temperature capability is excluded", func(t *testing.T) {
+		d := newTestDevice("blu-abc123", "BLU Sensor")
+		d.Info = &shelly.DeviceInfo{BTHome: &shelly.BTHomeInfo{Capabilities: []string{"window"}}}
+		got := classifyThermometers([]*myhome.Device{d})
+		if len(got) != 0 {
+			t.Errorf("expected no thermometers, got %+v", got)
+		}
+	})
+
+	t.Run("plain switch device is excluded", func(t *testing.T) {
+		d := newTestDevice("shellyplus1-abc", "Living Room Switch")
+		got := classifyThermometers([]*myhome.Device{d})
+		if len(got) != 0 {
+			t.Errorf("expected no thermometers, got %+v", got)
+		}
+	})
+
+	t.Run("room id is carried through", func(t *testing.T) {
+		d := newTestDevice("shellyht-1", "Sensor")
+		d.RoomId = "bedroom"
+		got := classifyThermometers([]*myhome.Device{d})
+		if len(got) != 1 || got[0].RoomId != "bedroom" {
+			t.Fatalf("expected RoomId 'bedroom', got %+v", got)
+		}
+	})
+}
+
+func TestClassifyDoors(t *testing.T) {
+	t.Run("no devices", func(t *testing.T) {
+		got := classifyDoors(nil)
+		if len(got) != 0 {
+			t.Errorf("expected no doors, got %+v", got)
+		}
+	})
+
+	t.Run("blu device with window capability", func(t *testing.T) {
+		d := newTestDevice("blu-window1", "Front Door")
+		d.MAC = "11:22:33:44:55:66"
+		d.Info = &shelly.DeviceInfo{BTHome: &shelly.BTHomeInfo{Capabilities: []string{"window"}}}
+		got := classifyDoors([]*myhome.Device{d})
+		if len(got) != 1 {
+			t.Fatalf("expected 1 door, got %+v", got)
+		}
+		if got[0].Type != "BLU" || got[0].MqttTopic != "shelly-blu/events/11:22:33:44:55:66" {
+			t.Errorf("unexpected result: %+v", got[0])
+		}
+	})
+
+	t.Run("blu device without window capability is excluded", func(t *testing.T) {
+		d := newTestDevice("blu-temp1", "Temp Sensor")
+		d.Info = &shelly.DeviceInfo{BTHome: &shelly.BTHomeInfo{Capabilities: []string{"temperature"}}}
+		got := classifyDoors([]*myhome.Device{d})
+		if len(got) != 0 {
+			t.Errorf("expected no doors, got %+v", got)
+		}
+	})
+
+	t.Run("gen1 thermometer-like id is excluded", func(t *testing.T) {
+		d := newTestDevice("shellyht-208500", "Bedroom Sensor")
+		got := classifyDoors([]*myhome.Device{d})
+		if len(got) != 0 {
+			t.Errorf("expected no doors (door.list only recognizes BLU window sensors), got %+v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Extracts the device-classification logic out of `myhome/devices/impl/manager.go`'s `HandleThermometerList`/`HandleDoorList` into pure functions (`classifyThermometers`, `classifyDoors`) that take an already-fetched `[]*myhome.Device` and return the matching summaries — no I/O, directly testable. Adds `myhome/devices/impl/manager_test.go` covering: Gen1 thermometers (by `Info.Application` and by id prefix), BLU thermometers/door sensors (matched/excluded by BTHome capability), and that `RoomId` is carried through. No behavior change.

## Scope note: the "registry core" this issue originally asked for already exists

Issue #309 asked to "separate device-registry state transitions (add/update/match/forget devices, modified-flag bookkeeping) from MQTT discovery I/O" in `manager.go`. On inspection, **that separation already exists and is already tested**: `DeviceManager` doesn't hold registry state itself — it delegates entirely to `dm.dr`, a `myhome/devices.DeviceRegistry` interface (`myhome/devices/device.go`), backed by `mhd.NewCache(ctx, s)` (`myhome/devices/cache.go`), which is covered by `myhome/devices/cache_test.go`. `manager.go` itself is thin RPC-handler wiring plus orchestration that talks to real Shelly devices (`shelly.NewDeviceFromSummary`, `shellysetup.SetupDevice`, MQTT discovery loops) — closer in shape to `myhome/daemon`'s startup wiring than to a hidden state machine.

Given that, this PR targets the genuine pure-logic gap that remained in `manager.go` (the classification functions) rather than re-doing already-solved registry work. The remaining untested surface (`triggerAutoSetup`, `Start`, the discovery/refresh loops) is heavily entangled with real device/MQTT I/O and doesn't have a clean pure core to extract without a larger redesign — left as-is rather than forcing a risky refactor.

## Test plan

- [x] `go test ./myhome/devices/...` — all new and existing tests pass
- [x] `go build ./myhome/devices/...` — no breakage
- [x] `make test` — full workspace suite green

Part of #311, closes #309.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- test(devices): extract pure device classification from manager.go ([650dea6](https://github.com/asnowfix/home-automation/commit/650dea663bf74e09de9328946f6c55f31c61255b))
<!-- END-AUTO-GENERATED-COMMITS -->