### PR TITLE
fix(build): use fully-qualified import path for version ldflags

### DIFF
--- a/myhome/Makefile
+++ b/myhome/Makefile
@@ -3,10 +3,12 @@
 #cmd
 PWD ?= $(shell cd)
 
-GO_LDFLAGS += -X version.Program=$(notdir $(PWD))
-GO_LDFLAGS += -X version.Repo=$(shell git config --get remote.$(shell git remote).url)
-GO_LDFLAGS += -X version.Version=$(shell git describe --tags --exact-match 2>/dev/null || git describe --always)$(shell git diff-index --quiet HEAD -- || echo '-dirty')
-GO_LDFLAGS += -X version.Commit=$(shell git rev-parse HEAD)
+VERSION_PKG := github.com/asnowfix/home-automation/pkg/version
+
+GO_LDFLAGS += -X $(VERSION_PKG).Program=$(notdir $(PWD))
+GO_LDFLAGS += -X $(VERSION_PKG).Repo=$(shell git config --get remote.$(shell git remote).url)
+GO_LDFLAGS += -X $(VERSION_PKG).Version=$(shell git describe --tags --exact-match 2>/dev/null || git describe --always)$(shell git diff-index --quiet HEAD -- || echo '-dirty')
+GO_LDFLAGS += -X $(VERSION_PKG).Commit=$(shell git rev-parse HEAD)
 
 GOFLAGS = -ldflags="$(GO_LDFLAGS)"
 


### PR DESCRIPTION
## Summary
- \`myhome/Makefile\`'s \`GO_LDFLAGS\` used bare package names (\`-X version.Version=...\`) instead of the fully-qualified import path (\`github.com/asnowfix/home-automation/pkg/version.Version\`). Go's linker silently no-ops an \`-X\` flag that doesn't resolve to a real import path, so \`Version\`/\`Commit\`/\`Program\`/\`Repo\` were never actually set by \`make build\`/\`make run\`, or by CI's \`build-pr-deb\` job.
- \`pkg/version.GetVersion()\` then falls back to \`git describe\`, which happens to succeed in a dev checkout (masking the bug locally) but fails on any packaged install with no \`.git\` directory — surfacing as "unknown" version in the CLI and web UI.
- \`.goreleaser.yml\` already used the correct fully-qualified path, so official tagged releases were unaffected; this brings \`myhome/Makefile\` in line with it.

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] Copied the built binary to \`/tmp\` (outside any git checkout) and ran \`myhome version\` — correctly printed the embedded version instead of falling back/failing<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(build): use fully-qualified import path for version ldflags ([204f906](https://github.com/asnowfix/home-automation/commit/204f906e15a822ff1fb35151dce96dd34b82ce9d))
<!-- END-AUTO-GENERATED-COMMITS -->