### PR TITLE
fix(pool-pump): serialize Shelly.call dispatch to fix "Too many calls in progress" crash

### DIFF
--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -913,13 +913,24 @@ function mapSpeedToSwitch(speed) {
 }
 
 // === OUTPUT CONTROL ===
-function turnOffAllSwitches(callback) {
-  for (var i = 0; i < STATE.outputs.length; i++) {
-    Shelly.call("Switch.Set", {id: STATE.outputs[i], on: false}, function(res, err) {
-      if (err && false) {}
-    });
+// Turns off outputs one at a time via the task queue. Dispatching Shelly.call from
+// inside a for loop fires all iterations before any response arrives, exhausting the
+// 5-concurrent-RPC budget (see AGENTS.md "Callback Depth Limits" — Cause B).
+function turnOffAllSwitchesNext(ids, index, callback) {
+  if (index >= ids.length) {
+    if (callback) callback();
+    return;
   }
-  if (callback) queueTask(callback);
+  var id = ids[index];
+  index++;
+  Shelly.call("Switch.Set", {id: id, on: false}, function(res, err) {
+    if (err && false) {}
+    queueTask(function() { turnOffAllSwitchesNext(ids, index, callback); });
+  });
+}
+
+function turnOffAllSwitches(callback) {
+  turnOffAllSwitchesNext(STATE.outputs, 0, callback);
 }
 
 function turnOffPro1(callback) {
@@ -939,9 +950,31 @@ function setOutput(outputId, on, callback) {
     if (callback) callback();
     return;
   }
-  
+
   log("Setting switch", outputId, "to", on);
   Shelly.call("Switch.Set", {id: outputId, on: on}, callback);
+}
+
+// Turns off every output except exceptId, one at a time via the task queue
+// (see turnOffAllSwitches above for why a for-loop of Shelly.call is unsafe here).
+function turnOffOtherOutputsNext(ids, index, exceptId, callback) {
+  if (index >= ids.length) {
+    if (callback) callback();
+    return;
+  }
+  var id = ids[index];
+  index++;
+  if (id === exceptId) {
+    turnOffOtherOutputsNext(ids, index, exceptId, callback);
+    return;
+  }
+  setOutput(id, false, function() {
+    queueTask(function() { turnOffOtherOutputsNext(ids, index, exceptId, callback); });
+  });
+}
+
+function turnOffOtherOutputs(exceptId, callback) {
+  turnOffOtherOutputsNext(STATE.outputs, 0, exceptId, callback);
 }
 
 // === SOFTWARE FUSE (ANTI-CYCLING PROTECTION) ===
@@ -1021,15 +1054,8 @@ function activateOutput(outputId, callback) {
 
   if (STATE.deviceType === "pro3") {
     safeActivatePro3(outputId, function() {
-      // Turn off all outputs simultaneously
-      for (var i = 0; i < STATE.outputs.length; i++) {
-        Shelly.call("Switch.Set", {id: STATE.outputs[i], on: false}, function(res, err) {
-          if (err && false) {}
-        });
-      }
-
-      // Use task queue instead of a one-shot timer to avoid consuming a timer slot
-      queueTask(function() {
+      // Turn off all outputs (one at a time via the task queue — see turnOffAllSwitches)
+      turnOffAllSwitches(function() {
         if (outputId !== -1) {
           setOutput(outputId, true, function() {
             STATE.activeOutput = outputId;
@@ -1185,14 +1211,9 @@ function handleSwitchEvent(info) {
   }
 
   if (STATE.deviceType === "pro3" && info.state === true) {
-    // Ensure only one output is on
+    // Ensure only one output is on (one at a time via the task queue — see turnOffOtherOutputs)
     var activatedOutput = info.id;
-    for (var i = 0; i < STATE.outputs.length; i++) {
-      var outputId = STATE.outputs[i];
-      if (outputId !== activatedOutput) {
-        setOutput(outputId, false);
-      }
-    }
+    turnOffOtherOutputs(activatedOutput);
     STATE.activeOutput = activatedOutput;
     saveState();
 


### PR DESCRIPTION
## Summary
- `filtration-hiver` crashed with `Uncaught Error: Too many calls in progress` inside `storeValue("schedule-mode", ...)`.
- Root cause: `turnOffAllSwitches()`, `activateOutput()`, and `handleSwitchEvent()` each dispatched `Shelly.call` from inside a `for` loop, firing all iterations before any response arrives and exhausting the device's 5-concurrent-RPC budget — documented as "Cause B" in `AGENTS.md` "Callback Depth Limits". Once enough calls piled up, a later fire-and-forget `KVS.Set` tipped the count over the limit and crashed the script uncaught.
- Fix: serialize all three sites through the existing task-queue pattern (`turnOffAllSwitchesNext`, `turnOffOtherOutputsNext`), and have `activateOutput()` reuse `turnOffAllSwitches()` instead of duplicating the loop.

Related to #250 — a script emulator enforcing the device's resource limits would have caught this class of bug automatically.

## Test plan
- [x] `go test ./internal/shelly/scripts/...` passes
- [x] `node -c internal/shelly/scripts/pool-pump.js` (syntax check)
- [x] Manually verified live on `filtration-hiver`: reproduced the original crash via `myhome ctl shelly script status`, confirmed the buggy for-loop pattern was the cause, and confirmed the pump resumes normal operation after this fix<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): serialize Switch.Set/KVS.Set dispatch to fix "Too many calls in progress" crash ([bc324f8](https://github.com/asnowfix/home-automation/commit/bc324f87ed55e6a5c7215efefc8e9320b79f5827))
<!-- END-AUTO-GENERATED-COMMITS -->