### PR TITLE
refactor(shelly): decouple pkg/shelly from app internals, clean public API (#360)

### DIFF
--- a/cmd/datacollector/main.go
+++ b/cmd/datacollector/main.go
@@ -100,15 +100,9 @@ func main() {
 		logger.Info("Testing device", "id", device.Id(), "name", device.Name())
 
 		// Create Shelly device instance
-		shellyDevice, err := shelly.NewDeviceFromSummary(ctx, logger, device)
+		sd, err := shelly.NewDeviceFromSummary(ctx, logger, device)
 		if err != nil {
 			logger.Error(err, "Failed to create Shelly device", "device_id", device.Id())
-			continue
-		}
-
-		sd, ok := shellyDevice.(*shelly.Device)
-		if !ok {
-			logger.Error(fmt.Errorf("not a Shelly device"), "Invalid device type", "device_id", device.Id())
 			continue
 		}
 

--- a/go.work
+++ b/go.work
@@ -58,6 +58,7 @@ use (
 	./pkg/shelly/sswitch
 	./pkg/shelly/system
 	./pkg/shelly/types
+	./pkg/shelly/typestest
 	./pkg/shelly/wifi
 	./pkg/tapo
 	./pkg/version

--- a/internal/myhome/device.go
+++ b/internal/myhome/device.go
@@ -155,14 +155,10 @@ func (d *Device) Refresh(ctx context.Context) (bool, error) {
 		sd, ok := d.Impl().(*shellyapi.Device)
 		if !ok || sd == nil {
 			var err error
-			device, err := shellyapi.NewDeviceFromSummary(ctx, d.log, d)
+			sd, err = shellyapi.NewDeviceFromSummary(ctx, d.log, d)
 			if err != nil {
 				d.log.Error(err, "Failed to create device from summary", "device", d.DeviceSummary)
 				return false, err
-			}
-			sd, ok = device.(*shellyapi.Device)
-			if !ok {
-				return false, fmt.Errorf("device is not a Shelly device: %T", device)
 			}
 			d.WithImpl(sd)
 		}

--- a/internal/myhome/foreach.go
+++ b/internal/myhome/foreach.go
@@ -3,7 +3,6 @@ package myhome
 import (
 	"context"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 
@@ -15,14 +14,22 @@ import (
 // The function should return a result and an error.
 // The Foreach function aggregates the results of all the function calls and returns a single result.
 // If any of the function calls return an error, the Foreach function will return that error.
-func Foreach(ctx context.Context, log logr.Logger, name string, via types.Channel, fn func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error), args []string) (any, error) {
+func Foreach(ctx context.Context, log logr.Logger, name string, via types.Channel, fn shelly.Do, args []string) (any, error) {
 	// Get a list of devices that match the given name.
-	devices, err := TheClient.LookupDevices(ctx, name)
+	found, err := TheClient.LookupDevices(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 
+	// pkg/devices.Device already satisfies shelly.Summary structurally, but
+	// Go does not implicitly convert []devices.Device to []shelly.Summary —
+	// each element must be reboxed into the interface pkg/shelly expects.
+	summaries := make([]shelly.Summary, len(*found))
+	for i, d := range *found {
+		summaries[i] = d
+	}
+
 	// Call the given function for each device in the list.
-	out, err := shelly.Foreach(ctx, log, *devices, via, fn, args)
+	out, err := shelly.Foreach(ctx, log, summaries, via, fn, args)
 	return out, err
 }

--- a/myhome/ctl/blu/follow/blu.go
+++ b/myhome/ctl/blu/follow/blu.go
@@ -13,7 +13,6 @@ import (
 	mhblu "github.com/asnowfix/home-automation/internal/myhome/blu"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -183,7 +182,7 @@ func listDevicesFollowingBlu(ctx context.Context, mac string) error {
 	kvKey := "follow/shelly-blu/" + mac
 
 	// Query all known Shelly devices using "*" wildcard
-	_, err := myhome.Foreach(ctx, log, "*", options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	_, err := myhome.Foreach(ctx, log, "*", options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 		sd, ok := device.(*shelly.Device)
 		if !ok {
 			return nil, nil // Skip non-Shelly devices
@@ -203,7 +202,7 @@ func listDevicesFollowingBlu(ctx context.Context, mac string) error {
 }
 
 // doSetKVS is a helper function for setting KVS entries on Shelly devices
-func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -215,7 +214,7 @@ func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device de
 }
 
 // doDeleteKVS is a helper function for deleting KVS entries on Shelly devices
-func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -226,7 +225,7 @@ func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device
 }
 
 // uploadScript is a helper function to upload and start scripts on Shelly devices
-func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -245,7 +244,7 @@ func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, devic
 }
 
 // deleteScript is a helper function to stop and delete scripts on Shelly devices
-func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -306,7 +305,7 @@ Examples:
 // listFollowedBluDevices lists the BLU devices followed by the specified follower device
 func listFollowedBluDevices(ctx context.Context, followerDevice string) error {
 	log := hlog.Logger
-	_, err := myhome.Foreach(ctx, log, followerDevice, options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	_, err := myhome.Foreach(ctx, log, followerDevice, options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 		sd, ok := device.(*shelly.Device)
 		if !ok {
 			return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)

--- a/myhome/ctl/blu/publish.go
+++ b/myhome/ctl/blu/publish.go
@@ -11,7 +11,6 @@ import (
 	mhblu "github.com/asnowfix/home-automation/internal/myhome/blu"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/ble"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
@@ -168,7 +167,7 @@ func listDevicesPublishingBlu(ctx context.Context, mac string) error {
 	kvKey := "publish/shelly-blu/" + mac
 
 	// Query all known Shelly devices using "*" wildcard
-	_, err := myhome.Foreach(ctx, log, "*", options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	_, err := myhome.Foreach(ctx, log, "*", options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 		sd, ok := device.(*shelly.Device)
 		if !ok {
 			return nil, nil // Skip non-Shelly devices
@@ -188,7 +187,7 @@ func listDevicesPublishingBlu(ctx context.Context, mac string) error {
 }
 
 // enableBleGateway enables the BLE observer/gateway on a Shelly device
-func enableBleGateway(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func enableBleGateway(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -217,7 +216,7 @@ func enableBleGateway(ctx context.Context, log logr.Logger, via types.Channel, d
 }
 
 // clearBluFollows deletes all publish/shelly-blu/* KVS entries to enable publish-all mode
-func clearBluFollows(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func clearBluFollows(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -251,7 +250,7 @@ func clearBluFollows(ctx context.Context, log logr.Logger, via types.Channel, de
 }
 
 // doSetKVS is a helper function for setting KVS entries on Shelly devices
-func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -263,7 +262,7 @@ func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device de
 }
 
 // doDeleteKVS is a helper function for deleting a KVS entry on Shelly devices
-func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -274,7 +273,7 @@ func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device
 }
 
 // uploadScript is a helper function to upload and start scripts on Shelly devices
-func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -293,7 +292,7 @@ func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, devic
 }
 
 // deleteScript is a helper function to stop and delete scripts on Shelly devices
-func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)

--- a/myhome/ctl/ctl.go
+++ b/myhome/ctl/ctl.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/internal/shelly/scripts"
 	"github.com/asnowfix/home-automation/myhome/ctl/blu"
 	"github.com/asnowfix/home-automation/myhome/ctl/config"
 	"github.com/asnowfix/home-automation/myhome/ctl/db"
@@ -83,7 +84,7 @@ var Cmd = &cobra.Command{
 			return err
 		}
 
-		shellyPkg.Init(log, mc, options.Flags.MqttTimeout, options.Flags.ShellyRateLimit)
+		shellyPkg.Init(log, mc, options.Flags.MqttTimeout, options.Flags.ShellyRateLimit, scripts.GetFS())
 
 		// Start cleanup goroutine that closes MQTT client when context is cancelled OR on signal
 		// This ensures cleanup happens even when command returns an error or is interrupted

--- a/myhome/ctl/garden/setup.go
+++ b/myhome/ctl/garden/setup.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
@@ -94,7 +93,7 @@ func getDeviceByAny(ctx context.Context, identifier string) (*myhome.Device, *sh
 	}
 	var sd *shelly.Device
 	var sdErr error
-	_, err = myhome.Foreach(ctx, hlog.Logger, d.Id(), types.ChannelDefault, func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+	_, err = myhome.Foreach(ctx, hlog.Logger, d.Id(), types.ChannelDefault, func(ctx context.Context, log logr.Logger, via types.Channel, dev shelly.Summary, args []string) (any, error) {
 		if s, ok := dev.(*shelly.Device); ok {
 			sd = s
 		} else {

--- a/myhome/ctl/heater/delete.go
+++ b/myhome/ctl/heater/delete.go
@@ -10,7 +10,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -31,7 +30,7 @@ var deleteCmd = &cobra.Command{
 	},
 }
 
-func doDelete(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doDelete(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/heater/setup.go
+++ b/myhome/ctl/heater/setup.go
@@ -12,7 +12,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
@@ -93,7 +92,7 @@ func init() {
 	_ = setupCmd.MarkFlagRequired("room-id")
 }
 
-func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/heater/show.go
+++ b/myhome/ctl/heater/show.go
@@ -10,7 +10,7 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
 	"github.com/asnowfix/home-automation/myhome/mqtt"
-	"github.com/asnowfix/home-automation/pkg/devices"
+	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 
 	"github.com/go-logr/logr"
@@ -38,7 +38,7 @@ func init() {
 	showCmd.Flags().DurationVar(&showFlags.Timeout, "timeout", 5*time.Second, "Query timeout")
 }
 
-func doShow(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doShow(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	// Get MQTT client
 	mc, err := mqtt.GetClientE(ctx)
 	if err != nil {

--- a/myhome/ctl/heater/status.go
+++ b/myhome/ctl/heater/status.go
@@ -10,7 +10,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
@@ -32,7 +31,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func doStatus(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doStatus(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/heater/update.go
+++ b/myhome/ctl/heater/update.go
@@ -11,7 +11,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
@@ -123,7 +122,7 @@ func init() {
 	}
 }
 
-func doUpdate(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doUpdate(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/mcp/mcp.go
+++ b/myhome/ctl/mcp/mcp.go
@@ -14,7 +14,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 )
@@ -85,7 +84,7 @@ func handleCall(ctx context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallTool
 	}
 
 	result, err := myhome.Foreach(ctx, hlog.Logger, deviceID, options.Via,
-		func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, _ []string) (any, error) {
+		func(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, _ []string) (any, error) {
 			sd, ok := device.(*shelly.Device)
 			if !ok {
 				return nil, fmt.Errorf("device is not a Shelly: %v", reflect.TypeOf(device))

--- a/myhome/ctl/pool/provider.go
+++ b/myhome/ctl/pool/provider.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 
@@ -29,7 +28,7 @@ func (p *poolProvider) GetDeviceByAny(ctx context.Context, identifier string) (*
 	// Return the first matching device
 	device := (*devices)[0]
 
-	// Convert pkg/devices.Device to myhome.Device
+	// Convert pkg/shelly.Summary to myhome.Device
 	mac := ""
 	if device.Mac() != nil {
 		mac = device.Mac().String()
@@ -54,7 +53,7 @@ func (p *poolProvider) GetShellyDevice(ctx context.Context, device *myhome.Devic
 	var shellyDevice *shelly.Device
 	var deviceErr error
 
-	_, err := myhome.Foreach(ctx, hlog.Logger, device.Id(), types.ChannelDefault, func(ctx context.Context, log logr.Logger, via types.Channel, d devices.Device, args []string) (any, error) {
+	_, err := myhome.Foreach(ctx, hlog.Logger, device.Id(), types.ChannelDefault, func(ctx context.Context, log logr.Logger, via types.Channel, d shelly.Summary, args []string) (any, error) {
 		sd, ok := d.(*shelly.Device)
 		if !ok {
 			deviceErr = fmt.Errorf("device is not a Shelly device")

--- a/myhome/ctl/shelly/call/main.go
+++ b/myhome/ctl/shelly/call/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 )
@@ -41,7 +40,7 @@ var Cmd = &cobra.Command{
 	},
 }
 
-func callOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func callOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/components/main.go
+++ b/myhome/ctl/shelly/components/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -29,7 +28,7 @@ var Cmd = &cobra.Command{
 	},
 }
 
-func doList(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doList(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/follow/shelly.go
+++ b/myhome/ctl/shelly/follow/shelly.go
@@ -11,7 +11,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -161,7 +160,7 @@ Examples:
 }
 
 // doSetKVS is a helper function for setting KVS entries on Shelly devices
-func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -173,7 +172,7 @@ func doSetKVS(ctx context.Context, log logr.Logger, via types.Channel, device de
 }
 
 // doDeleteKVS is a helper function for deleting KVS entries on Shelly devices
-func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -184,7 +183,7 @@ func doDeleteKVS(ctx context.Context, log logr.Logger, via types.Channel, device
 }
 
 // uploadScript is a helper function to upload and start scripts on Shelly devices
-func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -205,7 +204,7 @@ func uploadScript(ctx context.Context, log logr.Logger, via types.Channel, devic
 // listFollowedShellyDevices lists the Shelly devices followed by the given follower device
 func listFollowedShellyDevices(ctx context.Context, followerDevice string) error {
 	log := hlog.Logger
-	_, err := myhome.Foreach(ctx, log, followerDevice, options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+	_, err := myhome.Foreach(ctx, log, followerDevice, options.Via, func(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 		sd, ok := device.(*shelly.Device)
 		if !ok {
 			return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)
@@ -232,7 +231,7 @@ func listFollowedShellyDevices(ctx context.Context, followerDevice string) error
 }
 
 // deleteScript is a helper function to stop and delete scripts on Shelly devices
-func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func deleteScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %T %v", device, device)

--- a/myhome/ctl/shelly/jobs/cancel.go
+++ b/myhome/ctl/shelly/jobs/cancel.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/schedule"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -38,7 +37,7 @@ var cancelCtl = &cobra.Command{
 	},
 }
 
-func cancelOneDeviceJob(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func cancelOneDeviceJob(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/jobs/schedule.go
+++ b/myhome/ctl/shelly/jobs/schedule.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 )
@@ -29,7 +28,7 @@ var scheduleCtl = &cobra.Command{
 	},
 }
 
-func scheduleOneDeviceJobs(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func scheduleOneDeviceJobs(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/jobs/show.go
+++ b/myhome/ctl/shelly/jobs/show.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 )
@@ -30,7 +29,7 @@ var showCtl = &cobra.Command{
 	},
 }
 
-func showOneDeviceJobs(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func showOneDeviceJobs(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/kvs/delete.go
+++ b/myhome/ctl/shelly/kvs/delete.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -35,7 +34,7 @@ var deleteCtl = &cobra.Command{
 	},
 }
 
-func doDeleteKeys(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doDeleteKeys(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)
@@ -65,7 +64,7 @@ func doDeleteKeys(ctx context.Context, log logr.Logger, via types.Channel, devic
 	return nil, nil
 }
 
-func doDeleteKey(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, key string) (any, error) {
+func doDeleteKey(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, key string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/kvs/get.go
+++ b/myhome/ctl/shelly/kvs/get.go
@@ -11,7 +11,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -37,7 +36,7 @@ var getCtl = &cobra.Command{
 	},
 }
 
-func get(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func get(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/kvs/set.go
+++ b/myhome/ctl/shelly/kvs/set.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -35,7 +34,7 @@ var setCtl = &cobra.Command{
 	},
 }
 
-func setKeyValue(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func setKeyValue(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/mqtt/config.go
+++ b/myhome/ctl/shelly/mqtt/config.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	shellymqtt "github.com/asnowfix/home-automation/pkg/shelly/mqtt"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
@@ -37,7 +36,7 @@ var configCmd = &cobra.Command{
 	},
 }
 
-func configOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func configOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/mqtt/status.go
+++ b/myhome/ctl/shelly/mqtt/status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -35,7 +34,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func oneDeviceStatus(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceStatus(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/reboot/main.go
+++ b/myhome/ctl/shelly/reboot/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -28,7 +27,7 @@ var Cmd = &cobra.Command{
 	},
 }
 
-func oneDeviceReboot(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceReboot(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/debug.go
+++ b/myhome/ctl/shelly/script/debug.go
@@ -14,7 +14,6 @@ import (
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
 	"github.com/asnowfix/home-automation/internal/tools"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	shellyscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
@@ -36,7 +35,7 @@ var flags struct {
 	Port int
 }
 
-func doScriptDebug(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doScriptDebug(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("doScriptDebug requires [scriptName, true|false]")
 	}
@@ -207,7 +206,7 @@ var debugCtl = &cobra.Command{
 	},
 }
 
-func doDebug(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doDebug(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/enable-disable.go
+++ b/myhome/ctl/shelly/script/enable-disable.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -46,7 +45,7 @@ var disableCtl = &cobra.Command{
 	},
 }
 
-func doEnableDisable(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doEnableDisable(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/eval.go
+++ b/myhome/ctl/shelly/script/eval.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -48,7 +47,7 @@ Examples:
 	},
 }
 
-func doEval(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doEval(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/fetch.go
+++ b/myhome/ctl/shelly/script/fetch.go
@@ -10,7 +10,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -34,7 +33,7 @@ var fetchCtl = &cobra.Command{
 	},
 }
 
-func fetchFromOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func fetchFromOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)
@@ -58,7 +57,7 @@ func fetchFromOneDevice(ctx context.Context, log logr.Logger, via types.Channel,
 	}
 }
 
-func fetchOneScript(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) error {
+func fetchOneScript(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) error {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/list.go
+++ b/myhome/ctl/shelly/script/list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -48,7 +47,7 @@ var listCtl = &cobra.Command{
 	},
 }
 
-func doList(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doList(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/snapshot.go
+++ b/myhome/ctl/shelly/script/snapshot.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -53,7 +52,7 @@ with the real device after the file is written.`,
 	},
 }
 
-func doSnapshot(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, _ []string) (any, error) {
+func doSnapshot(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, _ []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/start-stop-delete.go
+++ b/myhome/ctl/shelly/script/start-stop-delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -41,7 +40,7 @@ var uploadCtl = &cobra.Command{
 var noMinify bool
 var forceUpload bool
 
-func doUpload(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doUpload(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)
@@ -124,7 +123,7 @@ var deleteCtl = &cobra.Command{
 	},
 }
 
-func doStartStopDelete(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doStartStopDelete(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/status.go
+++ b/myhome/ctl/shelly/script/status.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	myScript "github.com/asnowfix/home-automation/internal/shelly/scripts"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -32,7 +31,7 @@ var statusCtl = &cobra.Command{
 	},
 }
 
-func doStatus(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doStatus(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/script/update.go
+++ b/myhome/ctl/shelly/script/update.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/internal/myhome"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -47,7 +46,7 @@ var updateCtl = &cobra.Command{
 var updateNoMinify bool
 var updateForce bool
 
-func doUpdate(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doUpdate(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/setup/main.go
+++ b/myhome/ctl/shelly/setup/main.go
@@ -14,7 +14,6 @@ import (
 	shellysetup "github.com/asnowfix/home-automation/internal/myhome/shelly/setup"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
 	mhmqtt "github.com/asnowfix/home-automation/myhome/mqtt"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/asnowfix/home-automation/pkg/shelly/wifi"
@@ -88,7 +87,7 @@ func getSetupConfig(ctx context.Context) (shellysetup.Config, error) {
 }
 
 // doSetup performs the actual setup logic for a single device
-func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("expected *shellyapi.Device, got %T", device)

--- a/myhome/ctl/shelly/status/main.go
+++ b/myhome/ctl/shelly/status/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/sswitch"
@@ -45,7 +44,7 @@ type DeviceStatus struct {
 	Components map[string]ComponentStatus `json:"components" yaml:"components"`
 }
 
-func doStatus(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doStatus(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/sys/config.go
+++ b/myhome/ctl/shelly/sys/config.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/system"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -67,7 +66,7 @@ Examples:
 	},
 }
 
-func oneDeviceConfig(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceConfig(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/sys/reboot.go
+++ b/myhome/ctl/shelly/sys/reboot.go
@@ -8,7 +8,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -31,7 +30,7 @@ var rebootCmd = &cobra.Command{
 	},
 }
 
-func oneDeviceReboot(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceReboot(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/wifi/config.go
+++ b/myhome/ctl/shelly/wifi/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -57,7 +56,7 @@ var configCmd = &cobra.Command{
 	},
 }
 
-func configOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func configOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device shellyapi.Summary, args []string) (any, error) {
 	sd, ok := device.(*shellyapi.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/wifi/list-ap-clients.go
+++ b/myhome/ctl/shelly/wifi/list-ap-clients.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/asnowfix/home-automation/pkg/shelly/wifi"
@@ -35,7 +34,7 @@ var listApClientsCmd = &cobra.Command{
 	},
 }
 
-func oneDeviceListApClients(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceListApClients(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/wifi/scan.go
+++ b/myhome/ctl/shelly/wifi/scan.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/asnowfix/home-automation/pkg/shelly/wifi"
@@ -35,7 +34,7 @@ var scanCmd = &cobra.Command{
 	},
 }
 
-func oneDeviceScan(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceScan(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/shelly/wifi/status.go
+++ b/myhome/ctl/shelly/wifi/status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/asnowfix/home-automation/pkg/shelly/wifi"
@@ -35,7 +34,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func oneDeviceStatus(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func oneDeviceStatus(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/ctl/sswitch/main.go
+++ b/myhome/ctl/sswitch/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	shellypkg "github.com/asnowfix/home-automation/pkg/shelly/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/sswitch"
@@ -93,7 +92,7 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func doSwitchOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device devices.Device, args []string) (any, error) {
+func doSwitchOneDevice(ctx context.Context, log logr.Logger, via types.Channel, device shelly.Summary, args []string) (any, error) {
 	sd, ok := device.(*shelly.Device)
 	if !ok {
 		return nil, fmt.Errorf("device is not a Shelly: %s %v", reflect.TypeOf(device), device)

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 	myhomesfr "github.com/asnowfix/home-automation/internal/myhome/sfr"
 	shellygen2l "github.com/asnowfix/home-automation/internal/myhome/shelly/gen2"
 	"github.com/asnowfix/home-automation/internal/myhome/ui"
+	"github.com/asnowfix/home-automation/internal/shelly/scripts"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
 	"github.com/asnowfix/home-automation/myhome/devices/impl"
 	"github.com/asnowfix/home-automation/myhome/events"
@@ -161,7 +162,7 @@ func (d *daemon) Run() error {
 	}
 	defer mc.Close()
 
-	shelly.Init(log, mc, options.Flags.MqttTimeout, options.Flags.ShellyRateLimit)
+	shelly.Init(log, mc, options.Flags.MqttTimeout, options.Flags.ShellyRateLimit, scripts.GetFS())
 
 	// Start the main HTTP server (as a Mux), given to every other servers started below
 	// mux := http.NewServeMux()

--- a/myhome/daemon/pool_notices.go
+++ b/myhome/daemon/pool_notices.go
@@ -44,14 +44,9 @@ func NewPoolNotices(ctx context.Context, log logr.Logger, eventsSvc *events.Serv
 
 	log = log.WithName("PoolNotices")
 
-	d, err := shellyapi.NewDeviceFromMqttId(ctx, log, deviceID)
+	sd, err := shellyapi.NewDeviceFromMqttId(ctx, log, deviceID)
 	if err != nil {
 		log.Error(err, "Failed to create device handle, turnover notices disabled", "device_id", deviceID)
-		return nil
-	}
-	sd, ok := d.(*shellyapi.Device)
-	if !ok {
-		log.Error(fmt.Errorf("unexpected device type %T", d), "Turnover notices disabled", "device_id", deviceID)
 		return nil
 	}
 	if err := sd.Init(ctx); err != nil {

--- a/myhome/daemon/solar_automation.go
+++ b/myhome/daemon/solar_automation.go
@@ -362,13 +362,9 @@ type shellyPumpController struct {
 // lifetime of ctx (the daemon context). Must be called after shelly.Init() and
 // the MQTT client have been set up.
 func newShellyPumpController(ctx context.Context, log logr.Logger, deviceID string) (*shellyPumpController, error) {
-	d, err := shellyapi.NewDeviceFromMqttId(ctx, log, deviceID)
+	sd, err := shellyapi.NewDeviceFromMqttId(ctx, log, deviceID)
 	if err != nil {
 		return nil, fmt.Errorf("create device %s: %w", deviceID, err)
-	}
-	sd, ok := d.(*shellyapi.Device)
-	if !ok {
-		return nil, fmt.Errorf("unexpected device type %T", d)
 	}
 	if err := sd.Init(ctx); err != nil {
 		return nil, fmt.Errorf("init device %s: %w", deviceID, err)

--- a/myhome/devices/impl/manager.go
+++ b/myhome/devices/impl/manager.go
@@ -194,13 +194,10 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 		// Ensure implementation is loaded and initialized
 		sd, ok := device.Impl().(*shelly.Device)
 		if !ok || sd == nil {
-			impl, err := shelly.NewDeviceFromSummary(ctx, log, device)
+			var err error
+			sd, err = shelly.NewDeviceFromSummary(ctx, log, device)
 			if err != nil {
 				return nil, err
-			}
-			sd, ok = impl.(*shelly.Device)
-			if !ok {
-				return nil, fmt.Errorf("unexpected device implementation type: %T", impl)
 			}
 		}
 		// Initialize device (sets up MQTT channels if needed)
@@ -294,14 +291,11 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 		// Get or create Shelly device implementation
 		sd, ok := device.Impl().(*shelly.Device)
 		if !ok || sd == nil {
-			impl, err := shelly.NewDeviceFromSummary(ctx, log, device)
+			var err error
+			sd, err = shelly.NewDeviceFromSummary(ctx, log, device)
 			if err != nil {
 				log.Error(err, "Failed to create device for KVS update", "identifier", params.Identifier)
 				return nil, nil // DB update succeeded, KVS is best-effort
-			}
-			sd, ok = impl.(*shelly.Device)
-			if !ok {
-				return nil, nil
 			}
 		}
 
@@ -512,13 +506,9 @@ func (dm *DeviceManager) triggerAutoSetup(ctx context.Context, log logr.Logger, 
 	// Get the Shelly device implementation
 	sd, ok := device.Impl().(*shelly.Device)
 	if !ok {
-		d, err := shelly.NewDeviceFromSummary(ctx, log, device)
-		if err != nil || d == nil {
-			err = fmt.Errorf("cannot auto-setup: failed to create Shelly device %s", deviceId)
-			panic(err)
-		}
-		sd, ok = d.(*shelly.Device)
-		if !ok || sd == nil {
+		var err error
+		sd, err = shelly.NewDeviceFromSummary(ctx, log, device)
+		if err != nil || sd == nil {
 			err = fmt.Errorf("cannot auto-setup: failed to create Shelly device %s", deviceId)
 			panic(err)
 		}
@@ -730,13 +720,10 @@ func (dm *DeviceManager) runReconciliationLoop(ctx context.Context, interval tim
 func (dm *DeviceManager) reconcileOneDevice(ctx context.Context, log logr.Logger, device *myhome.Device) {
 	sd, ok := device.Impl().(*shelly.Device)
 	if !ok || sd == nil {
-		impl, err := shelly.NewDeviceFromSummary(ctx, log, device)
+		var err error
+		sd, err = shelly.NewDeviceFromSummary(ctx, log, device)
 		if err != nil {
 			log.Error(err, "Failed to create device for reconciliation", "device", device.Id())
-			return
-		}
-		sd, ok = impl.(*shelly.Device)
-		if !ok || sd == nil {
 			return
 		}
 	}
@@ -926,13 +913,10 @@ func classifyDoors(devices []*myhome.Device) []myhome.DoorInfo {
 func (dm *DeviceManager) GetShellyDevice(ctx context.Context, device *myhome.Device) (*shelly.Device, error) {
 	sd, ok := device.Impl().(*shelly.Device)
 	if !ok || sd == nil {
-		impl, err := shelly.NewDeviceFromSummary(ctx, dm.log, device)
+		var err error
+		sd, err = shelly.NewDeviceFromSummary(ctx, dm.log, device)
 		if err != nil {
 			return nil, err
-		}
-		sd, ok = impl.(*shelly.Device)
-		if !ok {
-			return nil, fmt.Errorf("unexpected device implementation type: %T", impl)
 		}
 	}
 	return sd, nil

--- a/pkg/shelly/device.go
+++ b/pkg/shelly/device.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	_ "github.com/asnowfix/home-automation/internal/myhome/net"
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
 	"github.com/asnowfix/home-automation/pkg/shelly/ratelimit"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
@@ -114,19 +112,61 @@ var (
 	deviceMqttRegistryMutex sync.RWMutex
 )
 
+// Summary is the minimal, serializable identity of a device — the shape a
+// caller already has on hand (e.g. a database row or an mDNS browse result)
+// before a live *Device is created for it. It deliberately excludes any
+// transport/session concern (CallE, MQTT channels, dialogs): those exist
+// only on *Device once initialized.
+//
+// Declared locally so pkg/shelly does not depend on the app's pkg/devices
+// package (see CLAUDE.md's Three-Tier Layer Rule): any type with these six
+// methods — including pkg/devices.Device — already satisfies it structurally.
+type Summary interface {
+	Manufacturer() string
+	Id() string
+	Name() string
+	Host() string
+	Ip() net.IP
+	Mac() net.HardwareAddr
+}
+
 type Device struct {
-	Id_         string              `json:"id"`
-	MacAddress_ net.HardwareAddr    `json:"-"`
-	Name_       string              `json:"name"`
-	Host_       net.IP              `json:"host"`
-	info        *shelly.DeviceInfo  `json:"-"`
-	config      *shelly.Config      `json:"-"`
-	status      *shelly.Status      `json:"-"`
-	mqtt        *DeviceMqttChannels `json:"-"` // MQTT channels (shared via registry, includes mutex for serialization)
-	dialogId    uint32              `json:"-"`
-	dialogs     sync.Map            `json:"-"` // map[uint32]bool
-	log         logr.Logger         `json:"-"`
-	modified    bool                `json:"-"`
+	id         string
+	macAddress net.HardwareAddr
+	name       string
+	host       net.IP
+	info       *shelly.DeviceInfo
+	config     *shelly.Config
+	status     *shelly.Status
+	mqtt       *DeviceMqttChannels // MQTT channels (shared via registry, includes mutex for serialization)
+	dialogId   uint32
+	dialogs    sync.Map // map[uint32]bool
+	log        logr.Logger
+	modified   bool
+}
+
+// deviceJSON is Device's wire format. Only the identity fields that were
+// historically exported (as Id_, Name_, Host_) round-trip; the MAC address
+// was already excluded from JSON, and the transport/cache fields never were.
+type deviceJSON struct {
+	Id   string `json:"id"`
+	Name string `json:"name"`
+	Host net.IP `json:"host"`
+}
+
+func (d *Device) MarshalJSON() ([]byte, error) {
+	return json.Marshal(deviceJSON{Id: d.id, Name: d.name, Host: d.host})
+}
+
+func (d *Device) UnmarshalJSON(data []byte) error {
+	var dto deviceJSON
+	if err := json.Unmarshal(data, &dto); err != nil {
+		return err
+	}
+	d.id = dto.Id
+	d.name = dto.Name
+	d.host = dto.Host
+	return nil
 }
 
 func (d *Device) Refresh(ctx context.Context, via types.Channel) (bool, error) {
@@ -212,10 +252,10 @@ func (d *Device) Manufacturer() string {
 }
 
 func (d *Device) Id() string {
-	if d.Id_ == "" || d.Id_ == "<nil>" {
+	if d.id == "" || d.id == "<nil>" {
 		return ""
 	}
-	return d.Id_
+	return d.id
 }
 
 func (d *Device) UpdateId(id string) {
@@ -223,19 +263,19 @@ func (d *Device) UpdateId(id string) {
 	if id == "" || id == "<nil>" || !deviceIdRe.MatchString(id) {
 		panic("invalid device id: " + id)
 	}
-	if d.Id_ == id {
+	if d.id == id {
 		return
 	}
-	d.Id_ = id
+	d.id = id
 	d.modified = true
 }
 
 func (d *Device) Host() string {
 
-	if d.Host_ == nil {
+	if d.host == nil {
 		return ""
 	}
-	return d.Host_.String()
+	return d.host.String()
 }
 
 func (d *Device) UpdateHost(host string) {
@@ -246,16 +286,16 @@ func (d *Device) UpdateHost(host string) {
 	if ip == nil {
 		return
 	}
-	if !ip.Equal(d.Host_) {
+	if !ip.Equal(d.host) {
 		d.modified = true
-		d.Host_ = ip
+		d.host = ip
 	}
 }
 
 func (d *Device) ClearHost() {
-	if d.Host_ != nil {
+	if d.host != nil {
 		d.modified = true
-		d.Host_ = nil
+		d.host = nil
 		d.log.Info("Cleared device host (HTTP channel will become not ready)", "device_id", d.Id())
 	}
 }
@@ -263,35 +303,35 @@ func (d *Device) ClearHost() {
 func (d *Device) Ip() net.IP {
 	if d.status != nil {
 		if d.status.Ethernet != nil {
-			d.Host_ = net.ParseIP(d.status.Ethernet.IP)
+			d.host = net.ParseIP(d.status.Ethernet.IP)
 		} else if d.status.Wifi != nil {
-			d.Host_ = net.ParseIP(d.status.Wifi.IP)
+			d.host = net.ParseIP(d.status.Wifi.IP)
 		}
 	}
-	return d.Host_
+	return d.host
 }
 
 func (d *Device) Name() string {
-	if d.Name_ == "" || d.Name_ == "<nil>" {
+	if d.name == "" || d.name == "<nil>" {
 		return ""
 	}
-	return d.Name_
+	return d.name
 }
 
 func (d *Device) UpdateName(name string) {
-	if name == "" || name == "<nil>" || name == d.Name_ {
+	if name == "" || name == "<nil>" || name == d.name {
 		return
 	}
-	d.Name_ = name
+	d.name = name
 	d.modified = true
 }
 
 func (d *Device) Mac() net.HardwareAddr {
-	return d.MacAddress_
+	return d.macAddress
 }
 
 func (d *Device) UpdateMac(mac string) {
-	if mac == d.MacAddress_.String() {
+	if mac == d.macAddress.String() {
 		return
 	}
 	if mac == "" || mac == "<nil>" {
@@ -305,7 +345,7 @@ func (d *Device) UpdateMac(mac string) {
 			d.log.Error(err, "Failed to parse MAC address", "mac", mac)
 			return
 		}
-		d.MacAddress_ = addr
+		d.macAddress = addr
 	}
 	d.modified = true
 }
@@ -548,10 +588,10 @@ func (d *Device) ReplyTo() string {
 	return d.mqtt.ReplyTo
 }
 
-func NewDeviceFromIp(ctx context.Context, log logr.Logger, ip net.IP) (devices.Device, error) {
+func NewDeviceFromIp(ctx context.Context, log logr.Logger, ip net.IP) (*Device, error) {
 	d := &Device{
-		Host_: ip,
-		log:   log,
+		host: ip,
+		log:  log,
 	}
 	err := d.init(ctx)
 	if err != nil {
@@ -585,7 +625,7 @@ func MacFromShellyID(id string) net.HardwareAddr {
 	return mac
 }
 
-func NewDeviceFromMqttId(ctx context.Context, log logr.Logger, id string) (devices.Device, error) {
+func NewDeviceFromMqttId(ctx context.Context, log logr.Logger, id string) (*Device, error) {
 	if id == "" || id == "<nil>" {
 		return nil, fmt.Errorf("invalid device id: %s", id)
 	}
@@ -599,7 +639,7 @@ func NewDeviceFromMqttId(ctx context.Context, log logr.Logger, id string) (devic
 	return d, nil
 }
 
-func NewDeviceFromSummary(ctx context.Context, log logr.Logger, summary devices.Device) (devices.Device, error) {
+func NewDeviceFromSummary(ctx context.Context, log logr.Logger, summary Summary) (*Device, error) {
 	if summary.Id() == "" {
 		return nil, fmt.Errorf("device summary has empty ID (name=%q, host=%q)", summary.Name(), summary.Host())
 	}
@@ -664,7 +704,7 @@ func (d *Device) initMqtt(ctx context.Context) error {
 	var err error
 	d.mqtt, err = d.mqtt.Init(ctx, d.Id())
 	if err != nil {
-		d.log.Error(err, "Unable to init MQTT channels", "device_id", d.Id_)
+		d.log.Error(err, "Unable to init MQTT channels", "device_id", d.id)
 		return err
 	}
 
@@ -730,7 +770,7 @@ func (d *Device) initDeviceInfo(ctx context.Context, via types.Channel) error {
 // 	return nil
 // }
 
-type Do func(context.Context, logr.Logger, types.Channel, devices.Device, []string) (any, error)
+type Do func(context.Context, logr.Logger, types.Channel, Summary, []string) (any, error)
 
 func Print(log logr.Logger, d any) error {
 	buf, err := json.Marshal(d)
@@ -744,12 +784,12 @@ func Print(log logr.Logger, d any) error {
 
 // DeviceResult represents the result of an operation on a single device
 type DeviceResult struct {
-	Device devices.Device
+	Device Summary
 	Result any
 	Error  error
 }
 
-func Foreach(ctx context.Context, log logr.Logger, deviceList []devices.Device, via types.Channel, do Do, args []string) (any, error) {
+func Foreach(ctx context.Context, log logr.Logger, deviceList []Summary, via types.Channel, do Do, args []string) (any, error) {
 	log.Info("Running", "func_type", reflect.TypeOf(do), "args", args, "nb_devices", len(deviceList))
 
 	// Create channels for results
@@ -759,7 +799,7 @@ func Foreach(ctx context.Context, log logr.Logger, deviceList []devices.Device, 
 	// Process each device in parallel
 	for _, dev := range deviceList {
 		wg.Add(1)
-		go func(devSummary devices.Device) {
+		go func(devSummary Summary) {
 			defer wg.Done()
 
 			// Skip devices whose ID is not yet known (partially discovered)
@@ -792,14 +832,7 @@ func Foreach(ctx context.Context, log logr.Logger, deviceList []devices.Device, 
 			}
 
 			// Initialize device
-			sd, ok := device.(*Device)
-			if !ok {
-				err := fmt.Errorf("invalid device type %T", device)
-				log.Error(nil, "Invalid device type", "type", reflect.TypeOf(device))
-				results <- DeviceResult{Device: devSummary, Error: err}
-				return
-			}
-			err = sd.init(ctx)
+			err = device.init(ctx)
 			if err != nil {
 				log.Error(err, "Unable to init device", "device", device)
 				results <- DeviceResult{Device: devSummary, Error: err}

--- a/pkg/shelly/device_test.go
+++ b/pkg/shelly/device_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/go-logr/logr"
 )
@@ -18,7 +17,7 @@ func (f fakeResolverFunc) ResolveHost(ctx context.Context, mac net.HardwareAddr,
 	return f(ctx, mac, name)
 }
 
-// stubDevice is a minimal devices.Device for tests.
+// stubDevice is a minimal Summary for tests.
 type stubDevice struct {
 	id   string
 	name string
@@ -51,12 +50,12 @@ func TestNewDeviceFromSummary_ValidId_Succeeds(t *testing.T) {
 
 func TestForeach_SkipsEmptyIdDevice(t *testing.T) {
 	called := false
-	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev Summary, args []string) (any, error) {
 		called = true
 		return nil, nil
 	}
 
-	deviceList := []devices.Device{
+	deviceList := []Summary{
 		stubDevice{id: "", name: "partial", host: "192.168.1.10"},
 	}
 
@@ -71,12 +70,12 @@ func TestForeach_SkipsEmptyIdDevice(t *testing.T) {
 
 func TestForeach_SkipsGen1Device(t *testing.T) {
 	called := false
-	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev Summary, args []string) (any, error) {
 		called = true
 		return nil, nil
 	}
 
-	deviceList := []devices.Device{
+	deviceList := []Summary{
 		stubDevice{id: "shellyht-aabbccddeeff"},
 	}
 
@@ -91,12 +90,12 @@ func TestForeach_SkipsGen1Device(t *testing.T) {
 
 func TestForeach_SkipsBluDevice(t *testing.T) {
 	called := false
-	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev Summary, args []string) (any, error) {
 		called = true
 		return nil, nil
 	}
 
-	deviceList := []devices.Device{
+	deviceList := []Summary{
 		stubDevice{id: "shellybluht3-aabbccddeeff"},
 	}
 
@@ -110,7 +109,7 @@ func TestForeach_SkipsBluDevice(t *testing.T) {
 }
 
 func TestForeach_EmptyList(t *testing.T) {
-	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev devices.Device, args []string) (any, error) {
+	do := func(ctx context.Context, log logr.Logger, via types.Channel, dev Summary, args []string) (any, error) {
 		return nil, nil
 	}
 	_, err := Foreach(context.Background(), logr.Discard(), nil, types.ChannelDefault, do, nil)
@@ -213,7 +212,7 @@ func TestChannel_ResolvesHostWhenNeitherMqttNorHttpReady(t *testing.T) {
 		return nil, errors.New("not found")
 	}))
 
-	d := &Device{Id_: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
+	d := &Device{id: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
 
 	got := d.Channel(context.Background(), types.ChannelDefault)
 	if got != types.ChannelHttp {
@@ -228,7 +227,7 @@ func TestChannel_NoResolverStaysDiscarded(t *testing.T) {
 	t.Cleanup(func() { types.SetHostResolver(nil) })
 	types.SetHostResolver(nil)
 
-	d := &Device{Id_: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
+	d := &Device{id: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
 
 	got := d.Channel(context.Background(), types.ChannelDefault)
 	if got != types.ChannelDefault {
@@ -244,7 +243,7 @@ func TestChannel_MqttReadyDoesNotCallResolver(t *testing.T) {
 		return net.ParseIP("192.168.1.1"), nil
 	}))
 
-	d := &Device{Id_: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
+	d := &Device{id: "shellyplus1pm-aabbccddeeff", log: logr.Discard()}
 	d.mqtt = &DeviceMqttChannels{ReplyTo: "x", To: make(chan []byte, 1), From: make(chan []byte, 1)}
 
 	got := d.Channel(context.Background(), types.ChannelDefault)

--- a/pkg/shelly/ethernet/ops_test.go
+++ b/pkg/shelly/ethernet/ops_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 )
 
 func TestGetConfig(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Config{Enable: true, Ip: "192.168.1.20"}
 		d.SetResult(getConfig.String(), want)
 
@@ -24,7 +25,7 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("eth config unavailable")
 		d.SetError(getConfig.String(), wantErr)
 
@@ -36,7 +37,7 @@ func TestGetConfig(t *testing.T) {
 }
 
 func TestSetConfig(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(setConfig.String(), &SetConfigResponse{Success: true})
 
 	err := SetConfig(context.Background(), d, types.ChannelDefault, &Config{Enable: true})
@@ -49,7 +50,7 @@ func TestSetConfig(t *testing.T) {
 }
 
 func TestSetConfig_DeviceError(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	wantErr := errors.New("eth set config failed")
 	d.SetError(setConfig.String(), wantErr)
 
@@ -60,7 +61,7 @@ func TestSetConfig_DeviceError(t *testing.T) {
 }
 
 func TestGetStatus(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &Status{IP: "192.168.1.20"}
 	d.SetResult(getStatus.String(), want)
 
@@ -75,7 +76,7 @@ func TestGetStatus(t *testing.T) {
 
 func TestDoGetStatus(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Status{IP: "192.168.1.20"}
 		d.SetResult(getStatus.String(), want)
 
@@ -89,7 +90,7 @@ func TestDoGetStatus(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("eth status unavailable")
 		d.SetError(getStatus.String(), wantErr)
 

--- a/pkg/shelly/kvs/main_test.go
+++ b/pkg/shelly/kvs/main_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 	"github.com/go-logr/logr"
 )
 
 func TestGetValue(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &GetResponse{Value: "17"}
 		d.SetResult(string(Get), want)
 
@@ -29,7 +30,7 @@ func TestGetValue(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("kvs unreachable")
 		d.SetError(string(Get), wantErr)
 
@@ -40,7 +41,7 @@ func TestGetValue(t *testing.T) {
 	})
 
 	t.Run("unexpected result type", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(string(Get), "not-a-response")
 
 		_, err := GetValue(context.Background(), logr.Discard(), types.ChannelDefault, d, "key")
@@ -51,7 +52,7 @@ func TestGetValue(t *testing.T) {
 }
 
 func TestSetKeyValue(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &Status{}
 	d.SetResult(string(Set), want)
 
@@ -69,7 +70,7 @@ func TestSetKeyValue(t *testing.T) {
 }
 
 func TestListKeys(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &ListResponse{Keys: map[string]Status{"a": {}}}
 	d.SetResult(string(List), want)
 
@@ -87,7 +88,7 @@ func TestListKeys(t *testing.T) {
 }
 
 func TestGetManyValues(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &GetManyResponse{Items: FlexibleMap{"a": "1"}}
 	d.SetResult(string(GetMany), want)
 
@@ -101,7 +102,7 @@ func TestGetManyValues(t *testing.T) {
 }
 
 func TestDeleteKey(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &Status{}
 	d.SetResult(string(Delete), want)
 

--- a/pkg/shelly/mdns.go
+++ b/pkg/shelly/mdns.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly/shelly"
 
 	"github.com/go-logr/logr"
@@ -16,7 +16,16 @@ import (
 
 const MDNS_SHELLIES string = "_shelly._tcp."
 
-func NewDeviceFromZeroConfEntry(ctx context.Context, log logr.Logger, resolver devices.Resolver, entry *zeroconf.ServiceEntry) (devices.Device, error) {
+// Resolver is the narrow lookup surface NewDeviceFromZeroConfEntry accepts —
+// declared locally so pkg/shelly does not depend on the app's pkg/devices
+// package (see CLAUDE.md's Three-Tier Layer Rule). Any type satisfying these
+// two methods, including pkg/devices.Resolver, already implements it.
+type Resolver interface {
+	LookupHost(ctx context.Context, log logr.Logger, host string) (ips []net.IP, err error)
+	LookupService(ctx context.Context, service string) (*url.URL, error)
+}
+
+func NewDeviceFromZeroConfEntry(ctx context.Context, log logr.Logger, resolver Resolver, entry *zeroconf.ServiceEntry) (*Device, error) {
 	s, _ := json.Marshal(entry)
 	log.V(1).Info("Found", "entry", s)
 
@@ -44,8 +53,8 @@ func NewDeviceFromZeroConfEntry(ctx context.Context, log logr.Logger, resolver d
 	}
 
 	d := &Device{
-		Id_:   deviceId,
-		Name_: entry.Instance,
+		id:   deviceId,
+		name: entry.Instance,
 		info: &shelly.DeviceInfo{
 			Id: deviceId,
 			Product: shelly.Product{

--- a/pkg/shelly/ops.go
+++ b/pkg/shelly/ops.go
@@ -2,10 +2,10 @@ package shelly
 
 import (
 	"context"
+	"io/fs"
 	"reflect"
 	"time"
 
-	scripts "github.com/asnowfix/home-automation/internal/shelly/scripts"
 	"github.com/asnowfix/home-automation/pkg/shelly/ble"
 	"github.com/asnowfix/home-automation/pkg/shelly/ethernet"
 	"github.com/asnowfix/home-automation/pkg/shelly/input"
@@ -27,7 +27,14 @@ import (
 
 type empty struct{}
 
-func Init(log logr.Logger, mc mqtt.Client, timeout time.Duration, rateLimitInterval time.Duration) {
+// Init wires up every Shelly RPC sub-API (switches, KVS, scripts, WiFi,
+// etc.) against registrar and mc. scriptsFS, if non-nil, is an embedded
+// filesystem of house-specific automation scripts (garden, pool-pump,
+// front-door…) that script.Init uses for version tracking; callers outside
+// home-automation can pass nil to disable that feature entirely — pkg/shelly
+// itself must not embed any one house's scripts (see CLAUDE.md's Three-Tier
+// Layer Rule).
+func Init(log logr.Logger, mc mqtt.Client, timeout time.Duration, rateLimitInterval time.Duration, scriptsFS fs.FS) {
 	log.Info("Init", "package", reflect.TypeOf(empty{}).PkgPath(), "rateLimit", rateLimitInterval)
 	registrar.Init(log)
 
@@ -44,7 +51,7 @@ func Init(log logr.Logger, mc mqtt.Client, timeout time.Duration, rateLimitInter
 	matter.Init(log, &registrar)
 	mqtt.Init(log, &registrar, mc, timeout)
 	schedule.Init(log, &registrar)
-	script.Init(log, &registrar, scripts.GetFS())
+	script.Init(log, &registrar, scriptsFS)
 	shttp.Init(log, &registrar)
 	sswitch.Init(log, &registrar)
 	system.Init(log, &registrar)

--- a/pkg/shelly/schedule/main_test.go
+++ b/pkg/shelly/schedule/main_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 	"github.com/go-logr/logr"
 )
 
 func TestShowJobs(t *testing.T) {
 	t.Run("happy path returns Scheduled", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Scheduled{Jobs: []Job{{JobId: JobId{Id: 1}}}}
 		d.SetResult(string(List), want)
 
@@ -28,7 +29,7 @@ func TestShowJobs(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("device unreachable")
 		d.SetError(string(List), wantErr)
 
@@ -40,7 +41,7 @@ func TestShowJobs(t *testing.T) {
 }
 
 func TestCancelJob(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(string(List), &Scheduled{Jobs: []Job{{JobId: JobId{Id: 42}}}})
 	d.SetResult(string(Delete), &JobId{Id: 42})
 
@@ -66,7 +67,7 @@ func TestCancelJob(t *testing.T) {
 }
 
 func TestCancelJob_NoMatchingJob_NoDeleteCall(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(string(List), &Scheduled{Jobs: []Job{{JobId: JobId{Id: 99}}}})
 
 	_, err := CancelJob(context.Background(), logr.Discard(), types.ChannelDefault, d, 42)
@@ -81,7 +82,7 @@ func TestCancelJob_NoMatchingJob_NoDeleteCall(t *testing.T) {
 }
 
 func TestCancelAllJobs(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(string(DeleteAll), nil)
 	d.SetResult(string(List), &Scheduled{})
 
@@ -95,7 +96,7 @@ func TestCancelAllJobs(t *testing.T) {
 }
 
 func TestCancelAllJobs_DeleteAllError(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	wantErr := errors.New("delete-all failed")
 	d.SetError(string(DeleteAll), wantErr)
 

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
@@ -1176,8 +1177,10 @@ type timerHandler struct {
 	timer     *time.Timer
 	startTime time.Time
 	nextFire  time.Time
-	stopped   bool
-	ch        chan []byte // cached channel, created once in Wait()
+	// stopped is read by the timer goroutines in Wait() while Stop() sets it
+	// from the VM goroutine, so it must be atomic.
+	stopped atomic.Bool
+	ch      chan []byte // cached channel, created once in Wait()
 }
 
 func (th *timerHandler) Wait() <-chan []byte {
@@ -1194,7 +1197,7 @@ func (th *timerHandler) Wait() <-chan []byte {
 		th.nextFire = time.Now().Add(th.period)
 		go func() {
 			for range th.ticker.C {
-				if th.stopped {
+				if th.stopped.Load() {
 					break
 				}
 				th.nextFire = time.Now().Add(th.period)
@@ -1213,7 +1216,7 @@ func (th *timerHandler) Wait() <-chan []byte {
 		th.nextFire = time.Now().Add(period)
 		go func() {
 			<-th.timer.C
-			if !th.stopped {
+			if !th.stopped.Load() {
 				th.ch <- []byte{} // Signal to fire callback
 			}
 			close(th.ch)
@@ -1242,7 +1245,7 @@ func (th *timerHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byte
 }
 
 func (th *timerHandler) Stop() {
-	th.stopped = true
+	th.stopped.Store(true)
 	if th.ticker != nil {
 		th.ticker.Stop()
 	}

--- a/pkg/shelly/shelly.go
+++ b/pkg/shelly/shelly.go
@@ -1,9 +1,8 @@
 package shelly
 
 import (
+	"encoding/json"
 	"net"
-
-	"github.com/asnowfix/home-automation/pkg/devices"
 )
 
 // func Devices(ctx context.Context, log logr.Logger, devices []devices.Device) []*Device {
@@ -41,7 +40,20 @@ func (d ShellyDevice) Online() bool {
 }
 
 func (d ShellyDevice) MarshalJSON() ([]byte, error) {
-	return devices.MarshalJSON(d)
+	type marshallableDevice struct {
+		Id   string           `json:"id"`
+		Name string           `json:"name"`
+		Host string           `json:"host"`
+		Ip   net.IP           `json:"ip"`
+		Mac  net.HardwareAddr `json:"mac"`
+	}
+	return json.Marshal(marshallableDevice{
+		Id:   d.Id(),
+		Name: d.Name(),
+		Host: d.Host(),
+		Ip:   d.Ip(),
+		Mac:  d.Mac(),
+	})
 }
 
 func (d ShellyDevice) Manufacturer() string {

--- a/pkg/shelly/shelly/ops_test.go
+++ b/pkg/shelly/shelly/ops_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/asnowfix/home-automation/pkg/shelly/sswitch"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 	"github.com/go-logr/logr"
 )
 
 func TestDoGetComponents(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &ComponentsResponse{Total: 1}
 		d.SetResult(GetComponents.String(), want)
 
@@ -26,7 +27,7 @@ func TestDoGetComponents(t *testing.T) {
 	})
 
 	t.Run("zero total is an error", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(GetComponents.String(), &ComponentsResponse{Total: 0})
 
 		_, err := DoGetComponents(context.Background(), d, &ComponentsRequest{})
@@ -36,7 +37,7 @@ func TestDoGetComponents(t *testing.T) {
 	})
 
 	t.Run("nil reply is an error", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(GetComponents.String(), nil)
 
 		_, err := DoGetComponents(context.Background(), d, &ComponentsRequest{})
@@ -46,7 +47,7 @@ func TestDoGetComponents(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("components unavailable")
 		d.SetError(GetComponents.String(), wantErr)
 
@@ -58,7 +59,7 @@ func TestDoGetComponents(t *testing.T) {
 }
 
 func TestDoCheckForUpdate(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &CheckForUpdateResponse{}
 	d.SetResult(CheckForUpdate.String(), want)
 
@@ -72,7 +73,7 @@ func TestDoCheckForUpdate(t *testing.T) {
 }
 
 func TestDoUpdate(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(Update.String(), nil)
 
 	err := DoUpdate(context.Background(), types.ChannelDefault, d, "beta")
@@ -86,7 +87,7 @@ func TestDoUpdate(t *testing.T) {
 }
 
 func TestDoReboot(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(Reboot.String(), nil)
 
 	if err := DoReboot(context.Background(), d); err != nil {
@@ -99,7 +100,7 @@ func TestDoReboot(t *testing.T) {
 
 func TestGetDeviceInfo(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &DeviceInfo{Id: "shellyplus1-abc", Product: Product{MacAddress: "AA:BB:CC:DD:EE:FF"}}
 		d.SetResult(getDeviceInfo.String(), want)
 
@@ -113,7 +114,7 @@ func TestGetDeviceInfo(t *testing.T) {
 	})
 
 	t.Run("missing id and mac is an error", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(getDeviceInfo.String(), &DeviceInfo{})
 
 		_, err := GetDeviceInfo(context.Background(), d, types.ChannelDefault)
@@ -124,7 +125,7 @@ func TestGetDeviceInfo(t *testing.T) {
 }
 
 func TestGetSwitchesSummary(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(GetComponents.String(), &ComponentsResponse{
 		Total: 1,
 		Config: Config{
@@ -150,7 +151,7 @@ func TestGetSwitchesSummary(t *testing.T) {
 }
 
 func TestGetSwitchesSummary_UnnamedSwitchDefaultsName(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	d.SetResult(GetComponents.String(), &ComponentsResponse{
 		Total: 1,
 		Config: Config{

--- a/pkg/shelly/shttp/channel_test.go
+++ b/pkg/shelly/shttp/channel_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 
 	"github.com/go-logr/logr"
 )
@@ -35,7 +36,7 @@ func TestCallE_SucceedsWithoutResolution(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	device := types.NewFakeDevice()
+	device := typestest.NewFakeDevice()
 	device.IdValue = "shellyplus1pm-aabbccddeeff"
 	device.HostValue = srv.Listener.Addr().String()
 
@@ -64,7 +65,7 @@ func TestCallE_RetriesOnceAfterReResolution(t *testing.T) {
 		return net.ParseIP("127.0.0.1"), nil
 	}))
 
-	device := types.NewFakeDevice()
+	device := typestest.NewFakeDevice()
 	device.IdValue = "shellyplus1pm-aabbccddeeff"
 	// Port 1 is reserved/unassigned: connection is refused immediately on
 	// both the first attempt and the retry (the resolver only returns a bare
@@ -95,7 +96,7 @@ func TestCallE_NoResolverClearsHostOnFailure(t *testing.T) {
 	t.Cleanup(func() { types.SetHostResolver(nil) })
 	types.SetHostResolver(nil)
 
-	device := types.NewFakeDevice()
+	device := typestest.NewFakeDevice()
 	device.IdValue = "shellyplus1pm-aabbccddeeff"
 	device.HostValue = "127.0.0.1:1"
 

--- a/pkg/shelly/system/ops_test.go
+++ b/pkg/shelly/system/ops_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 )
 
 func TestGetConfig(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Config{ConfigRevision: 7}
 		d.SetResult(getConfig.String(), want)
 
@@ -24,7 +25,7 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("sys config unavailable")
 		d.SetError(getConfig.String(), wantErr)
 
@@ -35,7 +36,7 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("RpcUdp with empty destination address is normalized to nil", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		cfg := &Config{
 			RpcUdp: &struct {
 				DestinationAddress string `json:"dst_addr"`
@@ -54,7 +55,7 @@ func TestGetConfig(t *testing.T) {
 	})
 
 	t.Run("RpcUdp with a real destination address is preserved", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		cfg := &Config{
 			RpcUdp: &struct {
 				DestinationAddress string `json:"dst_addr"`
@@ -74,7 +75,7 @@ func TestGetConfig(t *testing.T) {
 }
 
 func TestSetConfig(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &SetConfigResponse{RestartRequired: true}
 	d.SetResult(setConfig.String(), want)
 
@@ -93,7 +94,7 @@ func TestSetConfig(t *testing.T) {
 
 func TestGetStatus(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Status{UpTime: 100}
 		d.SetResult(getStatus.String(), want)
 
@@ -107,7 +108,7 @@ func TestGetStatus(t *testing.T) {
 	})
 
 	t.Run("unexpected result type", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(getStatus.String(), "not-a-status")
 
 		_, err := GetStatus(context.Background(), types.ChannelDefault, d)

--- a/pkg/shelly/types/types.go
+++ b/pkg/shelly/types/types.go
@@ -143,30 +143,41 @@ const (
 	None
 )
 
+// apiNames maps each Api constant to its display name. Unlike a positional
+// array literal, this can't silently desynchronize when a new Api is
+// inserted in the const block above: every entry is keyed by the constant
+// itself, so it tracks wherever that constant's iota value ends up. See
+// TestApiString_AllConstantsNamed, which fails loudly if a constant is added
+// here without a matching entry.
+var apiNames = map[Api]string{
+	Shelly:             "Shelly",
+	Schedule:           "Schedule",
+	Webhook:            "Webhook",
+	HTTP:               "HTTP",
+	KVS:                "KVS",
+	System:             "System",
+	WiFi:               "WiFi",
+	Ethernet:           "Ethernet",
+	BluetoothLowEnergy: "BluetoothLowEnergy",
+	Cloud:              "Cloud",
+	Mqtt:               "Mqtt",
+	OutboundWebsocket:  "OutboundWebsocket",
+	Script:             "Script",
+	Input:              "Input",
+	Modbus:             "Modbus",
+	Voltmeter:          "Voltmeter",
+	Cover:              "Cover",
+	Switch:             "Switch",
+	Light:              "Light",
+	DevicePower:        "DevicePower",
+	Humidity:           "Humidity",
+	Temperature:        "Temperature",
+	None:               "None",
+}
+
 func (api Api) String() string {
-	return [...]string{
-		"Shelly",
-		"Schedule",
-		"Webhook",
-		"HTTP",
-		"KVS",
-		"System",
-		"WiFi",
-		"Ethernet",
-		"BluetoothLowEnergy",
-		"Cloud",
-		"Mqtt",
-		"OutboundWebsocket",
-		"Script",
-		"Input",
-		"Modbus",
-		"Voltmeter",
-		"Cover",
-		"Switch",
-		"Light",
-		"DevicePower",
-		"Humidity",
-		"Temperature",
-		"None",
-	}[api]
+	if name, ok := apiNames[api]; ok {
+		return name
+	}
+	return fmt.Sprintf("Api(%d)", uint32(api))
 }

--- a/pkg/shelly/types/types_test.go
+++ b/pkg/shelly/types/types_test.go
@@ -1,0 +1,60 @@
+package types
+
+import "testing"
+
+// TestApiString_AllConstantsNamed guards against the exact failure mode a
+// positional []string{...} literal has: a new Api constant inserted into the
+// iota block above without a corresponding apiNames entry. Since apiNames is
+// keyed by the constants themselves, this only fails if a constant's entry
+// is missing outright — never from a silent reordering.
+func TestApiString_AllConstantsNamed(t *testing.T) {
+	all := []Api{
+		Shelly,
+		Schedule,
+		Webhook,
+		HTTP,
+		KVS,
+		System,
+		WiFi,
+		Ethernet,
+		BluetoothLowEnergy,
+		Cloud,
+		Mqtt,
+		OutboundWebsocket,
+		Script,
+		Input,
+		Modbus,
+		Voltmeter,
+		Cover,
+		Switch,
+		Light,
+		DevicePower,
+		Humidity,
+		Temperature,
+		None,
+	}
+
+	if got, want := len(apiNames), len(all); got != want {
+		t.Errorf("apiNames has %d entries, expected exactly %d (one per Api constant) — a constant was added/removed without updating apiNames", got, want)
+	}
+
+	seen := make(map[Api]bool, len(all))
+	for _, api := range all {
+		if seen[api] {
+			t.Errorf("Api constant %d listed twice in this test's all slice", api)
+		}
+		seen[api] = true
+
+		name, ok := apiNames[api]
+		if !ok || name == "" {
+			t.Errorf("Api constant %d (%q via String()) has no entry in apiNames", api, api.String())
+		}
+	}
+}
+
+func TestApiString_UnknownValueDoesNotPanic(t *testing.T) {
+	unknown := Api(9999)
+	if got, want := unknown.String(), "Api(9999)"; got != want {
+		t.Errorf("String() for unknown Api = %q, want %q", got, want)
+	}
+}

--- a/pkg/shelly/typestest/fake_device.go
+++ b/pkg/shelly/typestest/fake_device.go
@@ -1,14 +1,20 @@
-package types
+// Package typestest provides test doubles for pkg/shelly/types, following
+// the stdlib convention of a separate "test support" package (cf.
+// net/http/httptest) rather than shipping test-only code in the production
+// types package.
+package typestest
 
 import (
 	"context"
 	"fmt"
 	"net"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/types"
 )
 
 // FakeDeviceCall records a single CallE invocation made against a FakeDevice.
 type FakeDeviceCall struct {
-	Via    Channel
+	Via    types.Channel
 	Method string
 	Params any
 }
@@ -56,7 +62,7 @@ func (f *FakeDevice) SetError(method string, err error) {
 // CallE implements Device. It records the call and returns whatever was
 // configured via SetResult/SetError; if nothing was configured for method it
 // returns an error naming the unconfigured method.
-func (f *FakeDevice) CallE(ctx context.Context, via Channel, method string, params any) (any, error) {
+func (f *FakeDevice) CallE(ctx context.Context, via types.Channel, method string, params any) (any, error) {
 	f.Calls = append(f.Calls, FakeDeviceCall{Via: via, Method: method, Params: params})
 	if err, ok := f.errs[method]; ok {
 		return nil, err
@@ -80,9 +86,9 @@ func (f *FakeDevice) From() <-chan []byte   { return nil }
 func (f *FakeDevice) StartDialog(ctx context.Context) uint32    { return 0 }
 func (f *FakeDevice) StopDialog(ctx context.Context, id uint32) {}
 
-func (f *FakeDevice) IsHttpReady() bool                                { return true }
-func (f *FakeDevice) IsMqttReady() bool                                { return true }
-func (f *FakeDevice) Channel(ctx context.Context, via Channel) Channel { return via }
+func (f *FakeDevice) IsHttpReady() bool                                            { return true }
+func (f *FakeDevice) IsMqttReady() bool                                            { return true }
+func (f *FakeDevice) Channel(ctx context.Context, via types.Channel) types.Channel { return via }
 
 func (f *FakeDevice) UpdateName(name string) { f.NameValue = name }
 func (f *FakeDevice) UpdateHost(host string) { f.HostValue = host }
@@ -93,4 +99,4 @@ func (f *FakeDevice) UpdateId(id string)     { f.IdValue = id }
 func (f *FakeDevice) IsModified() bool { return false }
 func (f *FakeDevice) ResetModified()   {}
 
-var _ Device = (*FakeDevice)(nil)
+var _ types.Device = (*FakeDevice)(nil)

--- a/pkg/shelly/typestest/go.mod
+++ b/pkg/shelly/typestest/go.mod
@@ -1,0 +1,3 @@
+module github.com/asnowfix/home-automation/pkg/shelly/typestest
+
+go 1.25.0

--- a/pkg/shelly/wifi/ops_test.go
+++ b/pkg/shelly/wifi/ops_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"github.com/asnowfix/home-automation/pkg/shelly/typestest"
 )
 
 func TestDoGetConfig(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Config{}
 		d.SetResult(string(GetConfig), want)
 
@@ -24,7 +25,7 @@ func TestDoGetConfig(t *testing.T) {
 	})
 
 	t.Run("device error propagates", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		wantErr := errors.New("wifi config unavailable")
 		d.SetError(string(GetConfig), wantErr)
 
@@ -35,7 +36,7 @@ func TestDoGetConfig(t *testing.T) {
 	})
 
 	t.Run("unexpected result type", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(string(GetConfig), "not-a-config")
 
 		_, err := DoGetConfig(context.Background(), types.ChannelDefault, d)
@@ -46,7 +47,7 @@ func TestDoGetConfig(t *testing.T) {
 }
 
 func TestDoSetConfig(t *testing.T) {
-	d := types.NewFakeDevice()
+	d := typestest.NewFakeDevice()
 	want := &SetConfigResponse{}
 	d.SetResult(string(SetConfig), want)
 
@@ -64,7 +65,7 @@ func TestDoSetConfig(t *testing.T) {
 
 func TestDoGetStatus(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		want := &Status{SSID: "home-net"}
 		d.SetResult(GetStatus.String(), want)
 
@@ -78,7 +79,7 @@ func TestDoGetStatus(t *testing.T) {
 	})
 
 	t.Run("unexpected result type", func(t *testing.T) {
-		d := types.NewFakeDevice()
+		d := typestest.NewFakeDevice()
 		d.SetResult(GetStatus.String(), "not-a-status")
 
 		_, err := DoGetStatus(context.Background(), types.ChannelDefault, d)


### PR DESCRIPTION
Closes #360. Part of umbrella #368 (Wave 3 — export blocker for the standalone go-shellies extraction, see docs/EXTRACT-PKG-SHELLY-PLAN.md).

## What

- **Zero app-couplings left in `pkg/shelly`**: no `internal/*`, `myhome/*`, or `pkg/devices` imports remain (verified via `go list -deps`). The `internal/myhome/net` blank-import in `device.go` is gone — mDNS resolver registration is now an explicit call at app wiring time.
- **Public API cleanup**: trailing-underscore exported fields (`Id_`, `MacAddress_`, `Name_`, `Host_`) replaced with unexported fields + `MarshalJSON`/`UnmarshalJSON` (wire format unchanged); device constructors return `*shelly.Device` (no premature interface); `Do`/`Foreach` typed on a small local `shelly.Summary` interface.
- **`FakeDevice`** moved (`git mv`) from `pkg/shelly/types` to a dedicated `pkg/shelly/typestest` module (go.work-registered) so the production package carries no test fake.
- **`types.Api.String()`** switched from a positional array literal to a map keyed by the constants, with a guard test preventing silent desync.
- ~40 downstream files (`myhome/ctl/*`, `internal/myhome`, `myhome/daemon`, `myhome/devices/impl`) mechanically updated.

## Verification (by the implementation agent, pre-commit)

- `make generate` / `make build`: green
- `make test`: full workspace loop green (exit 0, every module ok)
- `golangci-lint`: 0 issues on every touched tree
- `go test -race ./pkg/shelly/...`: pass

## Notes

- Implemented by the issue agent (verification completed and reported green); committed/pushed by the coordinator after the agent's connection dropped at the commit step, so the work is a single squashed-style commit rather than the agent's planned logical grouping — immaterial under the campaign's squash-merge policy.
- Wire-format compatibility of the MarshalJSON/UnmarshalJSON replacements is a key review point.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- refactor(shelly): decouple pkg/shelly from app internals, clean public API ([32b0ad9](https://github.com/asnowfix/home-automation/commit/32b0ad95fe23e642472870ade6629a3bf75aa086))
- fix(script): make timerHandler.stopped atomic to fix pre-existing race ([5c3f87c](https://github.com/asnowfix/home-automation/commit/5c3f87c7af7ae1843ce9f9feb92a89fbcff4bdbe))
<!-- END-AUTO-GENERATED-COMMITS -->