### PR TITLE
fix(beem): correct box/summary endpoint method and response shape

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,10 @@ run-local-daemon: build
 		kill $$PIDS 2>/dev/null; sleep 1; kill -9 $$PIDS 2>/dev/null || true; \
 	fi
 	@rm -f "$(LOCAL_DAEMON_PID)"
-	@(nohup ./myhome/myhome daemon run --instance local --mqtt-broker $(MYHOME_MQTT_BROKER) > "$(LOCAL_DAEMON_LOG)" 2>&1 & echo $$! > "$(LOCAL_DAEMON_PID)")
+	@( \
+		if [ -f .env ]; then set -a; . ./.env; set +a; fi; \
+		nohup ./myhome/myhome daemon run --instance local --mqtt-broker $(MYHOME_MQTT_BROKER) > "$(LOCAL_DAEMON_LOG)" 2>&1 & echo $$! > "$(LOCAL_DAEMON_PID)" \
+	)
 	@sleep 1
 	@echo "run-local-daemon: started (pid $$(cat "$(LOCAL_DAEMON_PID)")), logs: $(LOCAL_DAEMON_LOG)"
 

--- a/docs/beem-energy.md
+++ b/docs/beem-energy.md
@@ -20,7 +20,7 @@ Beem Energy produces solar PnP kits (Hoymiles micro-inverters + DTU gateway). Th
 ### REST API
 
 - **Login:** `POST https://api-x.beem.energy/beemapp/user/login` with `{email, password}` → JWT `accessToken`
-- **Data:** `GET https://api-x.beem.energy/beemapp/box/summary` (Bearer token) → instantaneous production W, daily Wh, monthly Wh
+- **Data:** `POST https://api-x.beem.energy/beemapp/box/summary` (Bearer token) with body `{month, year}` (current period) → JSON array, one entry per registered Beem box: `wattHour` (instantaneous production W, despite the name), `totalDay` (Wh), `totalMonth` (Wh). This project assumes a single-box household and reads `[0]`.
 - **Token refresh:** on 401 or proactively 60 s before expiry; token is stateless in memory (no disk persistence needed)
 
 ### Community references

--- a/pkg/beem/client.go
+++ b/pkg/beem/client.go
@@ -13,10 +13,11 @@ import (
 	"github.com/go-logr/logr"
 )
 
