### PR TITLE
backport: pin SQLite connection pool to a single connection

### DIFF
--- a/myhome/events/storage.go
+++ b/myhome/events/storage.go
@@ -63,6 +63,12 @@ func NewStorage(log logr.Logger, dbPath string) (*Storage, error) {
 		log.Error(err, "Failed to connect to events database", "dbPath", dbPath)
 		return nil, err
 	}
+	// A pooled second connection to ":memory:" opens its own empty database
+	// (no shared-cache URI is used here), so reads on that connection would
+	// silently see none of the rows written on the first. Pin the pool to a
+	// single connection to keep all reads/writes on the same in-memory (or
+	// file) database; SQLite serializes writers anyway.
+	db.SetMaxOpenConns(1)
 
 	if _, err := db.Exec(`PRAGMA journal_mode=WAL`); err != nil {
 		db.Close()

--- a/myhome/storage/db.go
+++ b/myhome/storage/db.go
@@ -23,6 +23,12 @@ func NewDeviceStorage(log logr.Logger, dbName string) (*DeviceStorage, error) {
 		log.Error(err, "Failed to connect to database", "dbType", "sqlite", "dbName", dbName)
 		return nil, err
 	}
+	// A pooled second connection to ":memory:" opens its own empty database
+	// (no shared-cache URI is used here), so reads on that connection would
+	// silently see none of the rows written on the first. Pin the pool to a
+	// single connection to keep all reads/writes on the same in-memory (or
+	// file) database; SQLite serializes writers anyway.
+	db.SetMaxOpenConns(1)
 
 	// WAL mode gives better write throughput by allowing concurrent readers
 	// during a write. On in-memory databases the pragma is a no-op (SQLite


### PR DESCRIPTION
## Summary
Backport of #337 to \`v0.11.x\`.

Unblocks the stuck \`tag-patch\` workflow (https://github.com/asnowfix/home-automation/actions/runs/29189725329/job/86642176701), which fails \`make test\` on this branch because of an intermittent \`TestSendDigest\` failure in \`myhome/notice\`.

- Root cause: \`sqlx.Connect\`'s default connection pool can open more than one physical connection. For a \`:memory:\` DSN (used throughout the test suite), each new connection gets its own *empty* in-memory database — no shared-cache URI is used. A write on connection A is then invisible to a read on connection B, so \`SendDigest\`'s query could silently return zero rows despite the event having just been recorded.
- Fix: \`db.SetMaxOpenConns(1)\` in both \`myhome/events/storage.go\` and \`myhome/storage/db.go\`. SQLite serializes writers anyway, so this has no production cost.

## Test plan
- [x] \`go test ./myhome/notice/... ./myhome/events/... ./myhome/storage/... -count=1\` on this branch — all pass
- [x] Clean cherry-pick from #337, no conflicts
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(storage): pin SQLite connection pool to a single connection ([62d2195](https://github.com/asnowfix/home-automation/commit/62d21959814072f2591e2a8e9bc1efd1be21e507))
<!-- END-AUTO-GENERATED-COMMITS -->