### PR TITLE
fix(devices): stop empty MAC/Host from colliding devices in cache

### DIFF
--- a/myhome/devices/cache.go
+++ b/myhome/devices/cache.go
@@ -78,7 +78,7 @@ func (c *Cache) SetDevice(ctx context.Context, d *myhome.Device, overwrite bool)
 	defer c.mutex.Unlock()
 
 	for i, existing := range c.devices {
-		if existing.Id() == d.Id() || existing.MAC == d.MAC || existing.Host_ == d.Host_ || existing.Name() == d.Name() {
+		if sameDevice(existing, d) {
 			if !overwrite {
 				return false, fmt.Errorf("device already exists: %v", *d)
 			}
@@ -91,6 +91,26 @@ func (c *Cache) SetDevice(ctx context.Context, d *myhome.Device, overwrite bool)
 		return true, err
 	}
 	return c.db.SetDevice(ctx, d, overwrite)
+}
+
+// sameDevice reports whether existing and d identify the same physical
+// device. Empty-string fields (MAC/Host_ unresolved, e.g. for Gen1/BLU
+// devices) must never be compared for equality, or two unrelated devices
+// that both lack that field would be treated as duplicates of each other.
+func sameDevice(existing, d *myhome.Device) bool {
+	if existing.Id() == d.Id() {
+		return true
+	}
+	if existing.MAC != "" && existing.MAC == d.MAC {
+		return true
+	}
+	if existing.Host_ != "" && existing.Host_ == d.Host_ {
+		return true
+	}
+	if existing.Name() != "" && existing.Name() == d.Name() {
+		return true
+	}
+	return false
 }
 
 func (c *Cache) insert(d *myhome.Device) (*myhome.Device, error) {

--- a/myhome/devices/cache_test.go
+++ b/myhome/devices/cache_test.go
@@ -675,6 +675,54 @@ func TestCache_SetDevice_NoOverwrite_RejectsDuplicate(t *testing.T) {
 	}
 }
 
+// TestCache_SetDevice_EmptyMACAndHostDoNotCollide reproduces the production
+// bug where two distinct devices sharing an empty MAC and/or Host (common for
+// Gen1/BLU sensors, e.g. shellyht-* temperature sensors, that never resolve a
+// hostname) would be treated as the "same" device by SetDevice's OR-matching
+// loop: inserting the second device evicted the first from the cache slice
+// instead of replacing itself, leaving the second device's later re-insertion
+// (e.g. on the next periodic refresh) to duplicate itself in the list while
+// the first device vanished silently.
+func TestCache_SetDevice_EmptyMACAndHostDoNotCollide(t *testing.T) {
+	reg := newFakeRegistry()
+	c := NewCache(testCtx(t), reg)
+	ctx := context.Background()
+
+	d1 := fakeDevice("shellyht-CC2E04", "temperature-bureau", "", "")
+	d2 := fakeDevice("shellyht-CC2489", "temperature-cuisine", "", "")
+
+	if _, err := c.SetDevice(ctx, d1, true); err != nil {
+		t.Fatalf("SetDevice d1: %v", err)
+	}
+	if _, err := c.SetDevice(ctx, d2, true); err != nil {
+		t.Fatalf("SetDevice d2: %v", err)
+	}
+
+	all, err := c.GetAllDevices(ctx)
+	if err != nil {
+		t.Fatalf("GetAllDevices: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 distinct devices, got %d: %+v", len(all), all)
+	}
+
+	// Re-insert d2 again (simulating a periodic refresh / repeated MQTT
+	// announcement) and confirm it still doesn't duplicate or evict d1.
+	if _, err := c.SetDevice(ctx, fakeDevice("shellyht-CC2489", "temperature-cuisine", "", ""), true); err != nil {
+		t.Fatalf("SetDevice d2 (re-insert): %v", err)
+	}
+	all, err = c.GetAllDevices(ctx)
+	if err != nil {
+		t.Fatalf("GetAllDevices: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 distinct devices after re-insert, got %d: %+v", len(all), all)
+	}
+	if _, err := c.GetDeviceById(ctx, "shellyht-CC2E04"); err != nil {
+		t.Errorf("d1 should still be present after d2's re-insertion: %v", err)
+	}
+}
+
 // ── tests: Flush ──────────────────────────────────────────────────────────────
 
 // TestCache_Flush_ClearsAllMaps verifies that Flush resets all five internal


### PR DESCRIPTION
## Summary
- Some devices (`spots-piscine`, `temperature-bureau`, `temperature-chambre-*`, `temperature-cuisine`) were showing up twice in the web UI device list. The SQLite `devices` table on the NAS has exactly one row per device — no DB-level duplication.
- Root cause: `Cache.SetDevice` (`myhome/devices/cache.go`) matched an incoming device against the in-memory cache using `Id() || MAC || Host_ || Name()`. Devices with an unresolved `MAC`/`Host_` (Gen1 sensors like `shellyht-*`, and any device before mDNS resolves a hostname) have empty strings there, so two *unrelated* devices sharing an empty `MAC`/`Host_` were treated as duplicates of each other: the wrong entry got evicted from the cache slice, and the real device was appended a second time on its next refresh/MQTT update.
- Fix: only compare `MAC`/`Host_` for equality when both sides are non-empty.

## Test plan
- [x] Added `TestCache_SetDevice_EmptyMACAndHostDoNotCollide`, reproducing the exact scenario (two `shellyht-*` devices with empty MAC/Host, one re-inserted as on a refresh tick) — fails on `main`, passes with the fix.
- [x] `make test` (full workspace) passes.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(devices): stop empty MAC/Host from colliding devices in cache ([c3bb1c8](https://github.com/asnowfix/home-automation/commit/c3bb1c8ba8bf7ffbf667678a023c01b3dc01ddd0))
<!-- END-AUTO-GENERATED-COMMITS -->