-// loginURL and summaryURL are vars so tests can redirect to a local httptest.Server.
+// loginURL, summaryURL and devicesURL are vars so tests can redirect to a local httptest.Server.
 var (
 	loginURL   = "https://api-x.beem.energy/beemapp/user/login"
 	summaryURL = "https://api-x.beem.energy/beemapp/box/summary"
+	devicesURL = "https://api-x.beem.energy/beemapp/devices"
 )
 
 const (
@@ -30,14 +31,70 @@ type loginResponse struct {
 	ExpiresIn   float64 `json:"expiresIn"` // seconds until expiry
 }
 
-// summaryResponse is the JSON payload returned by the Beem summary endpoint.
-type summaryResponse struct {
-	// Instantaneous solar production in watts.
-	InstantPower float64 `json:"instantPower"`
-	// Energy produced today in watt-hours.
-	DayEnergy float64 `json:"dayEnergy"`
+// boxSummary is one entry of the JSON array returned by the Beem summary
+// endpoint: one object per registered Beem box. Field names match the wire
+// format, captured from a live response (confirmed against the
+// CharlesP44/Beem_Energy Home Assistant integration, since Beem has no
+// public API docs). All fields are modeled even though PowerSample only
+// surfaces WattHour/TotalDay/TotalMonth today, so a future consumer doesn't
+// need another round of wire-format archaeology.
+type boxSummary struct {
+	BoxID        int       `json:"boxId"`
+	SerialNumber string    `json:"serialNumber"`
+	Name         string    `json:"name"`
+	LastAlive    time.Time `json:"lastAlive"`
+	// LastProduction is the timestamp of the last non-zero production sample.
+	LastProduction time.Time `json:"lastProduction"`
 	// Energy produced this month in watt-hours.
-	MonthEnergy float64 `json:"monthEnergy"`
+	TotalMonth float64 `json:"totalMonth"`
+	// Energy produced today in watt-hours.
+	TotalDay float64 `json:"totalDay"`
+	// Instantaneous solar production in watts (misleadingly named on the wire).
+	WattHour float64 `json:"wattHour"`
+	Year     int     `json:"year"`
+	Month    int     `json:"month"`
+	// LastDbm is the box's last known WiFi signal strength in dBm.
+	LastDbm int `json:"lastDbm"`
+	// Power is the box's nameplate/peak power rating in watts, not a live reading.
+	Power float64 `json:"power"`
+	// Weather is present but always null in every capture so far; kept as
+	// raw JSON since its populated shape is undocumented.
+	Weather json.RawMessage `json:"weather"`
+}
+
+// DevicesResponse is the JSON payload returned by GET /beemapp/devices: the
+// full device topology for the account. Batteries and EnergySwitches are
+// always empty for this project's PnP-kit-only household (no Beem Battery,
+// see docs/beem-energy.md) and are kept as raw JSON rather than modeled,
+// since their populated shape has never been observed against real hardware.
+type DevicesResponse struct {
+	BeemBoxes      []BeemBoxDevice   `json:"beemboxes"`
+	Batteries      []json.RawMessage `json:"batteries"`
+	EnergySwitches []json.RawMessage `json:"energySwitches"`
+}
+
+// BeemBoxDevice is one entry of DevicesResponse.BeemBoxes: static box
+// metadata and its attached solar panel equipment (as opposed to boxSummary,
+// which carries the box's production figures).
+type BeemBoxDevice struct {
+	ID              int              `json:"id"`
+	HouseID         int              `json:"houseId"`
+	Name            string           `json:"name"`
+	SerialNumber    string           `json:"serialNumber"`
+	Power           float64          `json:"power"`
+	CreatedAt       time.Time        `json:"createdAt"`
+	SolarEquipments []SolarEquipment `json:"solarEquipments"`
+}
+
+// SolarEquipment is one panel array attached to a BeemBoxDevice.
+type SolarEquipment struct {
+	ID              int     `json:"id"`
+	Type            string  `json:"type"`
+	BoxID           int     `json:"boxId"`
+	Orientation     float64 `json:"orientation"`
+	Tilt            float64 `json:"tilt"`
+	PeakPower       float64 `json:"peakPower"`
+	GuaranteeStatus string  `json:"guaranteeStatus"`
 }
 
 // Client authenticates against the Beem Energy REST API and polls production data.
@@ -130,13 +187,25 @@ func (c *Client) PollSummary(ctx context.Context) (PowerSample, error) {
 	return sample, err
 }
 
-// fetchSummary performs the actual GET /beemapp/box/summary request.
+// fetchSummary performs the actual POST /beemapp/box/summary request.
+// The endpoint requires a JSON body of {month, year} for the current period
+// and returns a JSON array with one entry per registered Beem box.
 // It returns the parsed sample, the HTTP status code, and any error.
 func (c *Client) fetchSummary(ctx context.Context) (PowerSample, int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, summaryURL, nil)
+	now := time.Now()
+	body, err := json.Marshal(map[string]int{
+		"month": int(now.Month()),
+		"year":  now.Year(),
+	})
+	if err != nil {
+		return PowerSample{}, 0, fmt.Errorf("beem: marshal summary request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, summaryURL, bytes.NewReader(body))
 	if err != nil {
 		return PowerSample{}, 0, fmt.Errorf("beem: create summary request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.token)
 
 	resp, err := c.http.Do(req)
@@ -148,23 +217,86 @@ func (c *Client) fetchSummary(ctx context.Context) (PowerSample, int, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return PowerSample{}, http.StatusUnauthorized, fmt.Errorf("beem: unauthorized")
 	}
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(resp.Body)
 		return PowerSample{}, resp.StatusCode, fmt.Errorf("beem: summary failed with status %d: %s", resp.StatusCode, string(data))
 	}
 
-	var sr summaryResponse
-	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+	var boxes []boxSummary
+	if err := json.NewDecoder(resp.Body).Decode(&boxes); err != nil {
 		return PowerSample{}, resp.StatusCode, fmt.Errorf("beem: decode summary response: %w", err)
 	}
+	if len(boxes) == 0 {
+		return PowerSample{}, resp.StatusCode, fmt.Errorf("beem: summary response contained no boxes")
+	}
 
+	// Single-box household assumption: with more than one registered Beem
+	// box this would need to sum production across boxes, but nothing in
+	// this project's setup has more than one.
+	box := boxes[0]
 	sample := PowerSample{
-		SolarW:    sr.InstantPower,
-		DailyWh:   sr.DayEnergy,
-		MonthlyWh: sr.MonthEnergy,
+		SolarW:    box.WattHour,
+		DailyWh:   box.TotalDay,
+		MonthlyWh: box.TotalMonth,
 		Source:    "rest",
 		TS:        time.Now().UTC(),
 	}
 	c.log.V(1).Info("Beem summary fetched", "solar_w", sample.SolarW, "daily_wh", sample.DailyWh, "monthly_wh", sample.MonthlyWh)
 	return sample, resp.StatusCode, nil
+}
+
+// GetDevices fetches the account's device topology (Beem boxes, batteries,
+// energy switches) from the Beem API. On a 401 response it re-authenticates
+// and retries once, mirroring PollSummary.
+func (c *Client) GetDevices(ctx context.Context) (DevicesResponse, error) {
+	if err := c.refreshIfNeeded(ctx); err != nil {
+		return DevicesResponse{}, err
+	}
+
+	devices, status, err := c.fetchDevices(ctx)
+	if err == nil {
+		return devices, nil
+	}
+
+	if status == http.StatusUnauthorized {
+		c.log.Info("Received 401 from Beem API, re-authenticating")
+		if loginErr := c.login(ctx); loginErr != nil {
+			return DevicesResponse{}, loginErr
+		}
+		devices, _, err = c.fetchDevices(ctx)
+	}
+	return devices, err
+}
+
+// fetchDevices performs the actual GET /beemapp/devices request.
+// It returns the parsed topology, the HTTP status code, and any error.
+func (c *Client) fetchDevices(ctx context.Context) (DevicesResponse, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, devicesURL, nil)
+	if err != nil {
+		return DevicesResponse{}, 0, fmt.Errorf("beem: create devices request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return DevicesResponse{}, 0, fmt.Errorf("beem: devices request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return DevicesResponse{}, http.StatusUnauthorized, fmt.Errorf("beem: unauthorized")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		return DevicesResponse{}, resp.StatusCode, fmt.Errorf("beem: devices failed with status %d: %s", resp.StatusCode, string(data))
+	}
+
+	var dr DevicesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&dr); err != nil {
+		return DevicesResponse{}, resp.StatusCode, fmt.Errorf("beem: decode devices response: %w", err)
+	}
+
+	c.log.V(1).Info("Beem devices fetched", "beemboxes", len(dr.BeemBoxes), "batteries", len(dr.Batteries), "energy_switches", len(dr.EnergySwitches))
+	return dr, resp.StatusCode, nil
 }

--- a/pkg/beem/client_test.go
+++ b/pkg/beem/client_test.go
@@ -31,15 +31,16 @@ func loginOK(token string, expiresIn float64) http.HandlerFunc {
 	}
 }
 
-// summaryOK returns a valid summary handler.
+// summaryOK returns a valid summary handler serving the real API's shape: a
+// JSON array with one entry per registered Beem box.
 func summaryOK(solarW, dailyWh, monthlyWh float64) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(summaryResponse{
-			InstantPower: solarW,
-			DayEnergy:    dailyWh,
-			MonthEnergy:  monthlyWh,
-		})
+		json.NewEncoder(w).Encode([]boxSummary{{
+			WattHour:   solarW,
+			TotalDay:   dailyWh,
+			TotalMonth: monthlyWh,
+		}})
 	}
 }
 
