### PR TITLE
fix(daemon): fail startup on malformed config instead of silently ignoring it

### DIFF
--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -1,5 +1,4 @@
-#
- MyHome Configuration Example
+# MyHome Configuration Example
 # Copy this file to myhome.yaml and customize as needed
 
 mqtt:

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,27 @@ import (
 
 func defaultEventsDBPath() string {
 	return "events.db"
+}
+
+// loadConfigFile attempts to read myhome's YAML config into v (search paths
+// and env binding must already be configured on v). A missing file is
+// expected and benign — defaults/flags/env take over, matching the
+// documented "config file is optional" behavior. A file that exists but
+// fails to parse (e.g. a YAML syntax error) returns an error instead: a
+// previous version silently fell back to defaults in that case, logging the
+// same message as "no config file found" — which let a broken myhome.yaml
+// run for weeks with every config key quietly ignored (see pool/solar
+// options, which have no other way to be set short of CLI flags).
+func loadConfigFile(v *viper.Viper, log logr.Logger) error {
+	if err := v.ReadInConfig(); err == nil {
+		log.Info("Loaded config from", "file", v.ConfigFileUsed())
+		return nil
+	} else if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		log.Info("No config file found, using defaults and flags")
+		return nil
+	} else {
+		return fmt.Errorf("config file %s exists but failed to parse: %w", v.ConfigFileUsed(), err)
+	}
 }
 
 var disableGen1Proxy bool
@@ -99,11 +121,8 @@ var runCmd = &cobra.Command{
 		v.AutomaticEnv()
 		v.SetDefault("beem.poll_interval", "60s")
 
-		// Try to read config file (optional)
-		if err := v.ReadInConfig(); err == nil {
-			log.Info("Loaded config from", "file", v.ConfigFileUsed())
-		} else {
-			log.Info("No config file found, using defaults and flags")
+		if err := loadConfigFile(v, log); err != nil {
+			return err
 		}
 
 		// Bind flags to viper (flags take precedence over config file)

--- a/myhome/daemon/run_test.go
+++ b/myhome/daemon/run_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/viper"
+)
+
+// TestLoadConfigFileMissing verifies that a completely absent config file is
+// not an error: defaults/flags/env are expected to take over (this is the
+// documented "config file is optional" behavior).
+func TestLoadConfigFileMissing(t *testing.T) {
+	v := viper.New()
+	v.SetConfigName("myhome")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(t.TempDir()) // empty directory: no myhome.yaml present
+
+	if err := loadConfigFile(v, logr.Discard()); err != nil {
+		t.Fatalf("loadConfigFile with no config file present: got error %v, want nil", err)
+	}
+}
+
+// TestLoadConfigFileValid verifies a well-formed config file loads without
+// error and its values are readable afterward.
+func TestLoadConfigFileValid(t *testing.T) {
+	dir := t.TempDir()
+	writeConfig(t, dir, "pool:\n  device_id: \"shellypro1-abc123\"\n  enabled: true\n")
+
+	v := viper.New()
+	v.SetConfigName("myhome")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(dir)
+
+	if err := loadConfigFile(v, logr.Discard()); err != nil {
+		t.Fatalf("loadConfigFile with valid config: got error %v, want nil", err)
+	}
+	if got := v.GetString("pool.device_id"); got != "shellypro1-abc123" {
+		t.Errorf("pool.device_id = %q, want %q", got, "shellypro1-abc123")
+	}
+	if !v.GetBool("pool.enabled") {
+		t.Errorf("pool.enabled = false, want true")
+	}
+}
+
+// TestLoadConfigFileInvalid verifies that a config file which exists but
+// fails to parse — the exact class of bug found in production, where
+// myhome.yaml's header comment was missing its leading '#' and the whole
+// file silently failed to load for weeks — now aborts startup with an error
+// instead of being swallowed under the same message as "no config file".
+func TestLoadConfigFileInvalid(t *testing.T) {
+	dir := t.TempDir()
+	// Reproduces the real production bug: an unprefixed comment line collides
+	// with the following mapping key, making the document invalid YAML.
+	writeConfig(t, dir, "#\n MyHome Configuration Example\npool:\n  enabled: true\n")
+
+	v := viper.New()
+	v.SetConfigName("myhome")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(dir)
+
+	err := loadConfigFile(v, logr.Discard())
+	if err == nil {
+		t.Fatal("loadConfigFile with malformed config: got nil error, want non-nil")
+	}
+}
+
+func writeConfig(t *testing.T, dir, content string) {
+	t.Helper()
+	path := filepath.Join(dir, "myhome.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write test config: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Investigation into "why doesn't pool-pump.js's start/stop/water-supply events show up as `notice` severity in the events UI" found that pool-pump.js and the whole event pipeline (`Shelly.emitEvent` → MQTT `NotifyEvent` → `Gen2Listener` → `severityFor()` → `events.db`) were never broken — verified live end-to-end against the real production pool device, including `reason`-tagged start/stop events landing with correct `notice` severity.

The real root cause: `myhome-example.yaml`'s header comment was missing its leading `#`, making the whole file invalid YAML. Viper's `ReadInConfig()` swallowed that parse error under the exact same "no config file found" log message used for a genuinely absent file — so any deployment that copied this template (as its own header instructs) would silently run forever on defaults/flags/env only, with every config key ignored. That's what had happened in production: `pool:`/`solar:` settings in `myhome.yaml` had no effect for weeks, so `PoolNotices`/`SolarAutomation` never started, even though the on-device automation and notification code were fine.

## Changes

- `myhome-example.yaml`: fix the missing `#` (the actual bug that broke config loading).
- `myhome/daemon/run.go`: a config file that exists but fails to parse now aborts daemon startup with the parse error, instead of being silently swallowed. A genuinely absent config file remains optional (defaults/flags/env apply, unchanged) — this was an explicit scope decision to avoid breaking documented flag/env-only workflows.
- `myhome/daemon/run_test.go`: new tests for `loadConfigFile` covering absent / valid / malformed config files, including a regression test reproducing the exact production bug (unprefixed comment colliding with the following mapping key).

## Test plan

- [x] `go test ./myhome/daemon/...` — new tests pass
- [x] `make test` — full workspace green
- [x] Verified live against production: fixed the same typo in the deployed `/etc/myhome/myhome.yaml`, added the `pool:`/`solar:` section, restarted — config now loads, `PoolRuntimeTracker` initializes, and real `pool.water_supply_protected/restored` and `pool.pump_start` (reason: "Morning start event") notices are now flowing into the events UI with correct severity<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(daemon): fail startup on malformed config instead of silently ignoring it ([fa70998](https://github.com/asnowfix/home-automation/commit/fa709982fb97bc1b7c61ae328afea7d0a0e04154))
<!-- END-AUTO-GENERATED-COMMITS -->