### PR TITLE
Resolve device hosts on demand instead of caching IPs in the DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,14 @@ Ports: 6080 (dev web UI), 80 (systemd), 6060 (pprof), 9100 (Prometheus).
 
 ## Conventions
 
+### GitHub Issues
+
+A **self-contained issue** has full context and does not depend on any coding agent's or human's
+memory of a prior conversation or session — anyone (agent or human) can pick it up cold, with no
+other source of information than what the issue itself contains. It may, and should, reference
+external sources (docs URLs) and/or other issue(s) and/or PR(s), but must not assume the reader
+was present for the discussion that led to filing it.
+
 ### Go
 
 - **CLI output**: `fmt.Printf()` for user-facing messages; `hlog` for internal/debug logging. Never `log.Info()` in CLI commands.

--- a/docs/no-ip-address-plan.md
+++ b/docs/no-ip-address-plan.md
@@ -1,0 +1,205 @@
+# No IP addresses in the devices DB — implementation plan
+
+Status doc for an in-progress feature. Delete this file once all phases are checked off and
+merged. Update checkboxes as work lands so this can be resumed cold (fresh session / context
+loss) by reading this file plus `git log` / `git diff` on this branch.
+
+Branch/worktree: `feature+no-ip-address` (`.claude/worktrees/feature+no-ip-address`)
+
+Implements: #252. Concrete symptom that motivated it: PR #265 (garden sprinkler `arrosage`
+device) — device DHCP-renewed IP, daemon kept the stale cached IP, `shelly_list`/`shelly_call`
+timed out over HTTP while MQTT kept working fine.
+
+Deferred out of this issue, tracked separately: #336 (relaying HTTP through a NAT'ing gateway
+device — Shelly AP/RangeExtender, or the TP-Link Omada EAP 100 at `192.168.1.4`). This plan's
+`model.Router`/`model.Host` are scoped to **only ever return directly HTTP-dialable addresses**.
+
+## Design decisions (confirmed in conversation before implementation)
+
+1. MQTT stays the preferred channel (`Device.Channel()` priority unchanged). This work only
+   fixes the HTTP path so it degrades correctly instead of getting stuck on a stale IP forever.
+2. `internal/myhome/net/resolver.go`'s `Resolver.LookupHost` (DNS → mDNS `.local` fallback)
+   becomes a second `model.Router` implementation, alongside the existing SFR ARP-table-style one
+   (`internal/myhome/sfr/router.go`).
+3. **Sequential fallback chain**, not concurrent fan-out. The SFR router is backed by an
+   in-memory `sync.Map` refreshed by a background goroutine every minute — a lookup there is a
+   fast in-process read, not a live network call. mDNS is the only hop with real network latency.
+   Trying SFR first and only paying mDNS's cost on a miss is already near-optimal; concurrent
+   fan-out would add goroutine/cancellation complexity for no measurable win.
+4. Each `Router` implementation can be wrapped with a fallback: on a not-found result, try the
+   next `Router` in the chain. Terminates in a `NotFoundRouter` that always returns not-found —
+   this also lets call sites use a `Router` value unconditionally (no nil checks).
+5. **No periodic MAC→IP polling.** The current background loop in
+   `myhome/devices/impl/manager.go`'s `refreshOneDevice` (calls `router.GetHostByMac` once a
+   refresh cycle and rewrites `device.Host()`) is removed entirely. Resolution becomes purely
+   on-demand: lazily when a device has no known dialable IP, and once more on HTTP dial failure,
+   before falling back to MQTT.
+6. **No resolved IPs persisted to the devices DB.** The daemon stops writing live-resolved IPs
+   into the `host` DB column. Resolution is always live via the `Router` chain, keyed by MAC
+   (primary) and device ID (mDNS fallback — Shelly mDNS hostnames are `<device-id>.local`).
+7. `model.Router`'s doc comment states the direct-dialable-only invariant (point above, re #336).
+
+### Layering constraint (Three-Tier Layer Rule, see CLAUDE.md)
+
+`model.Router` lives in `internal/myhome/model` (MyHome-layer). `pkg/shelly` must not import
+`internal/myhome/*` packages directly. But the HTTP failure signal (and the "no known IP yet"
+signal) both originate deep inside `pkg/shelly/shttp/channel.go` / `pkg/shelly/device.go`, and
+that's exactly where a retry-after-re-resolution needs to happen to cover every caller uniformly.
+
+Resolved via dependency inversion, following the existing `sfr.StatusReporter` package-level
+injection pattern already used in this codebase:
+
+- `pkg/shelly/types`: new minimal interface `HostResolver` (one method: resolve MAC/name → IP).
+- `pkg/shelly`: package-level `var hostResolver types.HostResolver` + `SetHostResolver(r)`.
+- `internal/myhome` (daemon wiring) builds the real `Router` chain and calls
+  `shellyapi.SetHostResolver(...)` once at startup — the concrete `model.Router`-backed adapter
+  lives in `internal/myhome`, so `pkg/shelly` never imports it.
+
+## Progress
+
+### Phase 0 — Setup
+- [x] Worktree already exists, on branch `feature+no-ip-address`
+- [x] Follow-up issue #336 filed and cross-linked from #252
+- [x] `make generate` run successfully in this worktree
+
+### Phase 1 — `model.Router` chain infrastructure — DONE
+- [x] `internal/myhome/model/router.go`: added `ErrNotFound` sentinel + doc comment invariant
+      (direct-dialable-only, see #336)
+- [x] `internal/myhome/model/chain.go`: `Chain(primary, next Router) Router` — tries primary,
+      falls through to `next` on **any** error (not just `ErrNotFound`; simpler and still correct
+      since `NotFoundRouter` is always the terminal error)
+- [x] `NotFoundRouter` terminal implementation
+- [x] Unit tests (`chain_test.go`): primary-found, falls-through-on-error, terminates at
+      `NotFoundRouter` with `ErrNotFound`
+
+### Phase 2 — mDNS `model.Router` implementation — DONE
+- [x] `internal/myhome/mdnsrouter/router.go`, implementing `model.Router`: `GetHostByName`
+      resolves via an injected `mynet.Resolver` (constructor `New(resolver)`, not the package
+      singleton directly — matches the existing `DeviceManager.resolver` injection pattern, and
+      makes it testable with a fake); `GetHostByMac`/`GetHostByIp` return `ErrNotFound`
+- [x] Unit tests (`router_test.go`) with a fake `mynet.Resolver`
+
+### Phase 3 — `pkg/shelly` `HostResolver` seam — DONE
+- [x] `pkg/shelly/types`: `HostResolver` interface + package-level `SetHostResolver`/`ResolveHost`
+      (lives in `types`, not top-level `pkg/shelly`, so both `pkg/shelly` and the leaf
+      `pkg/shelly/shttp` module can reach it without an import cycle)
+- [x] `pkg/shelly.SetHostResolver` — thin forwarding alias for daemon-wiring ergonomics
+- [x] `types.Device.Channel(ctx, via)` — **signature change** (added `ctx`, needed so resolution
+      can happen before the channel-selection decision, not just after a dial failure; otherwise
+      a device with no known host would always fall to the discarded `ChannelDefault` caller
+      before ever reaching the HTTP dial code). Updated the 2 call sites
+      (`ops.go` `CallE`, `device.go` `Refresh`) and the 3 implementations (`Device`, `FakeDevice`,
+      test `fakeDevice`).
+  - `Device.Channel`: when neither MQTT nor HTTP is ready, tries `resolveHost(ctx)` (via the
+    injected resolver, keyed by MAC then device ID) before giving up to `ChannelDefault`. Skipped
+    entirely when MQTT is already ready (preserves MQTT-preferred priority, no wasted resolution).
+- [x] `pkg/shelly/shttp/channel.go` `callE`: on a dial failure, `ClearHost()`, ask the resolver
+      once, `UpdateHost()` + retry on success; falls back to clear+error (→ MQTT) as before if the
+      resolver is unset or the retry also fails
+- [x] **Bonus fix found via testing**: `getE`/`postE`'s IPv6-bracket detection was buggy —
+      `net.ParseIP` returns `nil` for a hostname or a `host:port` string, and `nil.To4() == nil`
+      is unconditionally true, so non-IP-literal hosts were always (incorrectly) wrapped in
+      `[...]` brackets. Replaced with a `formatHost` helper using `net.SplitHostPort`/
+      `net.JoinHostPort`.
+- [x] Unit tests: `device_test.go` (`Channel` resolves/doesn't-resolve/no-resolver cases),
+      `shttp/channel_test.go` (success path unaffected, retry-after-failure calls resolver
+      exactly once and updates/clears host correctly, no-resolver behavior preserved)
+- [x] `make test` green across the whole workspace
+
+### Phase 4 — Wire it up in the daemon — DONE
+- [x] `myhome/devices/impl/manager.go` `Start()`: builds `model.Chain(sfr.GetRouter(ctx),
+      model.Chain(mdnsrouter.New(dm.resolver), model.NotFoundRouter{}))` (or without SFR in
+      remote-proxy mode), stored in `dm.router`, and calls
+      `shelly.SetHostResolver(routerHostResolver{router: dm.router})`
+- [x] New `routerHostResolver` adapter (in `manager.go`) implements `types.HostResolver` by
+      trying `GetHostByMac` then `GetHostByName` on the chain — this is the internal/myhome-side
+      half of the dependency-inversion seam from Phase 3
+- [x] Removed the periodic MAC→IP polling block from `refreshOneDevice`; dropped its now-unused
+      `router model.Router` parameter (and the call site in `deviceUpdaterLoop`)
+- [x] `options.Flags.RemoteProxy` behavior preserved: SFR skipped in remote-proxy mode as before;
+      mDNS `Router` is always included (harmless — it just returns `ErrNotFound` quickly if
+      multicast can't reach the target network, no different from not having it)
+- [x] `internal/myhome/shelly/gen1` listener's separate one-off `router.GetHostByIp` usage
+      (MAC lookup from a Gen1 device's self-reported IP in its MQTT payload) is untouched — it's
+      a different, legitimate use of `model.Router`, not the periodic-polling antipattern
+- [x] `make build` + targeted `go test` green
+
+### Phase 5 — Stop persisting IPs to the DB — DONE
+- [x] `internal/myhome/device.go`: removed the 3 writes into `DeviceSummary.Host_` (persisted,
+      `db:"host"`) — `Refresh()`, `WithZeroConfEntry()` (which still uses the mDNS entry's IP
+      transiently, only as a lookup key into the SFR router to fill in MAC), and
+      `NewDeviceFromImpl()` (first-discovery path). Any existing DB value is now legacy/inert and
+      naturally ages out as devices get refreshed.
+- [x] Audited all flagged read call sites:
+  - `pkg/shelly/shelly.go:59` (`ShellyDevice.Ip()`) — **false positive**, wraps the live in-memory
+    `pkg/shelly.Device`, not the DB `DeviceSummary`; unaffected, no change needed.
+  - `internal/myhome/ui/template.go:138` — cosmetic-only fallback token (falls through to
+    Name/Id when Host is empty, which it usually was already); left as-is.
+  - `myhome/ctl/garden/setup.go`, `myhome/ctl/pool/{provider,setup}.go` — copy `Host_` into a
+    passthrough `*myhome.Device` that every caller discards in favor of the live `*shelly.Device`
+    obtained via `myhome.Foreach`/`GetShellyDevice` (keyed by device ID, goes through the
+    HostResolver seam); confirmed unused for connectivity, left as-is.
+  - `internal/myhome/proxy/reverse.go` `resolveToIPv4` — **real fix needed**: rewrote the
+    DB-lookup fallback to try `Host()`, then `Id()` (guaranteed to match the mDNS `<id>.local`
+    name), then `Name()`, instead of `Host()` then `Name()` then `Id()` — since `Host()` is now
+    always empty, `Id()` needs to be tried before `Name()` for mDNS resolution to reliably work.
+  - `myhome/ctl/open/main.go` — **real fix needed**: falls back to `<id>.local` when `Host()` is
+    empty, so `myhome ctl open <name>` still produces a URL a browser can resolve (via OS-level
+    mDNS/Bonjour) instead of `open http://` (empty host).
+- [x] New/updated unit tests: `internal/myhome/proxy/reverse_test.go` (ID-before-Name fallback
+      ordering, using a real in-memory `storage.DeviceStorage` + fake `mynet.Resolver`)
+- [x] `make build` + `make test` green
+
+### Phase 6 — Tests & verification — DONE
+- [x] `make test` green across the whole workspace
+- [x] The PR #265 stale-IP-self-heal scenario is covered deterministically by unit tests
+      (`pkg/shelly/shttp/channel_test.go` `TestCallE_RetriesOnceAfterReResolution`) rather than
+      reproduced against real hardware — deliberately not simulated live (would mean disrupting a
+      working device's actual connectivity on the production network for the sake of the test)
+- [x] Ran the built daemon locally (`go run ./myhome daemon run --instance local --mqtt-broker
+      tcp://192.168.1.2:1883`, ~45s bounded run) against the real home MQTT broker: SFR router and
+      mDNS resolver both start cleanly, no panics/errors from the new Router-chain/HostResolver
+      wiring, real devices discovered via mDNS and successfully called over HTTP (e.g.
+      `KVS.Get` against `192.168.1.37`, `192.168.1.36`) — confirms the happy path end-to-end
+      against production hardware
+
+## Out of scope (tracked elsewhere)
+
+- Relay-through-gateway for NAT'd devices (Shelly AP/RangeExtender, Omada EAP 100) — #336.
+- SNMP/direct ARP-table querying of arbitrary routers (only SFR's proprietary API is supported
+  today) — not requested, no other router hardware in scope currently.
+- Cover component support (roller shutters show no control in the UI) — #339. Discovered during
+  manual UI verification; unrelated to host/IP resolution, connectivity to those devices works.
+
+## Phase 7 — Live-testing follow-ups (post-implementation)
+
+- [x] **UI "open device web interface" button had disappeared for every device.** Root cause:
+      `internal/myhome/ui/htmx.go`'s device-card templates gated the button on `{{if .Host}}`,
+      which is now always empty (Phase 5). Fixed by adding `DeviceView.HasWebUI` (true unless the
+      device is BLU-only, which has no HTTP interface at all) and gating on that instead — the
+      link itself (`/devices/{{.LinkToken}}/`) already resolves live via `resolveToIPv4` (fixed in
+      Phase 5), so the button no longer needs a cached IP to know whether to render. Verified live:
+      clicking through to a device's web UI succeeded (HTML page + a WebSocket upgrade both
+      proxied correctly).
+- [x] **Migrate legacy cached IPs out of the DB.** `myhome/storage/db.go`'s `createTable()` gained
+      `migrateHostsToHostnames()`, run on every `NewDeviceStorage` open: any `host` value that
+      parses as a literal IP (i.e. left over from before this PR) is rewritten to `<id>.local`.
+      Idempotent, only touches rows with a literal-IP host, leaves everything else (empty, or
+      already a hostname) untouched.
+- [x] Added `pkg/shelly/types.ResolveHost` timing/outcome logging (mac, name, ip, err, elapsed) —
+      needed to diagnose a reported "refresh button loops forever" issue live.
+- [x] **Investigated a reported "refresh button loops forever" / then "1-2s per device" report.**
+      Root-caused: not the new resolution code (confirmed via the new logging: zero invocations
+      across the session — every tested device had MQTT ready, which is unconditionally preferred
+      over HTTP, unchanged from before this PR). The one concretely observed slow case (~28s) was
+      a pre-existing MQTT RPC timeout (`pkg/shelly/mqtt/channel.go`, 14s × 2 sequential calls) for
+      a device that didn't answer at that moment — reproduced fast (0.3-0.4s) on retry. The
+      settled 1-2s-per-device figure is consistent with two sequential MQTT round-trips plus the
+      SSE-driven UI update, not obviously a regression from this PR. No code change made for this;
+      flagged here in case it resurfaces with a specific reproducible device.
+
+## Follow-up issues filed during this work
+
+- #336 — relay support for devices NAT'ed behind a Shelly AP/RangeExtender or the TP-Link Omada
+  EAP 100 (deferred `model.Host.Via()` design)
+- #339 — Shelly Cover component support (roller shutters show no control in the UI)

--- a/internal/myhome/device.go
+++ b/internal/myhome/device.go
@@ -130,11 +130,14 @@ func (d *Device) WithName(name string) *Device {
 	return d
 }
 
+// NewDeviceFromImpl builds a Device from a freshly discovered
+// devices.Device. Host is deliberately not copied — see WithZeroConfEntry's
+// doc comment; device's IP already lives in-memory on the wrapped impl for
+// this run, and is never persisted to the devices DB.
 func NewDeviceFromImpl(ctx context.Context, log logr.Logger, device devices.Device) (*Device, error) {
 	d := NewDevice(log, SHELLY, device.Id())
 	d = d.WithImpl(device)
 	d = d.WithMAC(device.Mac())
-	d = d.WithHost(device.Host())
 	d = d.WithName(device.Name())
 
 	return d, nil
@@ -181,9 +184,12 @@ func (d *Device) Refresh(ctx context.Context) (bool, error) {
 		}
 
 		// Always copy config and info to myhome device, even if not modified
-		// This ensures they're available for saving to database
+		// This ensures they're available for saving to database.
+		// Host is deliberately NOT copied here: it is a live-resolved,
+		// in-memory-only value on sd (see pkg/shelly's types.HostResolver
+		// seam) and must not be persisted to the devices DB — see #252 /
+		// docs/no-ip-address-plan.md.
 		d.WithId(sd.Id())
-		d.WithHost(sd.Host())
 		d.WithName(sd.Name())
 		d.WithMAC(sd.Mac())
 		d.ConfigRevision = sd.ConfigRevision()
@@ -202,24 +208,29 @@ func (d *Device) Refresh(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+// WithZeroConfEntry updates d's name and MAC from a freshly browsed mDNS
+// entry. It deliberately does NOT write entry's IP into d.Host_: that field
+// is persisted to the devices DB, which must not cache resolved IPs — see
+// #252 / docs/no-ip-address-plan.md. The entry's IP is only used transiently
+// here, as a lookup key into the SFR router to discover the device's MAC.
 func (d *Device) WithZeroConfEntry(ctx context.Context, entry *zeroconf.ServiceEntry) *Device {
 	d.log.Info("Updating device", "id", d.Id, "zeroconf entry", entry)
 
+	var ip net.IP
 	if len(entry.AddrIPv4) > 0 {
-		d.WithHost(entry.AddrIPv4[0].String())
+		ip = entry.AddrIPv4[0]
 	} else if len(entry.AddrIPv6) > 0 {
-		d.WithHost(entry.AddrIPv6[0].String())
+		ip = entry.AddrIPv6[0]
 	}
 
 	if entry.Instance != "" && entry.Instance != d.Id() {
 		d.WithName(entry.Instance)
 	}
 
-	ip := net.ParseIP(d.Host())
 	if ip != nil {
 		host, err := sfr.GetRouter(ctx).GetHostByIp(ctx, ip)
 		if err != nil {
-			d.log.Error(err, "Failed to get host by IP", "ip", d.Host())
+			d.log.Error(err, "Failed to get host by IP", "ip", ip.String())
 			return d
 		}
 		d.WithMAC(host.Mac())

--- a/internal/myhome/mdnsrouter/router.go
+++ b/internal/myhome/mdnsrouter/router.go
@@ -1,0 +1,67 @@
+// Package mdnsrouter implements model.Router by resolving a device's mDNS
+// (.local) hostname to its current IP. It has no reverse mapping from MAC or
+// IP back to a name, so it is meant to be chained after a Router that does
+// (e.g. internal/myhome/sfr), via model.Chain.
+package mdnsrouter
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/asnowfix/home-automation/internal/myhome/model"
+	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
+
+	"github.com/go-logr/logr"
+)
+
+// Router resolves hosts by name via DNS/mDNS (see mynet.Resolver.LookupHost).
+type Router struct {
+	resolver mynet.Resolver
+}
+
+// New returns a Router backed by the given resolver (typically mynet.MyResolver(log)).
+func New(resolver mynet.Resolver) Router {
+	return Router{resolver: resolver}
+}
+
+func (Router) GetHostByMac(ctx context.Context, mac net.HardwareAddr) (model.Host, error) {
+	return nil, model.ErrNotFound
+}
+
+func (Router) GetHostByIp(ctx context.Context, ip net.IP) (model.Host, error) {
+	return nil, model.ErrNotFound
+}
+
+// GetHostByName resolves name (typically a Shelly device ID, e.g.
+// "shellyplus1-a4cf12abcdef") via mynet.Resolver.LookupHost, which tries
+// standard DNS first and falls back to mDNS at "<name>.local".
+func (r Router) GetHostByName(ctx context.Context, name string) (model.Host, error) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		log = logr.Discard()
+	}
+
+	ips, err := r.resolver.LookupHost(ctx, log, name)
+	if err != nil {
+		return nil, fmt.Errorf("mDNS lookup of %q failed: %w", name, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("mDNS lookup of %q returned no addresses: %w", name, model.ErrNotFound)
+	}
+
+	return &host{name: name, ip: ips[0]}, nil
+}
+
+// host is a minimal model.Host backed only by what mDNS resolution can tell
+// us: a name and an IP. Mac is unknown to this Router (see GetHostByMac).
+type host struct {
+	name string
+	ip   net.IP
+}
+
+func (h *host) Mac() net.HardwareAddr { return nil }
+func (h *host) Name() string          { return h.name }
+func (h *host) Ip() net.IP            { return h.ip }
+func (h *host) IsOnline() bool        { return true }
+func (h *host) String() string        { return fmt.Sprintf("%s (%s)", h.name, h.ip) }

--- a/internal/myhome/mdnsrouter/router_test.go
+++ b/internal/myhome/mdnsrouter/router_test.go
@@ -1,0 +1,87 @@
+package mdnsrouter
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/asnowfix/home-automation/internal/myhome/model"
+	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
+
+	"github.com/go-logr/logr"
+	"github.com/grandcat/zeroconf"
+)
+
+// fakeResolver implements mynet.Resolver with a canned LookupHost result;
+// the other methods are unused by mdnsrouter and just satisfy the interface.
+type fakeResolver struct {
+	ips []net.IP
+	err error
+}
+
+func (f *fakeResolver) WithLocalName(ctx context.Context, hostname string) mynet.Resolver { return f }
+func (f *fakeResolver) LookupHost(ctx context.Context, log logr.Logger, host string) ([]net.IP, error) {
+	return f.ips, f.err
+}
+func (f *fakeResolver) LookupService(ctx context.Context, service string) (*url.URL, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeResolver) BrowseService(ctx context.Context, service, domain string, entries chan<- *zeroconf.ServiceEntry) error {
+	return errors.New("not implemented")
+}
+func (f *fakeResolver) PublishService(ctx context.Context, instance, service, domain string, port int, txt []string, ifaces []net.Interface) (*zeroconf.Server, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestGetHostByName_Found(t *testing.T) {
+	r := New(&fakeResolver{ips: []net.IP{net.ParseIP("192.168.1.42")}})
+
+	host, err := r.GetHostByName(context.Background(), "shellyplus1-a4cf12abcdef")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if host.Ip().String() != "192.168.1.42" {
+		t.Errorf("got IP %v, want 192.168.1.42", host.Ip())
+	}
+	if host.Name() != "shellyplus1-a4cf12abcdef" {
+		t.Errorf("got name %q", host.Name())
+	}
+}
+
+func TestGetHostByName_LookupError(t *testing.T) {
+	r := New(&fakeResolver{err: errors.New("no such host")})
+
+	_, err := r.GetHostByName(context.Background(), "ghost")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestGetHostByName_NoAddresses(t *testing.T) {
+	r := New(&fakeResolver{ips: nil})
+
+	_, err := r.GetHostByName(context.Background(), "ghost")
+	if !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetHostByMac_Unsupported(t *testing.T) {
+	r := New(&fakeResolver{})
+
+	_, err := r.GetHostByMac(context.Background(), net.HardwareAddr{})
+	if !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestGetHostByIp_Unsupported(t *testing.T) {
+	r := New(&fakeResolver{})
+
+	_, err := r.GetHostByIp(context.Background(), net.IP{})
+	if !errors.Is(err, model.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/myhome/model/chain.go
+++ b/internal/myhome/model/chain.go
@@ -1,0 +1,60 @@
+package model
+
+import (
+	"context"
+	"net"
+)
+
+// chainRouter tries primary first; on any error it falls through to next.
+type chainRouter struct {
+	primary Router
+	next    Router
+}
+
+// Chain returns a Router that tries primary first and falls through to next
+// on error. Build a priority-ordered lookup stack by nesting calls, e.g.
+// Chain(sfrRouter, Chain(mdnsRouter, NotFoundRouter{})).
+func Chain(primary, next Router) Router {
+	return &chainRouter{primary: primary, next: next}
+}
+
+func (r *chainRouter) GetHostByMac(ctx context.Context, mac net.HardwareAddr) (Host, error) {
+	host, err := r.primary.GetHostByMac(ctx, mac)
+	if err == nil {
+		return host, nil
+	}
+	return r.next.GetHostByMac(ctx, mac)
+}
+
+func (r *chainRouter) GetHostByIp(ctx context.Context, ip net.IP) (Host, error) {
+	host, err := r.primary.GetHostByIp(ctx, ip)
+	if err == nil {
+		return host, nil
+	}
+	return r.next.GetHostByIp(ctx, ip)
+}
+
+func (r *chainRouter) GetHostByName(ctx context.Context, name string) (Host, error) {
+	host, err := r.primary.GetHostByName(ctx, name)
+	if err == nil {
+		return host, nil
+	}
+	return r.next.GetHostByName(ctx, name)
+}
+
+// NotFoundRouter is a terminal Router that never has a record for anything.
+// Put it at the bottom of a Chain so callers can always treat a Router value
+// as non-nil and get a uniform ErrNotFound once every real source has missed.
+type NotFoundRouter struct{}
+
+func (NotFoundRouter) GetHostByMac(ctx context.Context, mac net.HardwareAddr) (Host, error) {
+	return nil, ErrNotFound
+}
+
+func (NotFoundRouter) GetHostByIp(ctx context.Context, ip net.IP) (Host, error) {
+	return nil, ErrNotFound
+}
+
+func (NotFoundRouter) GetHostByName(ctx context.Context, name string) (Host, error) {
+	return nil, ErrNotFound
+}

--- a/internal/myhome/model/chain_test.go
+++ b/internal/myhome/model/chain_test.go
@@ -1,0 +1,97 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+// fakeHost implements Host for use in tests.
+type fakeHost struct {
+	mac  net.HardwareAddr
+	ip   net.IP
+	name string
+}
+
+func (h *fakeHost) Mac() net.HardwareAddr { return h.mac }
+func (h *fakeHost) Ip() net.IP            { return h.ip }
+func (h *fakeHost) Name() string          { return h.name }
+func (h *fakeHost) IsOnline() bool        { return true }
+func (h *fakeHost) String() string        { return h.name }
+
+// stubRouter returns host/err regardless of the key asked for.
+type stubRouter struct {
+	host Host
+	err  error
+}
+
+func (s stubRouter) GetHostByMac(ctx context.Context, mac net.HardwareAddr) (Host, error) {
+	return s.host, s.err
+}
+
+func (s stubRouter) GetHostByIp(ctx context.Context, ip net.IP) (Host, error) {
+	return s.host, s.err
+}
+
+func (s stubRouter) GetHostByName(ctx context.Context, name string) (Host, error) {
+	return s.host, s.err
+}
+
+func TestChain_PrimaryFound(t *testing.T) {
+	want := &fakeHost{name: "primary-host"}
+	primary := stubRouter{host: want}
+	next := stubRouter{err: errors.New("should not be called")}
+
+	r := Chain(primary, next)
+
+	got, err := r.GetHostByName(context.Background(), "anything")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestChain_FallsThroughOnError(t *testing.T) {
+	want := &fakeHost{name: "fallback-host"}
+	primary := stubRouter{err: ErrNotFound}
+	next := stubRouter{host: want}
+
+	r := Chain(primary, next)
+
+	got, err := r.GetHostByMac(context.Background(), net.HardwareAddr{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestChain_AllMissTerminatesAtNotFoundRouter(t *testing.T) {
+	primary := stubRouter{err: ErrNotFound}
+	middle := stubRouter{err: ErrNotFound}
+
+	r := Chain(primary, Chain(middle, NotFoundRouter{}))
+
+	_, err := r.GetHostByIp(context.Background(), net.ParseIP("10.0.0.1"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestNotFoundRouter_AlwaysErrNotFound(t *testing.T) {
+	var r Router = NotFoundRouter{}
+
+	if _, err := r.GetHostByMac(context.Background(), net.HardwareAddr{}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetHostByMac: expected ErrNotFound, got %v", err)
+	}
+	if _, err := r.GetHostByIp(context.Background(), net.IP{}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetHostByIp: expected ErrNotFound, got %v", err)
+	}
+	if _, err := r.GetHostByName(context.Background(), "x"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetHostByName: expected ErrNotFound, got %v", err)
+	}
+}

--- a/internal/myhome/model/router.go
+++ b/internal/myhome/model/router.go
@@ -2,8 +2,14 @@ package model
 
 import (
 	"context"
+	"errors"
 	"net"
 )
+
+// ErrNotFound is returned (or wrapped) by a Router implementation when it has
+// no record for the requested MAC/IP/name. Chain callers use it to decide
+// whether to fall through to the next Router; see Chain and NotFoundRouter.
+var ErrNotFound = errors.New("host not found")
 
 // Host represents a device on the network with IP and MAC address
 type Host interface {
@@ -14,7 +20,14 @@ type Host interface {
 	String() string
 }
 
-// Router provides access to network device information
+// Router provides access to network device information.
+//
+// Implementations MUST only ever resolve to an address that is directly
+// HTTP-dialable from this process (i.e. a plain routable IP on the local
+// network). A device that is only reachable by relaying a call through
+// another gateway device (e.g. a Shelly acting as a NAT'ing Wi-Fi access
+// point, or a router like the TP-Link Omada EAP 100) is out of scope for
+// this interface — see https://github.com/asnowfix/home-automation/issues/336.
 type Router interface {
 	GetHostByMac(ctx context.Context, mac net.HardwareAddr) (Host, error)
 	GetHostByIp(ctx context.Context, ip net.IP) (Host, error)

--- a/internal/myhome/proxy/reverse.go
+++ b/internal/myhome/proxy/reverse.go
@@ -381,28 +381,26 @@ func resolveToIPv4(ctx context.Context, log logr.Logger, resolver mynet.Resolver
 		}
 	}
 
-	// 3. Try myhome database lookup
+	// 3. Try myhome database lookup. device.Host is no longer persisted
+	// (see #252 / docs/no-ip-address-plan.md), so this normally falls
+	// through to resolving by device ID — which is guaranteed to match the
+	// device's mDNS "<id>.local" name — then Name as a last resort.
 	if db != nil {
 		if d, err := db.GetDeviceByAny(ctx, token); err == nil {
-			// Prefer device.Host when present
-			host := d.Host()
-			if host == "" {
-				// Fallbacks
-				host = d.Name()
-				if host == "" {
-					host = d.Id()
+			for _, candidate := range []string{d.Host(), d.Id(), d.Name()} {
+				if candidate == "" {
+					continue
 				}
-			}
-			if net.ParseIP(host) != nil {
-				ip := net.ParseIP(host)
-				if v4 := ip.To4(); v4 != nil {
-					return v4, nil
+				if ip := net.ParseIP(candidate); ip != nil {
+					if v4 := ip.To4(); v4 != nil {
+						return v4, nil
+					}
+					continue
 				}
-			} else if resolver != nil {
-				q := host
-				if strings.HasSuffix(strings.ToLower(q), ".local") {
-					q = strings.TrimSuffix(q, ".local")
+				if resolver == nil {
+					continue
 				}
+				q := strings.TrimSuffix(strings.ToLower(candidate), ".local")
 				if ips, err := resolver.LookupHost(ctx, log, q); err == nil {
 					if ip := pickV4(ips); ip != nil {
 						return ip, nil

--- a/internal/myhome/proxy/reverse_test.go
+++ b/internal/myhome/proxy/reverse_test.go
@@ -2,14 +2,108 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/asnowfix/home-automation/internal/myhome"
+	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
+	"github.com/asnowfix/home-automation/myhome/storage"
+
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
+	"github.com/grandcat/zeroconf"
 )
+
+// fakeResolver implements mynet.Resolver, returning a canned LookupHost
+// result keyed by the queried host. Other methods are unused by
+// resolveToIPv4 and just satisfy the interface.
+type fakeResolver struct {
+	byHost map[string][]net.IP
+}
+
+func (f *fakeResolver) WithLocalName(ctx context.Context, hostname string) mynet.Resolver { return f }
+func (f *fakeResolver) LookupHost(ctx context.Context, log logr.Logger, host string) ([]net.IP, error) {
+	if ips, ok := f.byHost[host]; ok {
+		return ips, nil
+	}
+	return nil, fmt.Errorf("no such host: %s", host)
+}
+func (f *fakeResolver) LookupService(ctx context.Context, service string) (*url.URL, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (f *fakeResolver) BrowseService(ctx context.Context, service, domain string, entries chan<- *zeroconf.ServiceEntry) error {
+	return fmt.Errorf("not implemented")
+}
+func (f *fakeResolver) PublishService(ctx context.Context, instance, service, domain string, port int, txt []string, ifaces []net.Interface) (*zeroconf.Server, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// newTestStorage returns an in-memory DeviceStorage seeded with one device
+// whose Host is empty (as devices are stored post-#252: no cached IPs).
+func newTestStorage(t *testing.T, log logr.Logger, id, name string) *storage.DeviceStorage {
+	t.Helper()
+	s, err := storage.NewDeviceStorage(log, ":memory:")
+	if err != nil {
+		t.Fatalf("failed to create test storage: %v", err)
+	}
+	t.Cleanup(s.Close)
+
+	dev := &myhome.Device{
+		DeviceSummary: myhome.DeviceSummary{
+			DeviceIdentifier: myhome.DeviceIdentifier{Manufacturer_: "shelly", Id_: id},
+			Name_:            name,
+		},
+	}
+	if _, err := s.SetDevice(context.Background(), dev, true); err != nil {
+		t.Fatalf("failed to seed test device: %v", err)
+	}
+	return s
+}
+
+// TestResolveToIPv4_FallsBackToDeviceIdThenName verifies that with an empty
+// (post-#252) device.Host, resolution tries the device ID first (the form
+// that matches its mDNS "<id>.local" name), and falls back to Name only if
+// ID resolution fails.
+func TestResolveToIPv4_FallsBackToDeviceIdThenName(t *testing.T) {
+	ctx := context.Background()
+	log := testr.New(t)
+
+	s := newTestStorage(t, log, "shellyplus1pm-aabbccddeeff", "pump")
+	resolver := &fakeResolver{byHost: map[string][]net.IP{
+		"shellyplus1pm-aabbccddeeff": {net.ParseIP("192.168.1.77")},
+	}}
+
+	ip, err := resolveToIPv4(ctx, log, resolver, s, "pump")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ip.Equal(net.ParseIP("192.168.1.77")) {
+		t.Errorf("got %v, want 192.168.1.77", ip)
+	}
+}
+
+func TestResolveToIPv4_FallsBackToNameWhenIdUnresolvable(t *testing.T) {
+	ctx := context.Background()
+	log := testr.New(t)
+
+	s := newTestStorage(t, log, "shellyplus1pm-aabbccddeeff", "pump")
+	resolver := &fakeResolver{byHost: map[string][]net.IP{
+		"pump": {net.ParseIP("192.168.1.88")},
+	}}
+
+	ip, err := resolveToIPv4(ctx, log, resolver, s, "pump")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ip.Equal(net.ParseIP("192.168.1.88")) {
+		t.Errorf("got %v, want 192.168.1.88", ip)
+	}
+}
 
 // TestResolveToIPv4_RawIP verifies that a plain IPv4 string is returned as-is.
 func TestResolveToIPv4_RawIP(t *testing.T) {

--- a/internal/myhome/ui/htmx.go
+++ b/internal/myhome/ui/htmx.go
@@ -554,7 +554,7 @@ const deviceCardsTemplate = `
       </p>
       <p class="subtitle is-7 has-text-grey">{{.Manufacturer}} · {{.Id}}</p>
       <div class="buttons mt-3">
-        {{if .Host}}
+        {{if .HasWebUI}}
           <a class="button is-link is-small" href="/devices/{{.LinkToken}}/" target="_blank" rel="noopener noreferrer" title="Open device web interface">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="10"></circle>
@@ -673,7 +673,7 @@ const deviceCardTemplate = `
       </p>
       <p class="subtitle is-7 has-text-grey">{{.Manufacturer}} · {{.Id}}</p>
       <div class="buttons mt-3">
-        {{if .Host}}
+        {{if .HasWebUI}}
           <a class="button is-link is-small" href="/devices/{{.LinkToken}}/" target="_blank" rel="noopener noreferrer" title="Open device web interface">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="10"></circle>

--- a/internal/myhome/ui/htmx_pool_test.go
+++ b/internal/myhome/ui/htmx_pool_test.go
@@ -78,3 +78,30 @@ func TestDeviceCardTemplate_PoolTags(t *testing.T) {
 		t.Errorf("non-pool device card unexpectedly rendered pool tags:\n%s", out)
 	}
 }
+
+// TestDeviceCardTemplate_WebUILink verifies the "open device web interface"
+// button is gated on HasWebUI, not on a cached Host value — Host is no
+// longer persisted (see #252/#336), and the link target (LinkToken) is
+// resolved live when clicked (see internal/myhome/proxy.resolveToIPv4), so
+// the button should still appear even when Host is empty.
+func TestDeviceCardTemplate_WebUILink(t *testing.T) {
+	tmpl := template.Must(template.New("device-card").Funcs(cardTemplateFuncs()).Parse(deviceCardTemplate))
+
+	var buf bytes.Buffer
+	withUI := DeviceView{Id: "shellyplus1-abc", Name: "Switch", LinkToken: "shellyplus1-abc", HasWebUI: true}
+	if err := tmpl.Execute(&buf, withUI); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if out := buf.String(); !strings.Contains(out, `href="/devices/shellyplus1-abc/"`) {
+		t.Errorf("expected web UI link for HasWebUI device, got:\n%s", out)
+	}
+
+	buf.Reset()
+	withoutUI := DeviceView{Id: "shellyblu-abc", Name: "Sensor", LinkToken: "shellyblu-abc", HasWebUI: false}
+	if err := tmpl.Execute(&buf, withoutUI); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if out := buf.String(); strings.Contains(out, "Open device web interface") {
+		t.Errorf("expected no web UI link for a BLU (HasWebUI=false) device, got:\n%s", out)
+	}
+}

--- a/internal/myhome/ui/template.go
+++ b/internal/myhome/ui/template.go
@@ -46,6 +46,7 @@ type DeviceView struct {
 	Manufacturer         string                          `json:"manufacturer"`
 	Host                 string                          `json:"host"`
 	LinkToken            string                          `json:"link_token"`
+	HasWebUI             bool                            `json:"has_web_ui"` // true if the device exposes an HTTP web UI at all (excludes BLU); reachability itself is resolved live when the link is opened, see internal/myhome/proxy
 	IsRefreshable        bool                            `json:"is_refreshable"`
 	HasHeaterScript      bool                            `json:"has_heater_script"`
 	HasDoorSensor        bool                            `json:"has_door_sensor"`        // true if device has door/window sensing capability
@@ -218,6 +219,13 @@ func DeviceToView(ctx context.Context, d *myhome.Device) DeviceView {
 	// Check if device is refreshable
 	isRefreshable := !shelly.IsBluDevice(d.Id()) && !shelly.IsGen1Device(d.Id())
 
+	// BLU devices are BLE-only sensors with no HTTP/web interface at all.
+	// Everything else has one, whether or not we currently have a cached
+	// dialable address for it — Host is no longer persisted (see #252), and
+	// the /devices/{token}/ proxy route resolves the device live (via MAC,
+	// then mDNS on its device ID) at click time instead.
+	hasWebUI := !shelly.IsBluDevice(d.Id())
+
 	// Get switch information
 	switches := make(map[int]pkgshelly.SwitchSummary)
 
@@ -311,6 +319,7 @@ func DeviceToView(ctx context.Context, d *myhome.Device) DeviceView {
 		Manufacturer:         d.Manufacturer(),
 		Host:                 host,
 		LinkToken:            token,
+		HasWebUI:             hasWebUI,
 		IsRefreshable:        isRefreshable,
 		HasHeaterScript:      hasHeater,
 		HasDoorSensor:        hasDoor,

--- a/myhome/ctl/open/main.go
+++ b/myhome/ctl/open/main.go
@@ -40,7 +40,13 @@ var Cmd = &cobra.Command{
 		}
 		fmt.Println(string(s))
 
-		sh := fmt.Sprintf("open http://%s", device.Host())
+		// device.Host is no longer persisted (see #252); fall back to the
+		// device's mDNS ".local" name and let the OS/browser resolve it.
+		host := device.Host()
+		if host == "" {
+			host = device.Id() + ".local"
+		}
+		sh := fmt.Sprintf("open http://%s", host)
 		log.Info("Executing command", "command", sh)
 		return exec.Command("sh", "-c", sh).Run()
 	},

--- a/myhome/devices/impl/manager.go
+++ b/myhome/devices/impl/manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/internal/myhome/mdnsrouter"
 	"github.com/asnowfix/home-automation/internal/myhome/model"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
 	"github.com/asnowfix/home-automation/internal/myhome/sfr"
@@ -353,11 +354,17 @@ func (dm *DeviceManager) Start(ctx context.Context) error {
 
 	dm.log.Info("Starting device manager")
 
+	// Build the host-resolution chain: SFR (fast, in-memory ARP-like lookup)
+	// first when available, then mDNS (.local, real network cost), then a
+	// terminal not-found. See docs/no-ip-address-plan.md.
+	mdnsRouter := mdnsrouter.New(dm.resolver)
 	if options.Flags.RemoteProxy == "" {
-		dm.router = sfr.GetRouter(ctx)
+		dm.router = model.Chain(sfr.GetRouter(ctx), model.Chain(mdnsRouter, model.NotFoundRouter{}))
 	} else {
 		dm.log.Info("Remote proxy configured — skipping SFR router (no direct LAN access assumed)")
+		dm.router = model.Chain(mdnsRouter, model.NotFoundRouter{})
 	}
+	shelly.SetHostResolver(routerHostResolver{router: dm.router})
 
 	// Pre-populate cache with existing devices from database
 	// This ensures devices exist when retained MQTT sensor messages arrive
@@ -473,7 +480,7 @@ func (dm *DeviceManager) deviceUpdaterLoop(ctx context.Context) {
 					dm.triggerAutoSetup(ctx, log, d, devId)
 				}
 
-				refreshOneDevice(logr.NewContext(tools.WithToken(ctx), log.WithName("refreshOneDevice").WithName(d.Name())), d, dm.router, dm.refreshed)
+				refreshOneDevice(logr.NewContext(tools.WithToken(ctx), log.WithName("refreshOneDevice").WithName(d.Name())), d, dm.refreshed)
 			}(device, isNewDevice, deviceId)
 		}
 	}
@@ -547,7 +554,28 @@ func (dm *DeviceManager) triggerAutoSetup(ctx context.Context, log logr.Logger, 
 	}()
 }
 
-func refreshOneDevice(ctx context.Context, device *myhome.Device, router model.Router, refreshed chan<- *myhome.Device) {
+// routerHostResolver adapts a model.Router to pkg/shelly/types.HostResolver,
+// letting pkg/shelly re-resolve a device's IP without depending on the
+// internal/myhome package (see the Three-Tier Layer Rule in CLAUDE.md).
+type routerHostResolver struct {
+	router model.Router
+}
+
+func (r routerHostResolver) ResolveHost(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error) {
+	if len(mac) > 0 {
+		if host, err := r.router.GetHostByMac(ctx, mac); err == nil {
+			return host.Ip(), nil
+		}
+	}
+	if name != "" {
+		if host, err := r.router.GetHostByName(ctx, name); err == nil {
+			return host.Ip(), nil
+		}
+	}
+	return nil, model.ErrNotFound
+}
+
+func refreshOneDevice(ctx context.Context, device *myhome.Device, refreshed chan<- *myhome.Device) {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
 		panic("BUG: No logger initialized")
@@ -565,32 +593,14 @@ func refreshOneDevice(ctx context.Context, device *myhome.Device, router model.R
 		return
 	}
 
-	var modified bool = false
-	if router != nil {
-		mac, err := net.ParseMAC(device.MAC)
-		host, err := router.GetHostByMac(ctx, mac)
-		if err == nil {
-			ip := host.Ip().String()
-			if ip != device.Host() {
-				log.V(1).Info("Changing IP", "device", device.DeviceSummary, "old_ip", device.Host(), "new_ip", ip)
-				device = device.WithHost(ip)
-				modified = true
-			}
-		} else {
-			log.Error(err, "Router has no IP for MAC", "device", device.DeviceSummary, "mac", device.MAC)
-			device = device.WithHost(fmt.Sprintf("%s.local", device.Id()))
-			modified = true
-		}
-	}
-
-	updated, err := device.Refresh(ctx)
+	// Host resolution (router MAC lookup, then mDNS) happens lazily inside
+	// pkg/shelly, only when an HTTP call actually needs it, via the
+	// types.HostResolver installed by shelly.SetHostResolver in Start()
+	// below — no periodic MAC->IP polling here. See docs/no-ip-address-plan.md.
+	modified, err := device.Refresh(ctx)
 	if err != nil {
 		log.Error(err, "Failed to refresh device", "device", device.DeviceSummary)
 		return
-	}
-
-	if updated {
-		modified = true
 	}
 
 	if !modified {

--- a/myhome/storage/db.go
+++ b/myhome/storage/db.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
+
 	"github.com/asnowfix/home-automation/internal/myhome"
 
 	"github.com/go-logr/logr"
@@ -121,6 +123,60 @@ func (s *DeviceStorage) createTable() error {
 			s.log.Error(err, "Failed to get rows affected")
 			// Don't return error - tables might not exist
 		}
+	}
+
+	if err := s.migrateHostsToHostnames(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// migrateHostsToHostnames replaces any literal IP address left in the host
+// column (from before #252) with "<id>.local". host is no longer written
+// with a live-resolved IP (see docs/no-ip-address-plan.md); a pre-existing
+// IP is stale by definition — the device may have moved to a different
+// address since it was last cached — so it is rewritten to the device's
+// mDNS-resolvable hostname instead of being left permanently wrong.
+func (s *DeviceStorage) migrateHostsToHostnames() error {
+	rows, err := s.db.Query(`SELECT rowid, id, host FROM devices WHERE host != ''`)
+	if err != nil {
+		s.log.Error(err, "Failed to query devices for host migration")
+		return err
+	}
+
+	type staleRow struct {
+		rowid int64
+		id    string
+	}
+	var stale []staleRow
+	for rows.Next() {
+		var rowid int64
+		var id, host string
+		if err := rows.Scan(&rowid, &id, &host); err != nil {
+			rows.Close()
+			s.log.Error(err, "Failed to scan device row during host migration")
+			return err
+		}
+		if net.ParseIP(host) != nil {
+			stale = append(stale, staleRow{rowid: rowid, id: id})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		s.log.Error(err, "Failed to iterate devices during host migration")
+		return err
+	}
+	rows.Close()
+
+	for _, r := range stale {
+		if _, err := s.db.Exec(`UPDATE devices SET host = ? WHERE rowid = ?`, r.id+".local", r.rowid); err != nil {
+			s.log.Error(err, "Failed to migrate cached IP to hostname", "id", r.id)
+			return err
+		}
+	}
+	if len(stale) > 0 {
+		s.log.Info("Migrated cached IP addresses in devices DB to mDNS hostnames", "count", len(stale))
 	}
 
 	return nil

--- a/myhome/storage/db_test.go
+++ b/myhome/storage/db_test.go
@@ -50,6 +50,58 @@ func TestNewDeviceStorage_CreatesSchema(t *testing.T) {
 	}
 }
 
+// TestMigrateHostsToHostnames_RewritesLegacyIPs verifies that a pre-existing
+// literal IP in host (left over from before #252) is rewritten to
+// "<id>.local" the next time the storage opens, while a non-IP host value
+// (e.g. already ".local", or empty) is left untouched.
+func TestMigrateHostsToHostnames_RewritesLegacyIPs(t *testing.T) {
+	s := newTestStorage(t)
+	ctx := context.Background()
+
+	withIP := makeDevice("Shelly", "shellyplus1pm-aabbccddeeff", "aa:bb:cc:dd:ee:ff", "pump", "192.168.1.101")
+	if _, err := s.SetDevice(ctx, withIP, false); err != nil {
+		t.Fatalf("SetDevice withIP: %v", err)
+	}
+	withHostname := makeDevice("Shelly", "shellyplus1pm-112233445566", "11:22:33:44:55:66", "light", "shellyplus1pm-112233445566.local")
+	if _, err := s.SetDevice(ctx, withHostname, false); err != nil {
+		t.Fatalf("SetDevice withHostname: %v", err)
+	}
+	noHost := makeDevice("Shelly", "shellyplus1pm-778899aabbcc", "77:88:99:aa:bb:cc", "spare", "")
+	if _, err := s.SetDevice(ctx, noHost, false); err != nil {
+		t.Fatalf("SetDevice noHost: %v", err)
+	}
+
+	// Re-running the migration (as NewDeviceStorage does on every open) must
+	// be idempotent and only touch the row that had a literal IP.
+	if err := s.migrateHostsToHostnames(); err != nil {
+		t.Fatalf("migrateHostsToHostnames: %v", err)
+	}
+
+	got, err := s.GetDeviceById(ctx, "shellyplus1pm-aabbccddeeff")
+	if err != nil {
+		t.Fatalf("GetDeviceById withIP: %v", err)
+	}
+	if want := "shellyplus1pm-aabbccddeeff.local"; got.Host() != want {
+		t.Errorf("withIP host = %q, want %q", got.Host(), want)
+	}
+
+	got, err = s.GetDeviceById(ctx, "shellyplus1pm-112233445566")
+	if err != nil {
+		t.Fatalf("GetDeviceById withHostname: %v", err)
+	}
+	if want := "shellyplus1pm-112233445566.local"; got.Host() != want {
+		t.Errorf("withHostname host = %q, want %q (should be untouched)", got.Host(), want)
+	}
+
+	got, err = s.GetDeviceById(ctx, "shellyplus1pm-778899aabbcc")
+	if err != nil {
+		t.Fatalf("GetDeviceById noHost: %v", err)
+	}
+	if got.Host() != "" {
+		t.Errorf("noHost host = %q, want empty", got.Host())
+	}
+}
+
 // ── SetDevice ─────────────────────────────────────────────────────────────────
 
 // TestSetDevice_InsertReportsChange confirms that the first insert of a device

--- a/pkg/shelly/device.go
+++ b/pkg/shelly/device.go
@@ -150,7 +150,7 @@ func (d *Device) Refresh(ctx context.Context, via types.Channel) (bool, error) {
 
 	// Resolve the channel after MQTT initialization - this ensures MQTT-only devices
 	// (no known host) use MQTT instead of the discard caller for ChannelDefault
-	via = d.Channel(via)
+	via = d.Channel(ctx, via)
 
 	if d.Id() == "" {
 		err := d.initDeviceInfo(ctx, via)
@@ -420,13 +420,13 @@ func (d *Device) StopDialog(ctx context.Context, id uint32) {
 	d.mqtt.Unlock()
 }
 
-func (d *Device) Channel(via types.Channel) types.Channel {
+func (d *Device) Channel(ctx context.Context, via types.Channel) types.Channel {
 	switch via {
 	case types.ChannelDefault:
 		if d.IsMqttReady() {
 			return types.ChannelMqtt
 		}
-		if d.IsHttpReady() {
+		if d.IsHttpReady() || d.resolveHost(ctx) {
 			return types.ChannelHttp
 		}
 	case types.ChannelMqtt:
@@ -434,12 +434,24 @@ func (d *Device) Channel(via types.Channel) types.Channel {
 			return types.ChannelMqtt
 		}
 	case types.ChannelHttp:
-		if d.IsHttpReady() {
+		if d.IsHttpReady() || d.resolveHost(ctx) {
 			return types.ChannelHttp
 		}
 	}
 	// Auto discarded
 	return types.ChannelDefault
+}
+
+// resolveHost asks the injected types.HostResolver (if any) for the
+// device's current IP, keyed by MAC first and then by device ID (mDNS
+// hostname). On success it updates Host_ and returns true.
+func (d *Device) resolveHost(ctx context.Context) bool {
+	ip, ok := types.ResolveHost(ctx, d.Mac(), d.Id())
+	if !ok {
+		return false
+	}
+	d.UpdateHost(ip.String())
+	return true
 }
 
 var nameRe = regexp.MustCompile(fmt.Sprintf("^(?P<id>[a-zA-Z0-9]+).%s.local.$", MDNS_SHELLIES))

--- a/pkg/shelly/device_test.go
+++ b/pkg/shelly/device_test.go
@@ -2,6 +2,7 @@ package shelly
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 
@@ -9,6 +10,13 @@ import (
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/go-logr/logr"
 )
+
+// fakeResolverFunc adapts a plain func to types.HostResolver for tests.
+type fakeResolverFunc func(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error)
+
+func (f fakeResolverFunc) ResolveHost(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error) {
+	return f(ctx, mac, name)
+}
 
 // stubDevice is a minimal devices.Device for tests.
 type stubDevice struct {
@@ -193,5 +201,57 @@ func TestNewDeviceFromMqttId_Valid(t *testing.T) {
 	}
 	if d.Id() != "shellyplus1pm-aabbccddeeff" {
 		t.Errorf("unexpected id: %q", d.Id())
+	}
+}
+
+func TestChannel_ResolvesHostWhenNeitherMqttNorHttpReady(t *testing.T) {
+	t.Cleanup(func() { types.SetHostResolver(nil) })
+	types.SetHostResolver(fakeResolverFunc(func(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error) {
+		if name == "shellyplus1pm-aabbccddeeff" {
+			return net.ParseIP("192.168.1.77"), nil
+		}
+		return nil, errors.New("not found")
+	}))
+
+	d := &Device{Id_: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
+
+	got := d.Channel(context.Background(), types.ChannelDefault)
+	if got != types.ChannelHttp {
+		t.Fatalf("expected ChannelHttp, got %v", got)
+	}
+	if d.Host() != "192.168.1.77" {
+		t.Errorf("expected host to be updated to 192.168.1.77, got %q", d.Host())
+	}
+}
+
+func TestChannel_NoResolverStaysDiscarded(t *testing.T) {
+	t.Cleanup(func() { types.SetHostResolver(nil) })
+	types.SetHostResolver(nil)
+
+	d := &Device{Id_: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
+
+	got := d.Channel(context.Background(), types.ChannelDefault)
+	if got != types.ChannelDefault {
+		t.Fatalf("expected ChannelDefault (discarded), got %v", got)
+	}
+}
+
+func TestChannel_MqttReadyDoesNotCallResolver(t *testing.T) {
+	t.Cleanup(func() { types.SetHostResolver(nil) })
+	called := false
+	types.SetHostResolver(fakeResolverFunc(func(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error) {
+		called = true
+		return net.ParseIP("192.168.1.1"), nil
+	}))
+
+	d := &Device{Id_: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
+	d.mqtt = &DeviceMqttChannels{ReplyTo: "x", To: make(chan []byte, 1), From: make(chan []byte, 1)}
+
+	got := d.Channel(context.Background(), types.ChannelDefault)
+	if got != types.ChannelMqtt {
+		t.Fatalf("expected ChannelMqtt, got %v", got)
+	}
+	if called {
+		t.Error("resolver should not be called when MQTT is already ready")
 	}
 }

--- a/pkg/shelly/ops.go
+++ b/pkg/shelly/ops.go
@@ -52,5 +52,12 @@ func Init(log logr.Logger, mc mqtt.Client, timeout time.Duration, rateLimitInter
 }
 
 func (r *Registrar) CallE(ctx context.Context, d types.Device, via types.Channel, mh types.MethodHandler, params any) (any, error) {
-	return r.channels[d.Channel(via)](ctx, d, mh, mh.Allocate(), params)
+	return r.channels[d.Channel(ctx, via)](ctx, d, mh, mh.Allocate(), params)
+}
+
+// SetHostResolver installs the resolver used to (re-)resolve a device's IP
+// address when it is unknown, or immediately after an HTTP dial failure.
+// See types.HostResolver. Call once at daemon startup.
+func SetHostResolver(r types.HostResolver) {
+	types.SetHostResolver(r)
 }

--- a/pkg/shelly/script/fetch_state_test.go
+++ b/pkg/shelly/script/fetch_state_test.go
@@ -61,7 +61,7 @@ func (f *fakeDevice) StartDialog(_ context.Context) uint32     { return 0 }
 func (f *fakeDevice) StopDialog(_ context.Context, _ uint32)  {}
 func (f *fakeDevice) IsHttpReady() bool                        { return false }
 func (f *fakeDevice) IsMqttReady() bool                        { return true }
-func (f *fakeDevice) Channel(via types.Channel) types.Channel  { return via }
+func (f *fakeDevice) Channel(_ context.Context, via types.Channel) types.Channel { return via }
 func (f *fakeDevice) UpdateName(_ string)                      {}
 func (f *fakeDevice) UpdateHost(_ string)                      {}
 func (f *fakeDevice) ClearHost()                               {}

--- a/pkg/shelly/shttp/channel.go
+++ b/pkg/shelly/shttp/channel.go
@@ -23,6 +23,19 @@ type HttpChannel struct {
 
 var httpChannel HttpChannel
 
+// formatHost normalizes a device host for use in an RPC URL. host may be a
+// bare IPv4/IPv6 address, a hostname, or any of those with an explicit
+// ":port" suffix; IPv6 literals are bracketed as required by URL syntax.
+func formatHost(host string) string {
+	if h, port, err := net.SplitHostPort(host); err == nil {
+		return net.JoinHostPort(h, port)
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+		return fmt.Sprintf("[%s]", host)
+	}
+	return host
+}
+
 func (ch *HttpChannel) callE(ctx context.Context, device types.Device, verb types.MethodHandler, out any, params any) (any, error) {
 	var res *http.Response
 	var err error
@@ -33,17 +46,31 @@ func (ch *HttpChannel) callE(ctx context.Context, device types.Device, verb type
 	log = log.WithName("shelly.HttpChannel")
 	ctx = logr.NewContext(ctx, log)
 
-	switch verb.HttpMethod {
-	case http.MethodGet:
-		res, err = ch.getE(ctx, device.Host(), verb.Method, params)
-	default:
-		res, err = ch.postE(ctx, device.Host(), http.MethodPost, verb.Method, params)
+	dial := func() (*http.Response, error) {
+		switch verb.HttpMethod {
+		case http.MethodGet:
+			return ch.getE(ctx, device.Host(), verb.Method, params)
+		default:
+			return ch.postE(ctx, device.Host(), http.MethodPost, verb.Method, params)
+		}
 	}
 
+	res, err = dial()
 	if err != nil {
-		log.Error(err, "HTTP error - clearing device host to fallback to MQTT", "device_id", device.Id())
+		log.Error(err, "HTTP error - re-resolving host before falling back to MQTT", "device_id", device.Id())
 		device.ClearHost()
-		return nil, err
+
+		if ip, ok := types.ResolveHost(ctx, device.Mac(), device.Id()); ok {
+			log.Info("Re-resolved host, retrying once", "device_id", device.Id(), "ip", ip.String())
+			device.UpdateHost(ip.String())
+			res, err = dial()
+		}
+
+		if err != nil {
+			log.Error(err, "HTTP error after re-resolution - clearing device host to fallback to MQTT", "device_id", device.Id())
+			device.ClearHost()
+			return nil, err
+		}
 	}
 
 	err = json.NewDecoder(res.Body).Decode(&out)
@@ -85,12 +112,7 @@ func (ch *HttpChannel) getE(ctx context.Context, host string, cmd string, params
 		qs = fmt.Sprintf("?%s", values.Encode())
 	}
 
-	ip := net.ParseIP(host)
-	if ip.To4() == nil {
-		// v6
-		host = fmt.Sprintf("[%s]", host)
-	}
-	requestURL := fmt.Sprintf("http://%s/rpc/%s%s", host, cmd, qs)
+	requestURL := fmt.Sprintf("http://%s/rpc/%s%s", formatHost(host), cmd, qs)
 	log.Info("Calling", "method", http.MethodGet, "url", requestURL)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
@@ -141,12 +163,7 @@ func (ch *HttpChannel) postE(ctx context.Context, host string, hm string, cmd st
 		}
 		requestURL = fmt.Sprintf("http://%s/rpc", host)
 	} else {
-		ip := net.ParseIP(host)
-		if ip.To4() == nil {
-			// v6
-			host = fmt.Sprintf("[%s]", host)
-		}
-		requestURL = fmt.Sprintf("http://%s/rpc/%s", host, cmd)
+		requestURL = fmt.Sprintf("http://%s/rpc/%s", formatHost(host), cmd)
 		if params != nil {
 			jsonData, err = json.Marshal(params)
 			if err != nil {

--- a/pkg/shelly/shttp/channel_test.go
+++ b/pkg/shelly/shttp/channel_test.go
@@ -1,0 +1,112 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/types"
+
+	"github.com/go-logr/logr"
+)
+
+// fakeResolverFunc adapts a plain func to types.HostResolver for tests.
+type fakeResolverFunc func(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error)
+
+func (f fakeResolverFunc) ResolveHost(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error) {
+	return f(ctx, mac, name)
+}
+
+func withLogger(ctx context.Context) context.Context {
+	return logr.NewContext(ctx, logr.Discard())
+}
+
+// TestCallE_SucceedsWithoutResolution verifies the plain happy path is
+// unaffected by the retry-on-failure logic: a device whose Host is already
+// dialable gets called once, no resolver involved.
+func TestCallE_SucceedsWithoutResolution(t *testing.T) {
+	t.Cleanup(func() { types.SetHostResolver(nil) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer srv.Close()
+
+	device := types.NewFakeDevice()
+	device.IdValue = "shellyplus1pm-aabbccddeeff"
+	device.HostValue = srv.Listener.Addr().String()
+
+	verb := types.MethodHandler{Method: "Shelly.GetStatus", HttpMethod: http.MethodGet}
+	out := map[string]any{}
+
+	_, err := httpChannel.callE(withLogger(context.Background()), device, verb, &out, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if device.Host() != srv.Listener.Addr().String() {
+		t.Errorf("host should be unchanged on success, got %q", device.Host())
+	}
+}
+
+// TestCallE_RetriesOnceAfterReResolution verifies that on a dial failure,
+// callE clears the stale host, asks the installed resolver exactly once,
+// updates the host with what it returns, and retries — and that if the
+// retry also fails, the host ends up cleared again.
+func TestCallE_RetriesOnceAfterReResolution(t *testing.T) {
+	t.Cleanup(func() { types.SetHostResolver(nil) })
+
+	resolveCalls := 0
+	types.SetHostResolver(fakeResolverFunc(func(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error) {
+		resolveCalls++
+		return net.ParseIP("127.0.0.1"), nil
+	}))
+
+	device := types.NewFakeDevice()
+	device.IdValue = "shellyplus1pm-aabbccddeeff"
+	// Port 1 is reserved/unassigned: connection is refused immediately on
+	// both the first attempt and the retry (the resolver only returns a bare
+	// IP, so the retry dials it on the default port-less host string, which
+	// is equally unreachable here) — good enough to exercise the retry path
+	// without depending on a real listener on the resolved address.
+	device.HostValue = "127.0.0.1:1"
+
+	verb := types.MethodHandler{Method: "Shelly.GetStatus", HttpMethod: http.MethodGet}
+	out := map[string]any{}
+
+	_, err := httpChannel.callE(withLogger(context.Background()), device, verb, &out, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if resolveCalls != 1 {
+		t.Errorf("expected resolver to be called exactly once, got %d", resolveCalls)
+	}
+	if device.Host() != "" {
+		t.Errorf("expected host to be cleared after retry also fails, got %q", device.Host())
+	}
+}
+
+// TestCallE_NoResolverClearsHostOnFailure verifies the pre-existing behavior
+// (clear host, give the caller an error to fall back to MQTT) is preserved
+// when no resolver is installed.
+func TestCallE_NoResolverClearsHostOnFailure(t *testing.T) {
+	t.Cleanup(func() { types.SetHostResolver(nil) })
+	types.SetHostResolver(nil)
+
+	device := types.NewFakeDevice()
+	device.IdValue = "shellyplus1pm-aabbccddeeff"
+	device.HostValue = "127.0.0.1:1"
+
+	verb := types.MethodHandler{Method: "Shelly.GetStatus", HttpMethod: http.MethodGet}
+	out := map[string]any{}
+
+	_, err := httpChannel.callE(withLogger(context.Background()), device, verb, &out, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if device.Host() != "" {
+		t.Errorf("expected host to be cleared, got %q", device.Host())
+	}
+}

--- a/pkg/shelly/types/fake_device.go
+++ b/pkg/shelly/types/fake_device.go
@@ -82,7 +82,7 @@ func (f *FakeDevice) StopDialog(ctx context.Context, id uint32) {}
 
 func (f *FakeDevice) IsHttpReady() bool           { return true }
 func (f *FakeDevice) IsMqttReady() bool           { return true }
-func (f *FakeDevice) Channel(via Channel) Channel { return via }
+func (f *FakeDevice) Channel(ctx context.Context, via Channel) Channel { return via }
 
 func (f *FakeDevice) UpdateName(name string) { f.NameValue = name }
 func (f *FakeDevice) UpdateHost(host string) { f.HostValue = host }

--- a/pkg/shelly/types/types.go
+++ b/pkg/shelly/types/types.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
+
+	"github.com/go-logr/logr"
 )
 
 type MethodsRegistrar interface {
@@ -30,7 +33,7 @@ type Device interface {
 
 	IsMqttReady() bool
 
-	Channel(via Channel) Channel
+	Channel(ctx context.Context, via Channel) Channel
 
 	UpdateName(name string)
 	UpdateHost(host string)
@@ -42,6 +45,41 @@ type Device interface {
 }
 
 type DeviceCaller func(ctx context.Context, device Device, mh MethodHandler, out any, params any) (any, error)
+
+// HostResolver resolves a device's current dialable IP address, e.g. via
+// mDNS or a router's ARP-like lookup table. Implemented by the internal/
+// myhome layer, which owns network-topology concerns, and injected here at
+// daemon startup via SetHostResolver — keeping pkg/shelly free of any
+// MyHome-specific dependency (see CLAUDE.md's Three-Tier Layer Rule).
+type HostResolver interface {
+	ResolveHost(ctx context.Context, mac net.HardwareAddr, name string) (net.IP, error)
+}
+
+var hostResolver HostResolver
+
+// SetHostResolver installs the HostResolver used to (re-)resolve a device's
+// IP address when it is unknown, or immediately after an HTTP dial failure,
+// before falling back to another channel (e.g. MQTT). Call once at daemon
+// startup; nil (the default) disables resolution.
+func SetHostResolver(r HostResolver) {
+	hostResolver = r
+}
+
+// ResolveHost calls the installed HostResolver, if any. ok is false if no
+// resolver is installed, or the installed one could not find an address.
+func ResolveHost(ctx context.Context, mac net.HardwareAddr, name string) (ip net.IP, ok bool) {
+	if hostResolver == nil {
+		return nil, false
+	}
+	log := logr.FromContextOrDiscard(ctx)
+	start := time.Now()
+	ip, err := hostResolver.ResolveHost(ctx, mac, name)
+	log.Info("ResolveHost", "mac", mac, "name", name, "ip", ip, "err", err, "elapsed", time.Since(start))
+	if err != nil || ip == nil {
+		return nil, false
+	}
+	return ip, true
+}
 
 type Channel uint32
 


### PR DESCRIPTION
## Summary

Implements #252: the devices DB no longer caches a device's resolved IP address. Resolution happens on demand through a chained `model.Router` (SFR ARP-style lookup, falling through to mDNS), fixing the stale-cached-IP bug from PR #265 (device DHCP-renews its IP, daemon kept using the old address).

- New `model.Router` fallback chain (SFR → mDNS → not-found terminal) and a `pkg/shelly/types.HostResolver` injection point, so `pkg/shelly` can (re-)resolve a device's IP without depending on `internal/myhome`.
- Removed the periodic MAC→IP polling loop; resolution is now purely on-demand, triggered when a device has no known host or an HTTP dial fails.
- Devices DB stops writing resolved IPs; a migration rewrites any pre-existing cached IP to `<id>.local` on next daemon start.
- Fixed the two places that broke once `Host` stopped being cached (`myhome ctl open`, the reverse-proxy's device-lookup fallback ordering) and a UI regression found during live testing (the "open device web UI" button was gated on the now-empty `Host` field).
- Fixed a latent IPv6-bracket-detection bug in the HTTP channel surfaced while testing.

Deliberately out of scope, tracked separately: #336 (relaying HTTP through a NAT'ing gateway device — Shelly AP/RangeExtender, TP-Link Omada EAP 100) and #339 (Shelly Cover component support, found unrelated during live UI testing).

Full design/implementation log: `docs/no-ip-address-plan.md`.

## Test plan

- [x] `make test` green across the whole workspace
- [x] Unit tests for the Router chain, mDNS Router, `HostResolver` retry-on-failure, DB migration, and UI template gating
- [x] Ran the built daemon against the real home MQTT broker: clean startup, real devices discovered and reachable over HTTP and MQTT, "open device web UI" link verified working end-to-end (HTML + WebSocket proxied correctly)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(shelly): add mDNS/SFR Router fallback chain and HostResolver seam ([84b66b7](https://github.com/asnowfix/home-automation/commit/84b66b77a8475f546f8a7af46692649ace43a9cf))
- feat(myhome): resolve device hosts on demand, stop caching IPs in the DB ([2626ac6](https://github.com/asnowfix/home-automation/commit/2626ac6ac5105e124f7f5dd94fe760737c8bff23))
- fix(ui): gate the device web-UI link on capability, not a cached host ([ee6be07](https://github.com/asnowfix/home-automation/commit/ee6be073ac700022e624a8949d33ff4443c16474))
- Merge branch 'main' into worktree-feature+no-ip-address ([af28094](https://github.com/asnowfix/home-automation/commit/af28094af7dc2014cdb493afdc39680d578010a4))
<!-- END-AUTO-GENERATED-COMMITS -->