### PR TITLE
feat(packaging): push bundled scripts to known devices on install

### DIFF
--- a/linux/README.md
+++ b/linux/README.md
@@ -47,7 +47,7 @@
 ```
 linux/
 ├── debian/           # Debian package scripts
-│   ├── postinst.sh   # Post-installation (enable & start services)
+│   ├── postinst.sh   # Post-installation (enable & start services, push scripts to known devices)
 │   ├── prerm.sh      # Pre-removal (stop services)
 │   └── postrm.sh     # Post-removal (disable services)
 ├── systemd/          # Systemd units and helper scripts

--- a/linux/debian/postinst.sh
+++ b/linux/debian/postinst.sh
@@ -195,6 +195,66 @@ if [ "$1" = "configure" ]; then
         systemctl restart "$timer"
     done
 
+    # -------------------------------------------------------------------
+    # Push the scripts bundled with this package to every Shelly device
+    # the daemon already knows about, so devices end up running the exact
+    # script versions shipped in this install/upgrade/downgrade.
+    #
+    # Script versioning is content-hash based (see
+    # internal/myhome/shelly/script/ops.go: UploadWithVersion compares a
+    # sha1 of the embedded script against a KVS-recorded hash on the
+    # device), not sequence-number based, so re-running this on a
+    # downgrade re-uploads scripts just as correctly as on an upgrade.
+    #
+    # `myhome ctl shelly script update '*'` only touches scripts already
+    # loaded on a device (see myhome/ctl/shelly/script/update.go), so
+    # devices never receive scripts they didn't already have.
+    # -------------------------------------------------------------------
+    MYHOME_BIN="/usr/bin/myhome"
+    if [ -x "$MYHOME_BIN" ]; then
+        echo "Waiting for $SERVICE to discover its known devices..."
+
+        POLL_INTERVAL=3
+        MAX_WAIT=90
+        elapsed=0
+        prev_count=-1
+        stable_polls=0
+        count=0
+
+        while [ "$elapsed" -lt "$MAX_WAIT" ]; do
+            count=$("$MYHOME_BIN" ctl --wait 5s list '*' --json 2>/dev/null | jq 'length' 2>/dev/null || echo 0)
+            case "$count" in ''|*[!0-9]*) count=0 ;; esac
+
+            # Stop as soon as the known-device count stops growing across
+            # two consecutive polls (device.match returns the daemon's
+            # DB-backed registry immediately, then fills in as retained
+            # MQTT messages and mDNS discovery catch up).
+            if [ "$count" -gt 0 ] && [ "$count" -eq "$prev_count" ]; then
+                stable_polls=$((stable_polls + 1))
+            else
+                stable_polls=0
+            fi
+            prev_count=$count
+
+            if [ "$stable_polls" -ge 2 ]; then
+                break
+            fi
+
+            sleep "$POLL_INTERVAL"
+            elapsed=$((elapsed + POLL_INTERVAL))
+        done
+
+        if [ "$count" -gt 0 ]; then
+            echo "Updating Shelly scripts on $count known device(s) (waited ${elapsed}s)..."
+            "$MYHOME_BIN" ctl --wait 180s shelly script update '*' || \
+                echo "Warning: script update did not complete cleanly on all devices; this does not affect package installation. Run 'myhome ctl shelly script update *' manually to retry." >&2
+        else
+            echo "No known devices found after ${elapsed}s; skipping script update. Run 'myhome ctl shelly script update *' manually once devices are reachable."
+        fi
+    else
+        echo "Warning: $MYHOME_BIN not found, skipping script update step" >&2
+    fi
+
     # Restart prometheus-mqtt-exporter to apply new configuration
     if systemctl list-unit-files prometheus-mqtt-exporter.service >/dev/null 2>&1; then
         if systemctl is-active --quiet prometheus-mqtt-exporter; then


### PR DESCRIPTION
## Summary
- `postinst.sh` now waits for the daemon to (re)discover its known devices after (re)starting the service (polls `myhome ctl list '*' --json`, stopping once the device count stabilizes across two polls, capped at 90s), then runs `myhome ctl shelly script update '*'` so every reachable device ends up running the script versions bundled with the just-installed package.
- Works for both upgrades and downgrades for free: script versioning is content-hash based (`UploadWithVersion` in `internal/myhome/shelly/script/ops.go`), so a script is re-uploaded whenever its hash differs from the device's KVS-recorded version, regardless of which direction the package version moved.
- Only touches scripts a device already has loaded — no new scripts get pushed to devices that never had them.
- Never fails the install: missing binary, no reachable daemon, or a failed update on some devices all degrade to a warning + manual-retry hint.

## Test plan
- [x] `bash -n linux/debian/postinst.sh`
- [ ] `make debpkg` and install/upgrade/downgrade on a real device to confirm the wait loop and script update both behave as expected<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(packaging): push bundled scripts to known devices on install ([04a8ee5](https://github.com/asnowfix/home-automation/commit/04a8ee557496bfb1b66ae33f526c44a00866bdaa))
<!-- END-AUTO-GENERATED-COMMITS -->