@@ -112,11 +113,11 @@ func TestPollSummary_401TriggersRelogin(t *testing.T) {
 		}
 		// Second call (after re-login): return a valid response.
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(summaryResponse{
-			InstantPower: 500,
-			DayEnergy:    1000,
-			MonthEnergy:  5000,
-		})
+		json.NewEncoder(w).Encode([]boxSummary{{
+			WattHour:   500,
+			TotalDay:   1000,
+			TotalMonth: 5000,
+		}})
 	}
 
 	loginHandler := func(w http.ResponseWriter, r *http.Request) {
@@ -199,6 +200,109 @@ func TestTokenProactiveRefresh(t *testing.T) {
 	}
 }
 
+// TestPollSummary_EmptyBoxList verifies that an empty array response (no
+// registered Beem box) is treated as an error rather than a zero-valued sample.
+func TestPollSummary_EmptyBoxList(t *testing.T) {
+	emptyListHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, "[]")
+	}
+
+	srv := buildTestServer(t, loginOK("tok-empty", 3600), emptyListHandler)
+	defer srv.Close()
+
+	c := newClientForTest(ClientConfig{Email: "u@example.com", Password: "pw"}, srv)
+
+	origLogin, origSummary := loginURL, summaryURL
+	loginURL = srv.URL + "/beemapp/user/login"
+	summaryURL = srv.URL + "/beemapp/box/summary"
+	defer func() { loginURL = origLogin; summaryURL = origSummary }()
+
+	ctx := context.Background()
+	if _, err := c.PollSummary(ctx); err == nil {
+		t.Fatal("PollSummary returned nil error for an empty box list, want an error")
+	}
+}
+
+// TestFetchSummary_RequestShape verifies the client sends a POST with a
+// {month, year} JSON body, matching the real API (a plain GET returns 404).
+func TestFetchSummary_RequestShape(t *testing.T) {
+	var gotMethod string
+	var gotBody map[string]int
+
+	summaryHandler := func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]boxSummary{{WattHour: 1, TotalDay: 2, TotalMonth: 3}})
+	}
+
+	srv := buildTestServer(t, loginOK("tok-shape", 3600), summaryHandler)
+	defer srv.Close()
+
+	c := newClientForTest(ClientConfig{Email: "u@example.com", Password: "pw"}, srv)
+
+	origLogin, origSummary := loginURL, summaryURL
+	loginURL = srv.URL + "/beemapp/user/login"
+	summaryURL = srv.URL + "/beemapp/box/summary"
+	defer func() { loginURL = origLogin; summaryURL = origSummary }()
+
+	ctx := context.Background()
+	if _, err := c.PollSummary(ctx); err != nil {
+		t.Fatalf("PollSummary returned unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	now := time.Now()
+	if gotBody["month"] != int(now.Month()) || gotBody["year"] != now.Year() {
+		t.Errorf("body = %+v, want month=%d year=%d", gotBody, int(now.Month()), now.Year())
+	}
+}
+
+// realWorldSummaryBody is a redacted copy of an actual Beem API
+// POST /beemapp/box/summary response: a JSON array containing several
+// fields (serialNumber, lastAlive, name, power, weather, ...) that
+// boxSummary doesn't model. wattHour is 0 here because the capture was
+// taken at night (no solar production).
+const realWorldSummaryBody = `[{"boxId":45967,"serialNumber":"REDACTED","lastAlive":"2026-07-06T21:46:12.217Z","lastProduction":"2026-07-06T21:05:00.000Z","name":"Home","totalMonth":37555,"totalDay":6248,"wattHour":0,"year":2026,"month":7,"lastDbm":-51,"power":1000,"weather":null}]`
+
+// TestPollSummary_RealWorldSummaryPayload verifies that the client correctly
+// extracts solar_w/daily_wh/monthly_wh from the actual shape of a Beem API
+// summary response, ignoring the fields boxSummary doesn't model.
+func TestPollSummary_RealWorldSummaryPayload(t *testing.T) {
+	summaryHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, realWorldSummaryBody)
+	}
+
+	srv := buildTestServer(t, loginOK("tok-real-summary", 3600), summaryHandler)
+	defer srv.Close()
+
+	c := newClientForTest(ClientConfig{Email: "u@example.com", Password: "pw"}, srv)
+
+	origLogin, origSummary := loginURL, summaryURL
+	loginURL = srv.URL + "/beemapp/user/login"
+	summaryURL = srv.URL + "/beemapp/box/summary"
+	defer func() { loginURL = origLogin; summaryURL = origSummary }()
+
+	ctx := context.Background()
+	sample, err := c.PollSummary(ctx)
+	if err != nil {
+		t.Fatalf("PollSummary returned unexpected error: %v", err)
+	}
+	if sample.SolarW != 0 {
+		t.Errorf("SolarW = %v, want 0", sample.SolarW)
+	}
+	if sample.DailyWh != 6248 {
+		t.Errorf("DailyWh = %v, want 6248", sample.DailyWh)
+	}
+	if sample.MonthlyWh != 37555 {
+		t.Errorf("MonthlyWh = %v, want 37555", sample.MonthlyWh)
+	}
+}
+
 // realWorldLoginBody is a redacted copy of an actual Beem API login response:
 // HTTP 201 Created (not 200 OK), a raft of account fields the client doesn't
 // model, and no "expiresIn" field at all.
