### PR TITLE
backport(#333): fix ldflags version import path

### DIFF
--- a/myhome/Makefile
+++ b/myhome/Makefile
@@ -3,10 +3,12 @@
 #cmd
 PWD ?= $(shell cd)
 
-GO_LDFLAGS += -X version.Program=$(notdir $(PWD))
-GO_LDFLAGS += -X version.Repo=$(shell git config --get remote.$(shell git remote).url)
-GO_LDFLAGS += -X version.Version=$(shell git describe --tags --exact-match 2>/dev/null || git describe --always)$(shell git diff-index --quiet HEAD -- || echo '-dirty')
-GO_LDFLAGS += -X version.Commit=$(shell git rev-parse HEAD)
+VERSION_PKG := github.com/asnowfix/home-automation/pkg/version
+
+GO_LDFLAGS += -X $(VERSION_PKG).Program=$(notdir $(PWD))
+GO_LDFLAGS += -X $(VERSION_PKG).Repo=$(shell git config --get remote.$(shell git remote).url)
+GO_LDFLAGS += -X $(VERSION_PKG).Version=$(shell git describe --tags --exact-match 2>/dev/null || git describe --always)$(shell git diff-index --quiet HEAD -- || echo '-dirty')
+GO_LDFLAGS += -X $(VERSION_PKG).Commit=$(shell git rev-parse HEAD)
 
 GOFLAGS = -ldflags="$(GO_LDFLAGS)"
 


### PR DESCRIPTION
## Summary
Backport of #333 to \`v0.11.x\`.

- \`myhome/Makefile\`'s \`GO_LDFLAGS\` used bare package names (\`-X version.Version=...\`) instead of the fully-qualified import path. The linker silently no-ops an \`-X\` flag that doesn't resolve, so \`Version\`/\`Commit\`/\`Program\`/\`Repo\` were never set by \`make build\`/\`make run\` or CI's \`build-pr-deb\` job — only tagged goreleaser builds (which already used the correct path) were unaffected.
- Symptom: "unknown" version shown in the CLI/UI on any packaged install without a \`.git\` directory — reproduced on the NAS after installing PR #332's artifact.

## Test plan
- [x] \`make build\`
- [x] \`make test\`
- [x] Copied the built binary outside the repo and ran \`myhome version\` — correctly printed the embedded version<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(build): use fully-qualified import path for version ldflags ([3bbd565](https://github.com/asnowfix/home-automation/commit/3bbd5658643c2b684eab18831d02482d0d46fa0b))
<!-- END-AUTO-GENERATED-COMMITS -->