### PR TITLE
fix(ui): stop redundant device enumeration and cache failed KVS lookups

### DIFF
--- a/internal/myhome/ui/server.go
+++ b/internal/myhome/ui/server.go
@@ -55,7 +55,7 @@ func Start(ctx context.Context, log logr.Logger, listenPort int, resolver mynet.
 
 		if path == "" {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			if err := RenderIndex(ctx, db, w); err != nil {
+			if err := RenderIndex(ctx, w); err != nil {
 				log.Error(err, "failed to render index page")
 				http.Error(w, "unable to render index", http.StatusInternalServerError)
 			}
@@ -65,7 +65,7 @@ func Start(ctx context.Context, log logr.Logger, listenPort int, resolver mynet.
 
 		if path == "event-log" {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			if err := RenderEventLog(ctx, db, w); err != nil {
+			if err := RenderEventLog(ctx, w); err != nil {
 				log.Error(err, "failed to render event log page")
 				http.Error(w, "unable to render event log", http.StatusInternalServerError)
 			}

--- a/internal/myhome/ui/template.go
+++ b/internal/myhome/ui/template.go
@@ -11,7 +11,6 @@ import (
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	pkgshelly "github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/sswitch"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -110,7 +109,6 @@ func applyPoolStatus(ctx context.Context, views []DeviceView) {
 // IndexData holds the data for rendering the index page
 type IndexData struct {
 	Version string
-	Devices []DeviceView
 }
 
 // index template and renderer
@@ -361,41 +359,25 @@ func DeviceToView(ctx context.Context, d *myhome.Device) DeviceView {
 
 // RenderEventLog renders the event log page.
 // It reuses the same index layout but injects the events table section.
-func RenderEventLog(ctx context.Context, db DeviceRegistry, w io.Writer) error {
+// Device data is loaded separately by the client via hx-get="/htmx/devices"
+// (index.html/eventLogPageHTML never reference .Devices), so this does not
+// enumerate devices — that work would be discarded and was the dominant
+// cost of loading this page (see #390).
+func RenderEventLog(ctx context.Context, w io.Writer) error {
 	data := IndexData{
-		Devices: []DeviceView{},
 		Version: ctx.Value(global.VersionKey).(string),
-	}
-	if db != nil {
-		devices, err := db.GetAllDevices(ctx)
-		if err == nil {
-			for _, d := range devices {
-				data.Devices = append(data.Devices, DeviceToView(ctx, d))
-			}
-		}
 	}
 	return eventLogTmpl.Execute(w, data)
 }
 
-// RenderIndex renders the index page with device list
-// Sensor values are read from cache and updated via SSE when they change
-func RenderIndex(ctx context.Context, db DeviceRegistry, w io.Writer) error {
+// RenderIndex renders the index page.
+// Device cards are loaded separately by the client via hx-get="/htmx/devices"
+// (see HTMXHandler.DeviceCards), so this does not enumerate devices itself —
+// that work would be discarded and was the dominant cost of loading this
+// page (see #390).
+func RenderIndex(ctx context.Context, w io.Writer) error {
 	data := IndexData{
-		Devices: []DeviceView{},
 		Version: ctx.Value(global.VersionKey).(string),
-	}
-	if db != nil {
-		devices, err := db.GetAllDevices(ctx)
-		if err != nil {
-			return indexTmpl.Execute(w, data)
-		}
-		for _, d := range devices {
-			data.Devices = append(data.Devices, DeviceToView(ctx, d))
-		}
-		sort.Slice(data.Devices, func(i, j int) bool {
-			return strings.ToLower(data.Devices[i].Name) < strings.ToLower(data.Devices[j].Name)
-		})
-		applyPoolStatus(ctx, data.Devices)
 	}
 	return indexTmpl.Execute(w, data)
 }

--- a/pkg/shelly/kvs/cache.go
+++ b/pkg/shelly/kvs/cache.go
@@ -11,12 +11,19 @@ import (
 // ttl bounds staleness from KVS writes this cache doesn't observe directly
 // (a script running on the device itself, another myhome process, the Shelly
 // app). SetKeyValue/DeleteKey invalidate their key immediately, so the TTL is
-// only a safety net, not the primary invalidation path.
+// only a safety net, not the primary invalidation path. This also bounds
+// "key not found" results: a device simply not having a given KVS key
+// configured (common — not every switch has "normally-closed" set) is a
+// stable fact, not a transient failure, so it's as cachable as a real value —
+// ObserveRevision already invalidates it immediately if the key is later set.
+// Before this, a failed Get was never cached at all, so it paid a live RPC
+// round trip on every single request, forever.
 const ttl = 5 * time.Minute
 
 type cacheEntry struct {
-	value   GetResponse
-	expires time.Time
+	value    GetResponse
+	notFound bool
+	expires  time.Time
 }
 
 var (
@@ -28,20 +35,26 @@ func cacheKey(deviceId, key string) string {
 	return deviceId + "\x00" + key
 }
 
-func cacheGet(deviceId, key string) (GetResponse, bool) {
+func cacheGet(deviceId, key string) (cacheEntry, bool) {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 	e, ok := cache[cacheKey(deviceId, key)]
 	if !ok || time.Now().After(e.expires) {
-		return GetResponse{}, false
+		return cacheEntry{}, false
 	}
-	return e.value, true
+	return e, true
 }
 
 func cachePut(deviceId, key string, value GetResponse) {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 	cache[cacheKey(deviceId, key)] = cacheEntry{value: value, expires: time.Now().Add(ttl)}
+}
+
+func cachePutNotFound(deviceId, key string) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	cache[cacheKey(deviceId, key)] = cacheEntry{notFound: true, expires: time.Now().Add(ttl)}
 }
 
 func cacheInvalidate(deviceId, key string) {

--- a/pkg/shelly/kvs/main.go
+++ b/pkg/shelly/kvs/main.go
@@ -42,9 +42,13 @@ func GetManyValues(ctx context.Context, log logr.Logger, via types.Channel, devi
 }
 
 func GetValue(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, key string) (*GetResponse, error) {
-	if cached, ok := cacheGet(device.Id(), key); ok {
+	if entry, ok := cacheGet(device.Id(), key); ok {
+		if entry.notFound {
+			log.V(1).Info("KVS cache hit (not found)", "device", device.Id(), "key", key)
+			return nil, fmt.Errorf("kvs: key %q not found on device %q (cached)", key, device.Id())
+		}
 		log.V(1).Info("KVS cache hit", "device", device.Id(), "key", key)
-		res := cached
+		res := entry.value
 		return &res, nil
 	}
 
@@ -53,6 +57,7 @@ func GetValue(ctx context.Context, log logr.Logger, via types.Channel, device ty
 	})
 	if err != nil {
 		log.Info("Unable to get on key (continuing)", "key", key)
+		cachePutNotFound(device.Id(), key)
 		return nil, err
 	}
 	res, ok := out.(*GetResponse)


### PR DESCRIPTION
## Summary

Switching between the Device and Events panes in the web UI took several seconds (measured 2.5-5.9s for `/`, 1.8s for `/event-log`). Bisected the regression to #379 (a correctness fix for a device-cache dedup bug) which, by correctly stopping suppression of real devices, exposed two independent pre-existing performance bugs:

1. **`RenderIndex` (`/`) and `RenderEventLog` (`/event-log`) both built a full `[]DeviceView` list that neither template actually renders** — device cards are loaded separately via `hx-get="/htmx/devices"`. This work was entirely wasted, and done twice on every Device-pane load (once discarded in `RenderIndex`, once for real in `/htmx/devices`).
2. **`kvs.GetValue` never cached failed lookups.** Any device missing a given KVS key (e.g. `normally-closed`, which not every switch has configured) retried a live MQTT round trip on every single page render, forever — not just during startup discovery.

## Fix

- `RenderIndex`/`RenderEventLog` no longer enumerate devices (dropped the now-unused `db DeviceRegistry` parameter too).
- `kvs.GetValue` caches `"not found"` results with the same TTL as successful lookups. A missing key is a stable device fact, not a transient failure, and `ObserveRevision`'s existing external-change detection already invalidates the cache if the key is later set.

## Measured impact

Local daemon, live house MQTT broker, 33 real devices:

| | Before | After |
|---|---|---|
| `served index` (`/`) | 2.5s – 5.9s | 168µs |
| `DeviceCards` (`/htmx/devices`) | ~3.9s | ~1ms |
| `served event log` (`/event-log`) | 1.8s | 183µs |

## Test plan

- [x] `go test ./internal/myhome/ui/... ./pkg/shelly/kvs/...` passes
- [x] `go build ./...` clean at root and `myhome/` module
- [x] Verified live against the real house MQTT broker: rebuilt, restarted the daemon, re-measured pane-switch latency before and after the fix<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(ui): stop redundant device enumeration and cache failed KVS lookups ([e7c0a02](https://github.com/asnowfix/home-automation/commit/e7c0a02ba29815da3c606fb7f5f07dc6efbabbad))
<!-- END-AUTO-GENERATED-COMMITS -->