@@ -232,5 +336,194 @@ func TestLogin_201CreatedRealWorldPayload(t *testing.T) {
 	}
 	if c.token != "tok-real-world" {
 		t.Errorf("token = %q, want \"tok-real-world\"", c.token)
+	}
+}
+
+// buildDevicesTestServer wires up login + devices routes, mirroring
+// buildTestServer but for GetDevices instead of PollSummary.
+func buildDevicesTestServer(t *testing.T, loginFn, devicesFn http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/beemapp/user/login", loginFn)
+	mux.HandleFunc("/beemapp/devices", devicesFn)
+	return httptest.NewServer(mux)
+}
+
+// devicesOK returns a valid devices handler.
+func devicesOK(payload DevicesResponse) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(payload)
+	}
+}
+
+// patchDevicesURLs points loginURL/devicesURL at srv and returns a restore func.
+func patchDevicesURLs(srv *httptest.Server) func() {
+	origLogin, origDevices := loginURL, devicesURL
+	loginURL = srv.URL + "/beemapp/user/login"
+	devicesURL = srv.URL + "/beemapp/devices"
+	return func() { loginURL = origLogin; devicesURL = origDevices }
+}
+
+// TestGetDevices_HappyPath verifies that GetDevices parses a beembox with
+// solar equipment and no batteries/energy switches (this project's hardware:
+// PnP kit only, no Beem Battery).
+func TestGetDevices_HappyPath(t *testing.T) {
+	want := DevicesResponse{
+		BeemBoxes: []BeemBoxDevice{{
+			ID:           45967,
+			HouseID:      43122,
+			Name:         "Home",
+			SerialNumber: "REDACTED",
+			Power:        1000,
+			SolarEquipments: []SolarEquipment{{
+				ID:              68465,
+				Type:            "on",
+				BoxID:           45967,
+				Orientation:     0,
+				Tilt:            30,
+				PeakPower:       1000,
+				GuaranteeStatus: "activated",
+			}},
+		}},
+		Batteries:      []json.RawMessage{},
+		EnergySwitches: []json.RawMessage{},
+	}
+
+	srv := buildDevicesTestServer(t, loginOK("tok-devices", 3600), devicesOK(want))
+	defer srv.Close()
+
+	c := newClientForTest(ClientConfig{Email: "u@example.com", Password: "pw"}, srv)
+	defer patchDevicesURLs(srv)()
+
+	ctx := context.Background()
+	got, err := c.GetDevices(ctx)
+	if err != nil {
+		t.Fatalf("GetDevices returned unexpected error: %v", err)
+	}
+	if len(got.BeemBoxes) != 1 {
+		t.Fatalf("len(BeemBoxes) = %d, want 1", len(got.BeemBoxes))
+	}
+	if got.BeemBoxes[0].Name != "Home" {
+		t.Errorf("BeemBoxes[0].Name = %q, want \"Home\"", got.BeemBoxes[0].Name)
+	}
+	if len(got.BeemBoxes[0].SolarEquipments) != 1 {
+		t.Fatalf("len(SolarEquipments) = %d, want 1", len(got.BeemBoxes[0].SolarEquipments))
+	}
+	if got.BeemBoxes[0].SolarEquipments[0].PeakPower != 1000 {
+		t.Errorf("SolarEquipments[0].PeakPower = %v, want 1000", got.BeemBoxes[0].SolarEquipments[0].PeakPower)
+	}
+	if len(got.Batteries) != 0 {
+		t.Errorf("len(Batteries) = %d, want 0 (no Beem Battery hardware)", len(got.Batteries))
+	}
+	if len(got.EnergySwitches) != 0 {
+		t.Errorf("len(EnergySwitches) = %d, want 0 (no Beem Battery hardware)", len(got.EnergySwitches))
+	}
+}
+
+// TestGetDevices_401TriggersRelogin verifies that a 401 from the devices
+// endpoint causes the client to re-authenticate and retry, mirroring
+// TestPollSummary_401TriggersRelogin.
+func TestGetDevices_401TriggersRelogin(t *testing.T) {
+	loginCalls := 0
+	devicesCalls := 0
+
+	devicesHandler := func(w http.ResponseWriter, r *http.Request) {
+		devicesCalls++
+		if devicesCalls == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(DevicesResponse{
+			BeemBoxes:      []BeemBoxDevice{{ID: 1, Name: "Home"}},
+			Batteries:      []json.RawMessage{},
+			EnergySwitches: []json.RawMessage{},
+		})
+	}
+
+	loginHandler := func(w http.ResponseWriter, r *http.Request) {
+		loginCalls++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(loginResponse{AccessToken: "tok-refresh", ExpiresIn: 3600})
+	}
+
+	srv := buildDevicesTestServer(t, loginHandler, devicesHandler)
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{Email: "u@example.com", Password: "pw"})
+	c.http = *srv.Client()
+	defer patchDevicesURLs(srv)()
+
+	ctx := context.Background()
+	got, err := c.GetDevices(ctx)
+	if err != nil {
+		t.Fatalf("GetDevices returned unexpected error after re-login: %v", err)
+	}
+	if loginCalls != 2 {
+		t.Errorf("loginCalls = %d, want 2 (initial + retry after 401)", loginCalls)
+	}
+	if devicesCalls != 2 {
+		t.Errorf("devicesCalls = %d, want 2 (401 + retry)", devicesCalls)
+	}
+	if len(got.BeemBoxes) != 1 || got.BeemBoxes[0].Name != "Home" {
+		t.Errorf("BeemBoxes = %+v, want one box named \"Home\"", got.BeemBoxes)
+	}
+}
+
+// realWorldDevicesBody is a redacted copy of an actual Beem API
+// GET /beemapp/devices response for this project's hardware (PnP kit only):
+// one beembox with one solar equipment array, no batteries, no energy
+// switches.
+const realWorldDevicesBody = `{"beemboxes":[{"id":45967,"houseId":43122,"name":"Home","serialNumber":"REDACTED","power":1000,"createdAt":"2026-05-30T06:44:43.310Z","solarEquipments":[{"id":68465,"type":"on","boxId":45967,"orientation":0,"tilt":30,"peakPower":1000,"guaranteeStatus":"activated"}],"newUserNotifications":[]}],"batteries":[],"energySwitches":[]}`
+
+// TestGetDevices_RealWorldPayload verifies that GetDevices correctly parses
+// the actual shape of a Beem API devices response, including fields
+// (newUserNotifications) that DevicesResponse doesn't model.
+func TestGetDevices_RealWorldPayload(t *testing.T) {
+	devicesHandler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, realWorldDevicesBody)
+	}
+
+	srv := buildDevicesTestServer(t, loginOK("tok-real-devices", 3600), devicesHandler)
+	defer srv.Close()
+
+	c := newClientForTest(ClientConfig{Email: "u@example.com", Password: "pw"}, srv)
+	defer patchDevicesURLs(srv)()
+
+	ctx := context.Background()
+	got, err := c.GetDevices(ctx)
+	if err != nil {
+		t.Fatalf("GetDevices returned unexpected error: %v", err)
+	}
+	if len(got.BeemBoxes) != 1 {
+		t.Fatalf("len(BeemBoxes) = %d, want 1", len(got.BeemBoxes))
+	}
+	box := got.BeemBoxes[0]
+	if box.ID != 45967 {
+		t.Errorf("BeemBoxes[0].ID = %d, want 45967", box.ID)
+	}
+	if box.HouseID != 43122 {
+		t.Errorf("BeemBoxes[0].HouseID = %d, want 43122", box.HouseID)
+	}
+	if box.Power != 1000 {
+		t.Errorf("BeemBoxes[0].Power = %v, want 1000", box.Power)
+	}
+	wantCreatedAt := time.Date(2026, 5, 30, 6, 44, 43, 310000000, time.UTC)
+	if !box.CreatedAt.Equal(wantCreatedAt) {
+		t.Errorf("BeemBoxes[0].CreatedAt = %v, want %v", box.CreatedAt, wantCreatedAt)
+	}
+	if len(box.SolarEquipments) != 1 {
+		t.Fatalf("len(SolarEquipments) = %d, want 1", len(box.SolarEquipments))
+	}
+	if box.SolarEquipments[0].GuaranteeStatus != "activated" {
+		t.Errorf("SolarEquipments[0].GuaranteeStatus = %q, want \"activated\"", box.SolarEquipments[0].GuaranteeStatus)
+	}
+	if len(got.Batteries) != 0 {
+		t.Errorf("len(Batteries) = %d, want 0", len(got.Batteries))
+	}
+	if len(got.EnergySwitches) != 0 {
+		t.Errorf("len(EnergySwitches) = %d, want 0", len(got.EnergySwitches))
 	}
 }


