### PR TITLE
fix(main): profile file lifecycle, cancel-func plumbing, daemon detection (#357)

### DIFF
--- a/cmd/datacollector/main.go
+++ b/cmd/datacollector/main.go
@@ -63,7 +63,8 @@ func main() {
 	logger = hlog.Logger
 
 	ctx := logr.NewContext(context.Background(), logger)
-	ctx = options.CommandLineContext(ctx)
+	ctx, cancel := options.CommandLineContext(ctx)
+	defer cancel()
 
 	mc, err := mqtt.GetClientE(ctx)
 	if err != nil {

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -7,9 +7,12 @@ import (
 type ContextKey uint
 
 const (
-	CancelKey ContextKey = iota
-	CpuProfileKey
-	VersionKey
+	// VersionKey and ProcessContextKey carry request-scoped data that's
+	// legitimately read far from where it's set. Control-flow dependencies
+	// (a CancelFunc, an *os.File) are NOT stored here — see myhome/main.go,
+	// myhome/ctl/ctl.go and myhome/daemon/daemon.go, which each own their
+	// cancellation/profile lifecycle explicitly instead.
+	VersionKey ContextKey = iota
 	ProcessContextKey
 )
 

--- a/myhome/ctl/ctl.go
+++ b/myhome/ctl/ctl.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"runtime/pprof"
 	"syscall"
 
 	"github.com/asnowfix/home-automation/hlog"
-	"github.com/asnowfix/home-automation/internal/global"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/blu"
 	"github.com/asnowfix/home-automation/myhome/ctl/config"
@@ -37,6 +35,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// cancelFunc is owned by this package alone, set once in PersistentPreRunE
+// and consumed once in PersistentPostRunE. It's a package-level var rather
+// than a context value on purpose: context.WithValue is for request-scoped
+// data, not for a control-flow handle like a CancelFunc (an unchecked type
+// assertion on a missing/mistyped value would panic). ctl.Cmd runs once per
+// process invocation, so there's no concurrent-invocation hazard here.
+var cancelFunc context.CancelFunc
+
 var Cmd = &cobra.Command{
 	Use:              "ctl",
 	Short:            "Control and manage home automation devices",
@@ -50,7 +56,9 @@ var Cmd = &cobra.Command{
 		log := hlog.Logger
 		ctx := logr.NewContext(cmd.Context(), log)
 
-		ctx = options.CommandLineContext(ctx)
+		var cancel context.CancelFunc
+		ctx, cancel = options.CommandLineContext(ctx)
+		cancelFunc = cancel
 
 		// Set the target instance name for RPC topics
 		if options.Flags.InstanceName != "" {
@@ -109,18 +117,18 @@ var Cmd = &cobra.Command{
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		f := ctx.Value(global.CpuProfileKey)
-		if f != nil {
-			defer pprof.StopCPUProfile()
-		}
+		// CPU profile start/stop/close is owned entirely by myhome/main.go's
+		// PersistentPostRunE (which always runs, as the root command's
+		// persistent hooks apply to every subcommand); nothing to do here.
 
 		mc, err := mqttclient.GetClientE(ctx)
 		if err != nil {
 			return err
 		}
 
-		cancel := ctx.Value(global.CancelKey).(context.CancelFunc)
-		cancel()
+		if cancelFunc != nil {
+			cancelFunc()
+		}
 		mc.Close()
 		return nil
 	},

--- a/myhome/ctl/options/options.go
+++ b/myhome/ctl/options/options.go
@@ -111,7 +111,13 @@ var Flags struct {
 
 var Via types.Channel
 
-func CommandLineContext(ctx context.Context) context.Context {
+// CommandLineContext builds the cancellable, request-scoped context shared by
+// every myhome entry point (daemon and ctl). It returns the derived context
+// together with its CancelFunc: the caller owns that CancelFunc explicitly
+// (e.g. in a package-level var used from PersistentPostRunE) rather than
+// threading it through context.WithValue, which is for request-scoped data,
+// not control-flow dependencies.
+func CommandLineContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	var cancel context.CancelFunc
 
 	// Create the process-wide context that background services can use
@@ -119,10 +125,8 @@ func CommandLineContext(ctx context.Context) context.Context {
 
 	if Flags.Wait > 0 {
 		ctx, cancel = context.WithTimeout(processCtx, Flags.Wait)
-		ctx = context.WithValue(ctx, global.CancelKey, cancel)
 	} else {
 		ctx, cancel = context.WithCancel(processCtx)
-		ctx = context.WithValue(ctx, global.CancelKey, cancel)
 	}
 
 	// Store the process-wide context so lazy-started services can access it
@@ -140,7 +144,7 @@ func CommandLineContext(ctx context.Context) context.Context {
 		cancel()
 		processCancel()
 	}()
-	return ctx
+	return ctx, cancel
 }
 
 func Args(args []string) []string {

--- a/myhome/daemon/cmd.go
+++ b/myhome/daemon/cmd.go
@@ -9,9 +9,33 @@ func init() {
 
 var disableDeviceManager bool
 
+// IsDaemonAnnotation, when set to "true" on a cobra.Command's Annotations,
+// marks that command (and, per IsDaemonCommand, every command nested under
+// it) as part of the daemon tree. Callers use this instead of matching on
+// cmd.Name()/cmd.Parent().Name(), which breaks as soon as a subcommand is
+// nested more than one level below "daemon".
+const IsDaemonAnnotation = "myhome.daemon"
+
 var Cmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "MyHome Daemon",
 	Long:  "MyHome Daemon, with embedded MQTT broker and persistent device manager",
 	Args:  cobra.NoArgs,
+	Annotations: map[string]string{
+		IsDaemonAnnotation: "true",
+	},
+}
+
+// IsDaemonCommand reports whether cmd, or any of its ancestors, is part of
+// the daemon command tree (i.e. carries IsDaemonAnnotation). This lets
+// callers apply daemon-specific defaults (e.g. verbose-by-default logging)
+// to "daemon run", "daemon install", and any subcommand nested arbitrarily
+// deep under them, without hardcoding command names/depth.
+func IsDaemonCommand(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Annotations != nil && c.Annotations[IsDaemonAnnotation] == "true" {
+			return true
+		}
+	}
+	return false
 }

--- a/myhome/daemon/cmd_test.go
+++ b/myhome/daemon/cmd_test.go
@@ -1,0 +1,67 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestIsDaemonCommand verifies daemon-tree detection via the
+// IsDaemonAnnotation, including at nesting depths beyond the direct
+// "daemon <subcommand>" pattern that a cmd.Parent().Name() == "daemon"
+// string check would miss.
+func TestIsDaemonCommand(t *testing.T) {
+	root := &cobra.Command{Use: "myhome"}
+	daemonCmd := &cobra.Command{
+		Use: "daemon",
+		Annotations: map[string]string{
+			IsDaemonAnnotation: "true",
+		},
+	}
+	run := &cobra.Command{Use: "run"}
+	nested := &cobra.Command{Use: "nested"}
+	deeplyNested := &cobra.Command{Use: "deeper"}
+	other := &cobra.Command{Use: "ctl"}
+	otherChild := &cobra.Command{Use: "list"}
+
+	root.AddCommand(daemonCmd, other)
+	daemonCmd.AddCommand(run)
+	run.AddCommand(nested)
+	nested.AddCommand(deeplyNested)
+	other.AddCommand(otherChild)
+
+	tests := []struct {
+		name string
+		cmd  *cobra.Command
+		want bool
+	}{
+		{"daemon root", daemonCmd, true},
+		{"direct child (run)", run, true},
+		{"nested two levels deep", nested, true},
+		{"nested three levels deep", deeplyNested, true},
+		{"sibling command tree (ctl)", other, false},
+		{"child of sibling tree (ctl list)", otherChild, false},
+		{"unattached command", &cobra.Command{Use: "detached"}, false},
+		{"nil command", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDaemonCommand(tt.cmd); got != tt.want {
+				t.Errorf("IsDaemonCommand(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+
+	// Sanity: the real daemon.Cmd tree carries the annotation and covers
+	// both existing subcommands, which is what myhome/main.go relies on to
+	// pick daemon-vs-ctl logging defaults.
+	if !IsDaemonCommand(runCmd) {
+		t.Errorf("expected the real runCmd to be recognized as a daemon command")
+	}
+	if !IsDaemonCommand(installCmd) {
+		t.Errorf("expected the real installCmd to be recognized as a daemon command")
+	}
+	if !IsDaemonCommand(uninstallCmd) {
+		t.Errorf("expected the real uninstallCmd to be recognized as a daemon command")
+	}
+}

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -7,7 +7,6 @@ import (
 	_ "net/http/pprof"
 	"time"
 
-	"github.com/asnowfix/home-automation/internal/global"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/internal/myhome/accounts"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
@@ -61,10 +60,19 @@ func (m *reportingMailer) Send(ctx context.Context, subject, body string) error 
 	return err
 }
 
+// NewDaemon owns its shutdown explicitly: it derives its own cancellable
+// context from ctx rather than reaching into ctx for a CancelFunc stashed
+// there by an unrelated caller (context values are for request-scoped data,
+// not control-flow handles, and a missing/mistyped value would panic here).
+// d.cancel (invoked from Stop, on OS service-stop requests) cancels d.ctx;
+// d.ctx.Done() also fires if the parent ctx is cancelled (e.g. SIGINT/SIGTERM
+// handled upstream in options.CommandLineContext), so both shutdown paths
+// still converge on the same <-d.ctx.Done() wait in Run.
 func NewDaemon(ctx context.Context) *daemon {
+	ctx, cancel := context.WithCancel(ctx)
 	return &daemon{
 		ctx:    ctx,
-		cancel: ctx.Value(global.CancelKey).(context.CancelFunc),
+		cancel: cancel,
 	}
 }
 

--- a/myhome/main.go
+++ b/myhome/main.go
@@ -22,12 +22,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// cpuProfileFile and shutdownCancel are owned by this package alone: they
+// are set once in PersistentPreRunE and consumed once in
+// PersistentPostRunE. They intentionally live as package-level vars rather
+// than context values — context.WithValue is for request-scoped data, not
+// for a control-flow handle (CancelFunc) or a resource that must be closed
+// exactly once (*os.File). myhome runs Execute() a single time per process,
+// so there's no concurrent-invocation hazard here.
+var cpuProfileFile *os.File
+var shutdownCancel context.CancelFunc
+
 var Cmd = &cobra.Command{
 	Use:  "myhome",
 	Args: cobra.NoArgs,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// For daemon commands, default to verbose unless --quiet is specified
-		isDaemon := cmd.Name() == "daemon" || cmd.Parent() != nil && cmd.Parent().Name() == "daemon"
+		isDaemon := daemon.IsDaemonCommand(cmd)
 		verbose := options.Flags.Verbose
 		debugFlag := options.Flags.Debug
 		if isDaemon {
@@ -58,9 +68,12 @@ var Cmd = &cobra.Command{
 			}
 			if err := pprof.StartCPUProfile(f); err != nil {
 				log.Error(err, "Failed to start CPU profile")
+				if closeErr := f.Close(); closeErr != nil {
+					log.Error(closeErr, "Failed to close CPU profile file after start failure")
+				}
 				return err
 			}
-			ctx = context.WithValue(ctx, global.CpuProfileKey, f)
+			cpuProfileFile = f
 		}
 
 		if debug.IsDebuggerAttached() {
@@ -74,7 +87,9 @@ var Cmd = &cobra.Command{
 			options.Flags.Wait = 0
 		}
 
-		ctx = options.CommandLineContext(ctx)
+		var cancel context.CancelFunc
+		ctx, cancel = options.CommandLineContext(ctx)
+		shutdownCancel = cancel
 		cmd.SetContext(ctx)
 
 		return nil
@@ -82,14 +97,19 @@ var Cmd = &cobra.Command{
 
 	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
+		log := hlog.Logger
 
-		f := ctx.Value(global.CpuProfileKey)
-		if f != nil {
-			defer pprof.StopCPUProfile()
+		if cpuProfileFile != nil {
+			pprof.StopCPUProfile()
+			if err := cpuProfileFile.Close(); err != nil {
+				log.Error(err, "Failed to close CPU profile file")
+			}
+			cpuProfileFile = nil
 		}
 
-		cancel := ctx.Value(global.CancelKey).(context.CancelFunc)
-		cancel()
+		if shutdownCancel != nil {
+			shutdownCancel()
+		}
 
 		<-ctx.Done()
 


### PR DESCRIPTION
Closes #357

## Approach

Implements the remaining scope of #357 (see deviation note below):

- **CPU-profile file lifecycle** (`myhome/main.go`): the profile `*os.File` no longer travels through `context.WithValue`; it lives in a package-level var set once in `PersistentPreRunE` and consumed once in `PersistentPostRunE`, which now calls `pprof.StopCPUProfile()` then `f.Close()` with the close error checked and logged. Previously the last statement was a no-op trailing `defer` and the file was never closed, so the profile tail could be lost. On `StartCPUProfile` failure the file is closed instead of leaked.
- **Cancel-func plumbing** (`myhome/ctl/options/options.go`, `myhome/main.go`, `myhome/ctl/ctl.go`, `myhome/daemon/daemon.go`): `options.CommandLineContext` now returns `(context.Context, context.CancelFunc)` instead of stashing the CancelFunc in the context. Each entry point owns its CancelFunc explicitly, and `daemon.NewDaemon` derives its own `context.WithCancel(ctx)` — parent cancellation still propagates, so SIGINT/SIGTERM handled upstream and service `Stop()` both converge on the same `<-d.ctx.Done()` wait in `Run`. This removes both panic-prone unchecked `ctx.Value(global.CancelKey).(context.CancelFunc)` assertions (`myhome/main.go`, `myhome/daemon/daemon.go`). `global.CancelKey` and `global.CpuProfileKey` are deleted: no `context.WithValue` carries an `*os.File` or `context.CancelFunc` anymore.
- **Daemon detection** (`myhome/daemon/cmd.go`): name string-matching (`cmd.Name() == "daemon" || cmd.Parent().Name() == "daemon"`, which breaks on deeper nesting) replaced with `IsDaemonAnnotation` set on `daemon.Cmd` plus `daemon.IsDaemonCommand(cmd)`, which walks the ancestor chain. Covered by a new table test in `myhome/daemon/cmd_test.go` (3-level nesting, sibling trees, nil, and the real run/install/uninstall commands).
- `cmd/datacollector/main.go` adapted to the new `CommandLineContext` signature (`defer cancel()`).

## Deviation note

Problems 1–2 of the issue (duplicated CPU-profile block, unchecked `pprof.StartCPUProfile` error) were **already fixed** in 25bf682 (PR #375, part of #355's errcheck cleanup). This PR implements only the remaining problems 3–5.

## Verification

- `make generate`, `make build`, `make test` — all pass.
- `golangci-lint run` and `go vet` — 0 issues on all touched packages.
- `go test -race ./myhome/daemon/...` — only the known pre-existing #373 race fails (solar automation mock, untouched here); the new `TestIsDaemonCommand` passes under `-race`; other touched packages race-clean.
- Acceptance criteria: `myhome --cpuprofile <file> version` produces a profile that `go tool pprof -top` parses cleanly (valid header, correct duration); grep confirms no `context.WithValue` stores `*os.File`/`CancelFunc`; annotation logic covered by test. `daemon run --help`, `daemon install --help`, `ctl list --help` all exit 0.

## Out-of-scope findings (documented on #357, not fixed here)

- `myhome/ctl/ctl.go`'s cleanup goroutine calls `os.Exit(0)` on signal, skipping `PersistentPostRunE` — a Ctrl-C'd `ctl` run still truncates its CPU profile; the goroutine also double-handles signals already handled by `options.CommandLineContext`. Belongs with the goroutine-lifecycle work in #364.
- `daemon.Run` starts the pprof HTTP server with timeout-less `http.ListenAndServe` — already covered by #364.
- `cmd/datacollector/main.go` uses `log.Fatalf` throughout, which skips deferred cleanup — #365 material.
- Confirmed the #373 race is still live (not RACE_SKIP'd) on this integration branch.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(main): stop leaking CPU-profile file and panicking on shutdown ([d9c5eba](https://github.com/asnowfix/home-automation/commit/d9c5ebaeab91d723f16310beeab6c8f62936f353))
<!-- END-AUTO-GENERATED-COMMITS -->