### PR DESCRIPTION
## Summary

- `PollSummary` was calling `GET /beemapp/box/summary` with no body, which returns 404 against the real API. The endpoint is actually a `POST` with a `{month, year}` JSON body, returning a JSON array (one entry per registered Beem box) — not the flat object previously assumed. Confirmed against a live account and cross-checked with the `CharlesP44/Beem_Energy` Home Assistant integration source.
- Added `GetDevices()` (`GET /beemapp/devices`) for the account's device topology, and widened `boxSummary` to model every field seen on the wire.
- Battery/EnergySwitch/MQTT endpoints intentionally not ported — no Beem Battery hardware in this household to verify them against. Tracked in #327.
- Test fixtures capture the actual redacted request/response bodies from the live API, so this can be caught offline next time the API shifts.
- Also fixes `run-local-daemon` to source `.env` inside its own subshell — a plain `-include` in the Makefile would leave literal quote characters in credential values (verified empirically).

## Test plan

- [x] `go test ./pkg/beem/...` — 12/12 pass, including new `GetDevices` and real-world-payload fixture tests
- [x] `make test` — full workspace suite passes
- [x] Verified live: daemon built from this branch successfully polls Beem and publishes real production data (`daily_wh`, `monthly_wh`) instead of failing with 404<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(beem): correct box/summary endpoint method and response shape ([50f046f](https://github.com/asnowfix/home-automation/commit/50f046fc7ce6d0785b0f74510065c29946c1d141))
- Merge branch 'main' into worktree-fix-beem-summary-endpoint ([37bb3f6](https://github.com/asnowfix/home-automation/commit/37bb3f66c187c4aae193b0be6475e469fedd9817))
<!-- END-AUTO-GENERATED-COMMITS -->