### PR TITLE
rpc: generics-based method registry + json.RawMessage wire types (#361)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -933,22 +933,7 @@ Follow this pattern (see temperature and occupancy services as examples):
    - `internal/myhome/occupancy.go` - Occupancy RPC types
    - `internal/myhome/yourservice.go` - Your service RPC types
 
-3. **Add method signature to `internal/myhome/methods.go`:**
-   ```go
-   var signatures map[Verb]MethodSignature = map[Verb]MethodSignature{
-       // ... existing methods
-       YourNewMethod: {
-           NewParams: func() any {
-               return &YourServiceParams{}
-           },
-           NewResult: func() any {
-               return &YourServiceResult{}
-           },
-       },
-   }
-   ```
-
-4. **Create handler in your service package (e.g., `myhome/yourservice/methods.go`):**
+3. **Create handler in your service package (e.g., `myhome/yourservice/methods.go`) and register it — no separate signature-map entry needed:**
    ```go
    type MethodHandlers struct {
        service *Service
@@ -963,22 +948,30 @@ Follow this pattern (see temperature and occupancy services as examples):
    }
    
    func (h *MethodHandlers) RegisterHandlers() {
-       myhome.RegisterMethodHandler(myhome.YourNewMethod, h.handleMethod)
+       myhome.Register(myhome.YourNewMethod, h.handleMethod)
        h.log.Info("Your service RPC handlers registered")
    }
    
-   func (h *MethodHandlers) handleMethod(params any) (any, error) {
-       p, ok := params.(*myhome.YourServiceParams)
-       if !ok {
-           return nil, fmt.Errorf("invalid params type")
-       }
-       
+   // handleMethod's signature IS the method's contract: myhome.Register infers
+   // the request/response wire types from it at compile time, so there is no
+   // separate signature-map entry to keep in sync and no `params any` type
+   // assertion to write — the compiler already guarantees params arrives as
+   // *myhome.YourServiceParams.
+   func (h *MethodHandlers) handleMethod(ctx context.Context, params *myhome.YourServiceParams) (*myhome.YourServiceResult, error) {
        // Your logic here
        return &myhome.YourServiceResult{Data: "result"}, nil
    }
    ```
 
-5. **Register in `myhome/daemon/daemon.go` after device manager starts:**
+   Callers on the other end use the generic `myhome.Call[P, R]` helper to get the same compile-time typing back:
+   ```go
+   result, err := myhome.Call[*myhome.YourServiceParams, *myhome.YourServiceResult](
+       ctx, myhome.TheClient, myhome.YourNewMethod, &myhome.YourServiceParams{Field: "x"},
+   )
+   ```
+   (`myhome.TheClient.CallE` itself stays untyped — it must satisfy the `Client` interface across the wire client, `FakeClient`, and `DeviceManager`'s in-process short-circuit alike — so always call through `myhome.Call`, not `CallE` directly, from application code.)
+
+4. **Register in `myhome/daemon/daemon.go` after device manager starts:**
    ```go
    // Register Your Service RPC methods if enabled
    if options.Flags.EnableYourService {
@@ -1015,7 +1008,7 @@ func NewRPCService(ctx context.Context) (*RPCService, error) {
 ```go
 // CORRECT - Do this!
 func (h *MethodHandlers) RegisterHandlers() {
-    myhome.RegisterMethodHandler(myhome.YourMethod, h.handleMethod)
+    myhome.Register(myhome.YourMethod, h.handleMethod)
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,13 @@ No business logic in `myhome/ctl/`. No MyHome-specific code in `pkg/shelly/`. Ut
 
 ### RPC System
 
-All methods share one MQTT topic (`myhome/rpc`). Adding a method requires four steps in order:
+All methods share one MQTT topic (`myhome/rpc`). Adding a method requires two steps in order:
 1. Add `Verb` constant → `internal/myhome/const.go`
-2. Add request/response types → `internal/myhome/<service>.go`
-3. Add to `signatures` map → `internal/myhome/methods.go`
-4. Register via `myhome.RegisterMethodHandler()` — never create a separate MQTT subscription
+2. Add request/response types (if new) → `internal/myhome/<service>.go`, then register the handler via `myhome.Register(verb, handler)` — never create a separate MQTT subscription
+
+`Register[P, R any](verb Verb, h func(ctx context.Context, p P) (R, error))` (`internal/myhome/methods.go`) replaces the old `signatures` map + `RegisterMethodHandler` pair: P and R are normally inferred from `h`'s own signature, so most registrations are a one-line call passing a method reference directly, e.g. `myhome.Register(myhome.HeaterGetConfig, s.HandleGetConfig)`. The wire request's `Params` (and the response's `Result`) travel as `json.RawMessage` end to end and are decoded exactly once, directly into `P` — there is no more runtime `reflect.TypeOf` check and no marshal-then-unmarshal round trip. Registering the same verb twice overwrites the previous registration (there is no `Unregister`); tests that need to swap a handler save the previous `*Method` via `myhome.Methods(verb)` and restore it with `myhome.RestoreMethod` in `t.Cleanup`.
+
+On the caller side, `myhome.TheClient.CallE(ctx, verb, params)` stays untyped (it must satisfy the `Client` interface across the wire client, `FakeClient`, and `DeviceManager`'s in-process short-circuit alike) — use the generic wrapper instead: `result, err := myhome.Call[ParamsType, ResultType](ctx, myhome.TheClient, verb, params)`. For a handler with no meaningful params or result, use `any` for that type parameter (e.g. `myhome.Call[any, *myhome.PoolGetStatusResult](ctx, myhome.TheClient, myhome.PoolGetStatus, nil)`).
 
 ### Key Packages
 
@@ -111,7 +113,7 @@ was present for the discussion that led to filing it.
 
 - **CLI output**: `fmt.Printf()` for user-facing messages; `hlog` for internal/debug logging. Never `log.Info()` in CLI commands.
 - **Config options**: adding any new option requires updating 4 files — `options.go`, `run.go`, `docs/configuration.md`, `myhome-example.yaml`. Env var pattern: `MYHOME_<SECTION>_<KEY>`.
-- **RPC handler tests**: tests that call `myhome.RegisterMethodHandler()` must restore state in `t.Cleanup` and must not call `t.Parallel()` (shared package-level map).
+- **RPC handler tests**: tests that call `myhome.Register()` must restore state in `t.Cleanup` (via `myhome.RestoreMethod`, since there is no `Unregister`) and must not call `t.Parallel()` (shared package-level map).
 - **Database migrations**: Use `COUNT(*)` (returns int) not bool when checking SQLite column existence. See AGENTS.md "Database Patterns".
 - **SQLite database paths**: new databases use a plain relative filename (e.g. `"foo.db"`), matching `myhome.db`. Do not invent a new default directory (e.g. `~/.myhome/`, XDG paths) unless all existing databases already use it. If a flag or config key lets the user supply an absolute path, the `NewStorage` constructor must call `os.MkdirAll(filepath.Dir(path), 0o755)` before opening the file — SQLite cannot create missing parent directories.
 - **File moves**: always `git mv`, never delete-and-recreate (preserves `git log --follow` history).

--- a/internal/myhome/client.go
+++ b/internal/myhome/client.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -144,28 +143,21 @@ func (hc *client) LookupDevices(ctx context.Context, name string) (*[]devices.De
 		return &[]devices.Device{device}, nil
 	}
 
-	var out any
-	var err error
-
+	verb := DeviceLookup
 	if strings.HasPrefix(name, "*") || strings.HasSuffix(name, "*") {
-		out, err = hc.CallE(ctx, DevicesMatch, name)
-	} else {
-		out, err = hc.CallE(ctx, DeviceLookup, name)
+		verb = DevicesMatch
 	}
+
+	mhd, err := Call[string, []DeviceSummary](ctx, hc, verb, name)
 	if err != nil {
 		return nil, err
 	}
 
-	mhd, ok := out.(*[]DeviceSummary)
-	if !ok {
-		return nil, fmt.Errorf("expected *[]myhome.DeviceSummary, got %T", out)
+	out := make([]devices.Device, len(mhd))
+	for i, d := range mhd {
+		out[i] = d
 	}
-
-	devices := make([]devices.Device, len(*mhd))
-	for i, d := range *mhd {
-		devices[i] = d
-	}
-	return &devices, nil
+	return &out, nil
 }
 
 func (hc *client) ForgetDevices(ctx context.Context, name string) error {
@@ -193,16 +185,14 @@ func (hc *client) CallE(ctx context.Context, method Verb, params any) (any, erro
 		return nil, err
 	}
 
-	m, exists := signatures[method]
-	if !exists {
-		return nil, fmt.Errorf("unknown method %s", method)
+	// Params is encoded once, up front, into the wire envelope's raw-JSON
+	// field. There is no per-verb type to check here: the compiler already
+	// enforced it at the call site via the generic Call[P, R] helper.
+	paramsRaw, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params for %s: %w", method, err)
 	}
 
-	if reflect.TypeOf(params) != reflect.TypeOf(m.NewParams()) {
-		err := fmt.Errorf("invalid parameter type for method %s: got %v, should be %v", method, reflect.TypeOf(params), reflect.TypeOf(m.NewParams()))
-		hc.log.Error(err, "Invalid parameter type")
-		return nil, err
-	}
 	req := request{
 		Dialog: Dialog{
 			Id:  requestId,
@@ -210,7 +200,7 @@ func (hc *client) CallE(ctx context.Context, method Verb, params any) (any, erro
 			Dst: InstanceName,
 		},
 		Method: method,
-		Params: params,
+		Params: paramsRaw,
 	}
 	reqStr, err := json.Marshal(req)
 	if err != nil {
@@ -270,22 +260,14 @@ func (hc *client) CallE(ctx context.Context, method Verb, params any) (any, erro
 		return nil, err
 	}
 
-	rs, err := json.Marshal(res.Result)
-	if err != nil {
-		hc.log.Error(err, "Failed to re-marshal response.result", "result", res.Result)
-		return nil, err
-	}
-	result := m.NewResult()
-	hc.log.Info("Result", "type", reflect.TypeOf(result))
-	err = json.Unmarshal(rs, &result)
-	if err != nil {
-		hc.log.Error(err, "Failed to re-unmarshal response.result", "payload", rs)
-		return nil, err
-	}
-
 	if res.Error != nil {
 		return nil, fmt.Errorf("%v (code:%v)", res.Error.Message, res.Error.Code)
 	}
 
-	return result, nil
+	// res.Result is already the raw JSON result from the wire, decoded
+	// exactly once (as part of unmarshalling the envelope in dispatch). It is
+	// handed back as-is; Call[P, R] does the single, type-specific unmarshal
+	// into the caller's chosen result type — no marshal-then-unmarshal round
+	// trip through an intermediate `any`.
+	return res.Result, nil
 }

--- a/internal/myhome/client_test.go
+++ b/internal/myhome/client_test.go
@@ -103,10 +103,13 @@ func newTestClient(t *testing.T, id string, timeout time.Duration) (*client, *fa
 func mustDeviceSummaryResponse(t *testing.T, req request, deviceId string) []byte {
 	t.Helper()
 	result := []DeviceSummary{{DeviceIdentifier: DeviceIdentifier{Id_: deviceId}, Name_: deviceId}}
-	var resultAny any = result
+	resultRaw, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
 	resp := response{
 		Dialog: Dialog{Id: req.Id, Src: InstanceName, Dst: req.Src},
-		Result: &resultAny,
+		Result: resultRaw,
 	}
 	b, err := json.Marshal(resp)
 	if err != nil {
@@ -157,8 +160,9 @@ func TestCallE_ConcurrentCalls_CorrelateResponsesByDialogID(t *testing.T) {
 	req1 := mustUnmarshalRequest(t, <-fake.reqCh)
 	req2 := mustUnmarshalRequest(t, <-fake.reqCh)
 
-	param1, _ := req1.Params.(string)
-	param2, _ := req2.Params.(string)
+	var param1, param2 string
+	_ = json.Unmarshal(req1.Params, &param1)
+	_ = json.Unmarshal(req2.Params, &param2)
 
 	resp1 := mustDeviceSummaryResponse(t, req1, param1)
 	resp2 := mustDeviceSummaryResponse(t, req2, param2)
@@ -176,12 +180,19 @@ func TestCallE_ConcurrentCalls_CorrelateResponsesByDialogID(t *testing.T) {
 		if r.err != nil {
 			t.Fatalf("%s: CallE error: %v", label, r.err)
 		}
-		ds, ok := r.out.(*[]DeviceSummary)
-		if !ok || ds == nil || len(*ds) != 1 {
-			t.Fatalf("%s: got %#v, want *[]DeviceSummary with 1 element", label, r.out)
+		raw, ok := r.out.(json.RawMessage)
+		if !ok {
+			t.Fatalf("%s: got %#v (%T), want json.RawMessage", label, r.out, r.out)
 		}
-		if (*ds)[0].Id_ != want {
-			t.Errorf("%s: got device id %q, want %q (response cross-wired to the wrong caller)", label, (*ds)[0].Id_, want)
+		var ds []DeviceSummary
+		if err := json.Unmarshal(raw, &ds); err != nil {
+			t.Fatalf("%s: unmarshal result: %v", label, err)
+		}
+		if len(ds) != 1 {
+			t.Fatalf("%s: got %d device summaries, want 1", label, len(ds))
+		}
+		if ds[0].Id_ != want {
+			t.Errorf("%s: got device id %q, want %q (response cross-wired to the wrong caller)", label, ds[0].Id_, want)
 		}
 	}
 	checkResult(t, "call A (device-a)", gotA, "device-a")

--- a/internal/myhome/config.go
+++ b/internal/myhome/config.go
@@ -23,14 +23,12 @@ func ConfigureDevice(ctx context.Context, log logr.Logger, identifier string, na
 	log = log.WithName("ConfigureDevice")
 
 	// Get the device from the database using RPC
-	result, err := TheClient.CallE(ctx, DeviceShow, &DeviceShowParams{Identifier: identifier})
+	device, err := Call[*DeviceShowParams, *Device](ctx, TheClient, DeviceShow, &DeviceShowParams{Identifier: identifier})
 	if err != nil {
 		return fmt.Errorf("device not found: %w", err)
 	}
-
-	device, ok := result.(*Device)
-	if !ok {
-		return fmt.Errorf("unexpected result type: %T", result)
+	if device == nil {
+		return fmt.Errorf("device not found: %s", identifier)
 	}
 
 	log.Info("Found device", "id", device.Id(), "name", device.Name(), "manufacturer", device.Manufacturer())
@@ -48,7 +46,7 @@ func ConfigureDevice(ctx context.Context, log logr.Logger, identifier string, na
 	// Save to local database if modified
 	if modified {
 		// Use the device update RPC method
-		_, err = TheClient.CallE(ctx, DeviceUpdate, device)
+		_, err = Call[*Device, any](ctx, TheClient, DeviceUpdate, device)
 		if err != nil {
 			return fmt.Errorf("failed to update device in local database: %w", err)
 		}

--- a/internal/myhome/methods.go
+++ b/internal/myhome/methods.go
@@ -57,12 +57,11 @@ func Methods(name Verb) (*Method, error) {
 // the runtime reflect.TypeOf check it required on the client: P is now
 // enforced by the compiler at every call site via the generic Call helper.
 //
-// Registering the same verb twice panics, matching the previous behavior of
-// RegisterMethodHandler.
+// Registering the same verb twice overwrites the previous registration
+// (matching the previous RegisterMethodHandler behavior); there is no
+// Unregister — tests that need to swap a handler just call Register again
+// and restore the previous *Method (via Methods) in t.Cleanup.
 func Register[P, R any](verb Verb, h func(ctx context.Context, p P) (R, error)) {
-	if _, exists := methods[verb]; exists {
-		panic(fmt.Errorf("method %s already registered", verb))
-	}
 	methods[verb] = &Method{
 		Name: verb,
 		Action: func(ctx context.Context, raw json.RawMessage) (any, error) {
@@ -78,3 +77,13 @@ func Register[P, R any](verb Verb, h func(ctx context.Context, p P) (R, error)) 
 }
 
 var methods = make(map[Verb]*Method)
+
+// RestoreMethod re-registers m verbatim under verb, bypassing the P/R
+// decode wrapper Register builds. It exists for test cleanup in packages
+// other than myhome itself: a test that swaps in a replacement handler via
+// Register can save the previous *Method (from Methods) and put it back
+// exactly via RestoreMethod in t.Cleanup, without needing to reconstruct a
+// typed Register call for a handler whose P/R it may not know.
+func RestoreMethod(verb Verb, m *Method) {
+	methods[verb] = m
+}

--- a/internal/myhome/methods.go
+++ b/internal/myhome/methods.go
@@ -2,22 +2,37 @@ package myhome
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 )
 
-type MethodHandler func(ctx context.Context, in any) (any, error)
-
-type MethodSignature struct {
-	NewParams func() any
-	NewResult func() any
-}
+// Action is the uniform, wire-facing entry point for a registered RPC
+// method: it receives the request's params exactly as decoded off the wire
+// (raw JSON, not yet interpreted) and returns the untyped result to be
+// marshalled back onto the wire. Every Method built by Register shares this
+// same shape regardless of its real parameter/result types.
+type Action func(ctx context.Context, params json.RawMessage) (any, error)
 
 type Method struct {
-	Name      Verb
-	Signature MethodSignature
-	ActionE   MethodHandler
+	Name   Verb
+	Action Action
 }
 
+// Call is a convenience wrapper for in-process callers that already hold a
+// typed params value instead of raw JSON — e.g. the UI's htmx/rpc handlers,
+// or DeviceManager's local dispatch shortcut that bypasses MQTT entirely. It
+// marshals params once and delegates to Action, so every call path (network
+// or in-process) decodes params through the exact same Register-generated
+// logic.
+func (m *Method) Call(ctx context.Context, params any) (any, error) {
+	raw, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params for %s: %w", m.Name, err)
+	}
+	return m.Action(ctx, raw)
+}
+
+// Methods looks up the Method registered for name.
 func Methods(name Verb) (*Method, error) {
 	m, exists := methods[name]
 	if !exists {
@@ -26,291 +41,40 @@ func Methods(name Verb) (*Method, error) {
 	return m, nil
 }
 
-func RegisterMethodHandler(name Verb, mh MethodHandler) {
-	s, exists := signatures[name]
-	if !exists {
-		panic(fmt.Errorf("unknown method %s", name))
+// Register registers h as the handler for verb. P is the method's parameter
+// type; it is decoded from the request's raw JSON exactly once, directly
+// into P — no intermediate "unmarshal once to see what we've got, then
+// unmarshal the whole message again with the right type" step. R is the
+// method's result type. Both are normally inferred from h, so a
+// registration is a single, compile-time-checked expression:
+//
+//	myhome.Register(myhome.DeviceShow, func(ctx context.Context, p *myhome.DeviceShowParams) (*myhome.Device, error) {
+//	    ...
+//	})
+//
+// This replaces the old two-step ritual (add an entry to the `signatures`
+// map keyed by func() any constructors, then call RegisterMethodHandler) and
+// the runtime reflect.TypeOf check it required on the client: P is now
+// enforced by the compiler at every call site via the generic Call helper.
+//
+// Registering the same verb twice panics, matching the previous behavior of
+// RegisterMethodHandler.
+func Register[P, R any](verb Verb, h func(ctx context.Context, p P) (R, error)) {
+	if _, exists := methods[verb]; exists {
+		panic(fmt.Errorf("method %s already registered", verb))
 	}
-	methods[name] = &Method{
-		Name:      name,
-		Signature: s,
-		ActionE:   mh,
+	methods[verb] = &Method{
+		Name: verb,
+		Action: func(ctx context.Context, raw json.RawMessage) (any, error) {
+			var p P
+			if len(raw) > 0 && string(raw) != "null" {
+				if err := json.Unmarshal(raw, &p); err != nil {
+					return nil, fmt.Errorf("unmarshal params for %s: %w", verb, err)
+				}
+			}
+			return h(ctx, p)
+		},
 	}
 }
 
-var methods map[Verb]*Method = make(map[Verb]*Method)
-
-var signatures map[Verb]MethodSignature = map[Verb]MethodSignature{
-	DevicesMatch: {
-		NewParams: func() any {
-			return ""
-		},
-		NewResult: func() any {
-			return &[]DeviceSummary{}
-		},
-	},
-	DeviceLookup: {
-		NewParams: func() any {
-			return ""
-		},
-		NewResult: func() any {
-			return &[]DeviceSummary{}
-		},
-	},
-	DeviceShow: {
-		NewParams: func() any {
-			return &DeviceShowParams{}
-		},
-		NewResult: func() any {
-			return &Device{}
-		},
-	},
-	DeviceForget: {
-		NewParams: func() any {
-			return ""
-		},
-		NewResult: func() any {
-			return nil
-		},
-	},
-	DeviceRefresh: {
-		NewParams: func() any {
-			return "" // device identifier (id/name/host/etc)
-		},
-		NewResult: func() any {
-			return nil
-		},
-	},
-	DeviceSetup: {
-		NewParams: func() any {
-			return &DeviceSetupParams{}
-		},
-		NewResult: func() any {
-			return nil
-		},
-	},
-	DeviceUpdate: {
-		NewParams: func() any {
-			return &Device{}
-		},
-		NewResult: func() any {
-			return nil
-		},
-	},
-	TemperatureGet: {
-		NewParams: func() any {
-			return &TemperatureGetParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureRoomConfig{}
-		},
-	},
-	TemperatureSet: {
-		NewParams: func() any {
-			return &TemperatureSetParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureSetResult{}
-		},
-	},
-	TemperatureList: {
-		NewParams: func() any {
-			return nil
-		},
-		NewResult: func() any {
-			return &TemperatureRoomList{}
-		},
-	},
-	TemperatureDelete: {
-		NewParams: func() any {
-			return &TemperatureDeleteParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureDeleteResult{}
-		},
-	},
-	TemperatureGetSchedule: {
-		NewParams: func() any {
-			return &TemperatureGetScheduleParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureScheduleResult{}
-		},
-	},
-	TemperatureGetWeekdayDefaults: {
-		NewParams: func() any {
-			return &TemperatureGetWeekdayDefaultsParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureWeekdayDefaults{}
-		},
-	},
-	TemperatureSetWeekdayDefault: {
-		NewParams: func() any {
-			return &TemperatureSetWeekdayDefaultParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureSetWeekdayDefaultResult{}
-		},
-	},
-	TemperatureGetKindSchedules: {
-		NewParams: func() any {
-			return &TemperatureGetKindSchedulesParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureKindScheduleList{}
-		},
-	},
-	TemperatureSetKindSchedule: {
-		NewParams: func() any {
-			return &TemperatureSetKindScheduleParams{}
-		},
-		NewResult: func() any {
-			return &TemperatureSetKindScheduleResult{}
-		},
-	},
-	OccupancyGetStatus: {
-		NewParams: func() any {
-			return nil
-		},
-		NewResult: func() any {
-			return &OccupancyStatusResult{}
-		},
-	},
-	HeaterGetConfig: {
-		NewParams: func() any {
-			return &HeaterGetConfigParams{}
-		},
-		NewResult: func() any {
-			return &HeaterGetConfigResult{}
-		},
-	},
-	HeaterSetConfig: {
-		NewParams: func() any {
-			return &HeaterSetConfigParams{}
-		},
-		NewResult: func() any {
-			return &HeaterSetConfigResult{}
-		},
-	},
-	ThermometerList: {
-		NewParams: func() any {
-			return nil
-		},
-		NewResult: func() any {
-			return &ThermometerListResult{}
-		},
-	},
-	DoorList: {
-		NewParams: func() any {
-			return nil
-		},
-		NewResult: func() any {
-			return &DoorListResult{}
-		},
-	},
-	RoomList: {
-		NewParams: func() any {
-			return nil
-		},
-		NewResult: func() any {
-			return &RoomListResult{}
-		},
-	},
-	RoomCreate: {
-		NewParams: func() any {
-			return &RoomCreateParams{}
-		},
-		NewResult: func() any {
-			return &RoomCreateResult{}
-		},
-	},
-	RoomEdit: {
-		NewParams: func() any {
-			return &RoomEditParams{}
-		},
-		NewResult: func() any {
-			return &RoomEditResult{}
-		},
-	},
-	RoomDelete: {
-		NewParams: func() any {
-			return &RoomDeleteParams{}
-		},
-		NewResult: func() any {
-			return &RoomDeleteResult{}
-		},
-	},
-	DeviceSetRoom: {
-		NewParams: func() any {
-			return &DeviceSetRoomParams{}
-		},
-		NewResult: func() any {
-			return nil
-		},
-	},
-	DeviceListByRoom: {
-		NewParams: func() any {
-			return &DeviceListByRoomParams{}
-		},
-		NewResult: func() any {
-			return &DeviceListByRoomResult{}
-		},
-	},
-	SwitchToggle: {
-		NewParams: func() any {
-			return &SwitchParams{}
-		},
-		NewResult: func() any {
-			return &SwitchResult{}
-		},
-	},
-	SwitchOn: {
-		NewParams: func() any {
-			return &SwitchParams{}
-		},
-		NewResult: func() any {
-			return &SwitchResult{}
-		},
-	},
-	SwitchOff: {
-		NewParams: func() any {
-			return &SwitchParams{}
-		},
-		NewResult: func() any {
-			return &SwitchResult{}
-		},
-	},
-	SwitchStatus: {
-		NewParams: func() any {
-			return &SwitchParams{}
-		},
-		NewResult: func() any {
-			return &SwitchResult{}
-		},
-	},
-	SwitchAll: {
-		NewParams: func() any {
-			return &SwitchAllParams{}
-		},
-		NewResult: func() any {
-			return &SwitchAllResult{}
-		},
-	},
-	EventList: {
-		NewParams: func() any {
-			return &EventListRequest{}
-		},
-		NewResult: func() any {
-			return &EventListResponse{}
-		},
-	},
-	PoolGetStatus: {
-		NewParams: func() any {
-			return nil
-		},
-		NewResult: func() any {
-			return &PoolGetStatusResult{}
-		},
-	},
-}
+var methods = make(map[Verb]*Method)

--- a/internal/myhome/methods_test.go
+++ b/internal/myhome/methods_test.go
@@ -46,18 +46,34 @@ func TestRegister_KnownVerb(t *testing.T) {
 	}
 }
 
-// TestRegister_DuplicateVerb_Panics verifies that registering a handler for
-// a verb that already has one panics, matching the old
-// RegisterMethodHandler behavior for a conflicting registration.
-func TestRegister_DuplicateVerb_Panics(t *testing.T) {
+// TestRegister_DuplicateVerb_Overwrites verifies that registering a second
+// handler for a verb that already has one replaces it rather than panicking,
+// matching the old RegisterMethodHandler's overwrite behavior. Tests rely on
+// this to swap in a replacement handler without an Unregister API (see
+// withHandler and myhome/occupancy/rpc_test.go's withRegisteredHandler).
+func TestRegister_DuplicateVerb_Overwrites(t *testing.T) {
 	withHandler(t, TemperatureGet, nopHandler)
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic for duplicate verb registration, but did not panic")
-		}
-	}()
-	Register(TemperatureGet, nopHandler)
+	called := false
+	Register(TemperatureGet, func(_ context.Context, _ any) (any, error) {
+		called = true
+		return "second", nil
+	})
+
+	m, err := Methods(TemperatureGet)
+	if err != nil {
+		t.Fatalf("Methods error: %v", err)
+	}
+	out, err := m.Action(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Action error: %v", err)
+	}
+	if !called {
+		t.Error("second registration's handler was not called; first handler was not overwritten")
+	}
+	if out != "second" {
+		t.Errorf("got %v, want %q", out, "second")
+	}
 }
 
 // TestMethods_Unregistered verifies that Methods returns an error (not a panic)

--- a/internal/myhome/methods_test.go
+++ b/internal/myhome/methods_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 )
 
-// withHandler registers h for verb v and restores the previous handler in
-// t.Cleanup. Tests must NOT call t.Parallel() because the methods map is a
-// package-level global.
-func withHandler(t *testing.T, v Verb, h MethodHandler) {
+// withHandler registers h for verb v via Register and restores the previous
+// registration (if any) in t.Cleanup. Tests must NOT call t.Parallel()
+// because the methods map is a package-level global.
+func withHandler[P, R any](t *testing.T, v Verb, h func(ctx context.Context, p P) (R, error)) {
 	t.Helper()
 	prev := methods[v]
-	RegisterMethodHandler(v, h)
+	delete(methods, v) // Register panics on double-registration; clear any prior entry first.
+	Register(v, h)
 	t.Cleanup(func() {
 		if prev == nil {
 			delete(methods, v)
@@ -22,12 +23,12 @@ func withHandler(t *testing.T, v Verb, h MethodHandler) {
 	})
 }
 
-// nopHandler is a minimal MethodHandler that returns a non-nil result.
+// nopHandler is a minimal handler that returns a non-nil result.
 func nopHandler(_ context.Context, _ any) (any, error) { return "ok", nil }
 
-// TestRegisterMethodHandler_KnownVerb verifies that a handler for a known verb
-// is stored and retrievable via Methods().
-func TestRegisterMethodHandler_KnownVerb(t *testing.T) {
+// TestRegister_KnownVerb verifies that a handler registered via Register is
+// stored and retrievable via Methods().
+func TestRegister_KnownVerb(t *testing.T) {
 	withHandler(t, TemperatureGet, nopHandler)
 
 	m, err := Methods(TemperatureGet)
@@ -40,24 +41,27 @@ func TestRegisterMethodHandler_KnownVerb(t *testing.T) {
 	if m.Name != TemperatureGet {
 		t.Errorf("Name: got %v, want %v", m.Name, TemperatureGet)
 	}
-	if m.ActionE == nil {
-		t.Error("expected ActionE to be set")
+	if m.Action == nil {
+		t.Error("expected Action to be set")
 	}
 }
 
-// TestRegisterMethodHandler_UnknownVerb_Panics verifies that registering a
-// handler for an unknown verb panics.
-func TestRegisterMethodHandler_UnknownVerb_Panics(t *testing.T) {
+// TestRegister_DuplicateVerb_Panics verifies that registering a handler for
+// a verb that already has one panics, matching the old
+// RegisterMethodHandler behavior for a conflicting registration.
+func TestRegister_DuplicateVerb_Panics(t *testing.T) {
+	withHandler(t, TemperatureGet, nopHandler)
+
 	defer func() {
 		if r := recover(); r == nil {
-			t.Error("expected panic for unknown verb, but did not panic")
+			t.Error("expected panic for duplicate verb registration, but did not panic")
 		}
 	}()
-	RegisterMethodHandler("unknown.verb.xyz", nopHandler)
+	Register(TemperatureGet, nopHandler)
 }
 
 // TestMethods_Unregistered verifies that Methods returns an error (not a panic)
-// for a known verb that has no registered handler.
+// for a verb that has no registered handler.
 func TestMethods_Unregistered(t *testing.T) {
 	// Ensure the verb has no handler (save and clear).
 	prev := methods[TemperatureGet]
@@ -88,47 +92,16 @@ func TestMethods_Registered(t *testing.T) {
 	}
 }
 
-// TestSignatures_AllHaveNewParams verifies that every entry in the signatures
-// map has a non-nil NewParams factory (or documents the nil case).
-func TestSignatures_AllHaveNewParams(t *testing.T) {
-	for verb, sig := range signatures {
-		if sig.NewParams == nil {
-			// Some verbs legitimately have nil params (no parameters needed).
-			// Document them; they are not a bug.
-			t.Logf("NOTICE: verb %q has nil NewParams (parameterless method)", verb)
-		}
-	}
-}
-
-// TestSignatures_AllHaveNewResult verifies that every entry in the signatures
-// map has a non-nil NewResult factory (or documents the nil case).
-func TestSignatures_AllHaveNewResult(t *testing.T) {
-	for verb, sig := range signatures {
-		if sig.NewResult == nil {
-			t.Logf("NOTICE: verb %q has nil NewResult (void-return method)", verb)
-		}
-	}
-}
-
-// TestSignatures_NotEmpty verifies that the signatures map is populated.
-func TestSignatures_NotEmpty(t *testing.T) {
-	if len(signatures) == 0 {
-		t.Error("signatures map is empty; expected registered method signatures")
-	}
-}
-
-// TestMethodHandler_Dispatch verifies that the registered handler is called
-// with the params produced by NewParams and returns the expected result.
-func TestMethodHandler_Dispatch(t *testing.T) {
+// TestRegister_ParamsDecodedExactlyOnce verifies that a request's raw JSON
+// params are decoded directly into the handler's declared parameter type,
+// with no double-unmarshal step, whether the method is invoked in-process
+// via Method.Call (typed params) or over the wire via Action (raw JSON).
+func TestRegister_ParamsDecodedExactlyOnce(t *testing.T) {
 	called := false
-	handler := func(_ context.Context, params any) (any, error) {
+	handler := func(_ context.Context, params *TemperatureGetParams) (*TemperatureRoomConfig, error) {
 		called = true
-		p, ok := params.(*TemperatureGetParams)
-		if !ok {
-			return nil, fmt.Errorf("unexpected params type: %T", params)
-		}
-		if p.RoomID != "r1" {
-			return nil, fmt.Errorf("unexpected room_id: %q", p.RoomID)
+		if params.RoomID != "r1" {
+			return nil, fmt.Errorf("unexpected room_id: %q", params.RoomID)
 		}
 		return &TemperatureRoomConfig{RoomID: "r1"}, nil
 	}
@@ -139,13 +112,9 @@ func TestMethodHandler_Dispatch(t *testing.T) {
 		t.Fatalf("Methods error: %v", err)
 	}
 
-	// Use NewParams to build params, then dispatch.
-	params := m.Signature.NewParams().(*TemperatureGetParams)
-	params.RoomID = "r1"
-
-	out, err := m.ActionE(context.Background(), params)
+	out, err := m.Call(context.Background(), &TemperatureGetParams{RoomID: "r1"})
 	if err != nil {
-		t.Fatalf("ActionE error: %v", err)
+		t.Fatalf("Call error: %v", err)
 	}
 	if !called {
 		t.Error("handler was not called")
@@ -157,28 +126,18 @@ func TestMethodHandler_Dispatch(t *testing.T) {
 	if result.RoomID != "r1" {
 		t.Errorf("result.RoomID: got %q, want %q", result.RoomID, "r1")
 	}
-}
 
-// TestAllVerbsInSignatures ensures that every Verb constant defined in the
-// package is present in the signatures map.
-func TestAllVerbsInSignatures(t *testing.T) {
-	allVerbs := []Verb{
-		DevicesMatch, DeviceLookup, DeviceShow, DeviceForget, DeviceRefresh,
-		DeviceSetup, DeviceUpdate,
-		TemperatureGet, TemperatureSet, TemperatureList, TemperatureDelete,
-		TemperatureGetSchedule, TemperatureGetWeekdayDefaults,
-		TemperatureSetWeekdayDefault, TemperatureGetKindSchedules,
-		TemperatureSetKindSchedule,
-		OccupancyGetStatus,
-		HeaterGetConfig, HeaterSetConfig,
-		ThermometerList, DoorList,
-		RoomList, RoomCreate, RoomEdit, RoomDelete,
-		DeviceSetRoom, DeviceListByRoom,
-		SwitchToggle, SwitchOn, SwitchOff, SwitchStatus, SwitchAll,
+	// And again via Action, simulating the wire path: raw JSON in, no
+	// pre-decoded Go value involved.
+	called = false
+	out, err = m.Action(context.Background(), []byte(`{"room_id":"r1"}`))
+	if err != nil {
+		t.Fatalf("Action error: %v", err)
 	}
-	for _, v := range allVerbs {
-		if _, ok := signatures[v]; !ok {
-			t.Errorf("verb %q is missing from signatures map", v)
-		}
+	if !called {
+		t.Error("handler was not called via Action")
+	}
+	if result, ok := out.(*TemperatureRoomConfig); !ok || result.RoomID != "r1" {
+		t.Fatalf("unexpected Action result: %#v", out)
 	}
 }

--- a/internal/myhome/proxy.go
+++ b/internal/myhome/proxy.go
@@ -24,7 +24,7 @@ type Client interface {
 // parameter type, R the expected result type; both are normally inferred
 // from the arguments, so a call site reads:
 //
-//	rooms, err := myhome.Call[any, myhome.RoomListResult](ctx, myhome.TheClient, myhome.RoomList, nil)
+//	rooms, err := myhome.Call[any, *myhome.RoomListResult](ctx, myhome.TheClient, myhome.RoomList, nil)
 //
 // CallE itself stays untyped (it must satisfy the Client interface for every
 // verb), so Call is what gives callers their compile-time result type back.

--- a/internal/myhome/proxy.go
+++ b/internal/myhome/proxy.go
@@ -2,6 +2,7 @@ package myhome
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/asnowfix/home-automation/pkg/devices"
@@ -19,6 +20,54 @@ type Client interface {
 	CallE(ctx context.Context, method Verb, params any) (any, error)
 }
 
+// Call is a typed convenience wrapper around Client.CallE. P is the request
+// parameter type, R the expected result type; both are normally inferred
+// from the arguments, so a call site reads:
+//
+//	rooms, err := myhome.Call[any, myhome.RoomListResult](ctx, myhome.TheClient, myhome.RoomList, nil)
+//
+// CallE itself stays untyped (it must satisfy the Client interface for every
+// verb), so Call is what gives callers their compile-time result type back.
+// For the wire client, CallE's result is the raw json.RawMessage taken
+// directly from the response envelope, so Call does exactly one
+// json.Unmarshal of it into R — no marshal-then-unmarshal round trip. Test
+// doubles (FakeClient) and the in-process DeviceManager short-circuit return
+// an already-typed R value instead; Call passes that through unchanged.
+func Call[P, R any](ctx context.Context, c Client, verb Verb, p P) (R, error) {
+	var zero R
+	out, err := c.CallE(ctx, verb, p)
+	if err != nil {
+		return zero, err
+	}
+	switch v := out.(type) {
+	case nil:
+		return zero, nil
+	case R:
+		return v, nil
+	case json.RawMessage:
+		if len(v) == 0 {
+			return zero, nil
+		}
+		var r R
+		if err := json.Unmarshal(v, &r); err != nil {
+			return zero, fmt.Errorf("unmarshal result for %s: %w", verb, err)
+		}
+		return r, nil
+	default:
+		// Defensive fallback: a handler or test double returned a value whose
+		// static type isn't R but is still JSON-compatible with it.
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return zero, fmt.Errorf("re-marshal result for %s: %w", verb, err)
+		}
+		var r R
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return zero, fmt.Errorf("unmarshal result for %s: %w", verb, err)
+		}
+		return r, nil
+	}
+}
+
 func ServerTopic() string {
 	return fmt.Sprintf("%s/rpc", InstanceName)
 }
@@ -33,10 +82,14 @@ type Dialog struct {
 	Dst string `json:"dst"`
 }
 
+// request is the wire envelope for an RPC call. Params is carried as raw
+// JSON so the server decodes it exactly once, directly into the handler's
+// declared parameter type (see Register) instead of unmarshalling the whole
+// message a second time to re-decode it with proper typing.
 type request struct {
 	Dialog
-	Method Verb `json:"method"`
-	Params any  `json:"params,omitempty"`
+	Method Verb            `json:"method"`
+	Params json.RawMessage `json:"params,omitempty"`
 }
 
 type Error struct {
@@ -44,10 +97,13 @@ type Error struct {
 	Message string `json:"message"`
 }
 
+// response is the wire envelope for an RPC reply. Result is raw JSON for the
+// same reason request.Params is: the client hands it directly to Call, which
+// unmarshals it once into the caller's chosen result type.
 type response struct {
 	Dialog
-	Result *any   `json:"result,omitempty"`
-	Error  *Error `json:"error,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *Error          `json:"error,omitempty"`
 }
 
 func ValidateDialog(d Dialog) error {

--- a/internal/myhome/server.go
+++ b/internal/myhome/server.go
@@ -9,6 +9,12 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// maxConcurrentRPCs bounds how many requests the server processes at once.
+// Without a bound, a burst of requests would spawn unbounded goroutines; with
+// no dispatch at all (the old behavior), one slow handler head-of-line-blocks
+// every other RPC, including the UI. See TestServer_SlowHandlerDoesNotBlockConcurrentRPC.
+const maxConcurrentRPCs = 16
+
 type server struct {
 	handler Server
 	from    <-chan []byte
@@ -21,7 +27,9 @@ type Server interface {
 func NewServerE(ctx context.Context, mc mqtt.Client, handler Server) (Server, error) {
 	log, err := logr.FromContext(ctx)
 	if err != nil {
-		panic(err)
+		// A missing logger in ctx is not fatal: fall back to a discard logger
+		// rather than panicking the caller's goroutine.
+		log = logr.Discard()
 	}
 	log = log.WithName("myhome.rpc")
 	from, err := mc.Subscribe(ctx, ServerTopic(), 16, InstanceName+"/server")
@@ -29,111 +37,132 @@ func NewServerE(ctx context.Context, mc mqtt.Client, handler Server) (Server, er
 		log.Error(err, "Failed to subscribe to server", "topic", ServerTopic())
 		return nil, err
 	}
-	s := server{
+	s := &server{
 		handler: handler,
 		from:    from,
 	}
 
-	go func(ctx context.Context) {
-		log, err := logr.FromContext(ctx)
-		if err != nil {
-			panic(err)
-		}
-		log.Info("Server message loop started")
-		for {
-			select {
-			case <-ctx.Done():
-				log.Info("Cancelled", "reason", ctx.Err())
-				return
-			case inMsg := <-from:
-				log.Info("Received message", "payload", string(inMsg))
-				var req request
-				var res response
-				var err error
-
-				err = json.Unmarshal(inMsg, &req)
-				if err != nil {
-					log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				err = ValidateDialog(req.Dialog)
-				if err != nil {
-					log.Error(err, "Invalid dialog:"+req.String())
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				method, err := handler.MethodE(req.Method)
-				if err != nil {
-					log.Error(err, "Failed to get action for method", "method", req.Method)
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				// re-do Unmarshalling with proper types in place, if needed
-				req.Params = method.Signature.NewParams()
-				err = json.Unmarshal(inMsg, &req)
-				if err != nil {
-					log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				tempResult := method.Signature.NewResult()
-				res.Result = &tempResult
-
-				res.Dialog = Dialog{
-					Id:  req.Id,
-					Src: mc.Id(),
-					Dst: req.Src,
-				}
-
-				out, err := method.ActionE(ctx, req.Params)
-				if err != nil {
-					log.Error(err, "Failed to call action")
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-
-				res.Result = &out
-
-				outMsg, err := json.Marshal(res)
-				if err != nil {
-					log.Error(err, "Failed to marshal response")
-					s.fail(ctx, 1, err, &req, mc)
-					continue
-				}
-				log.Info("Publishing response", "dst", res.Dst, "topic", ClientTopic(req.Src), "request_id", res.Id)
-				if err := mc.Publish(ctx, ClientTopic(req.Src), outMsg, mqtt.AtLeastOnce, false, InstanceName+".rpc/Server"); err != nil {
-					log.Error(err, "Failed to publish response", "dst", res.Dst, "request_id", res.Id)
-				}
-			}
-		}
-	}(logr.NewContext(ctx, log.WithName("Server")))
+	go s.loop(logr.NewContext(ctx, log.WithName("Server")), mc)
 
 	log.Info("Server started")
-	return &s, nil
+	return s, nil
 }
 
-func (sp *server) fail(ctx context.Context, code int, err error, req *request, mc mqtt.Client) {
-	var res = response{
+// loop is the single reader of s.from. It bounds concurrency with a
+// semaphore of size maxConcurrentRPCs and hands each message to its own
+// goroutine, so one slow handler cannot delay any other in-flight request.
+func (sp *server) loop(ctx context.Context, mc mqtt.Client) {
+	log, err := logr.FromContext(ctx)
+	if err != nil {
+		log = logr.Discard()
+	}
+	log.Info("Server message loop started")
+
+	sem := make(chan struct{}, maxConcurrentRPCs)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("Cancelled", "reason", ctx.Err())
+			return
+		case inMsg, ok := <-sp.from:
+			if !ok {
+				log.Info("Server subscription channel closed")
+				return
+			}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				log.Info("Cancelled while waiting for a dispatch slot", "reason", ctx.Err())
+				return
+			}
+			go func(inMsg []byte) {
+				defer func() { <-sem }()
+				sp.handle(ctx, log, mc, inMsg)
+			}(inMsg)
+		}
+	}
+}
+
+// handle decodes and dispatches a single request message, publishing exactly
+// one response (success or failure) back to the requester.
+func (sp *server) handle(ctx context.Context, log logr.Logger, mc mqtt.Client, inMsg []byte) {
+	log.Info("Received message", "payload", string(inMsg))
+
+	var req request
+	if err := json.Unmarshal(inMsg, &req); err != nil {
+		log.Error(err, "Failed to unmarshal request from payload", "payload", string(inMsg))
+		sp.fail(ctx, log, 1, err, &req, mc)
+		return
+	}
+
+	if err := ValidateDialog(req.Dialog); err != nil {
+		log.Error(err, "Invalid dialog:"+req.String())
+		sp.fail(ctx, log, 1, err, &req, mc)
+		return
+	}
+
+	method, err := sp.handler.MethodE(req.Method)
+	if err != nil {
+		log.Error(err, "Failed to get action for method", "method", req.Method)
+		sp.fail(ctx, log, 1, err, &req, mc)
+		return
+	}
+
+	out, err := method.Action(ctx, req.Params)
+	if err != nil {
+		log.Error(err, "Failed to call action")
+		sp.fail(ctx, log, 1, err, &req, mc)
+		return
+	}
+
+	resultRaw, err := json.Marshal(out)
+	if err != nil {
+		log.Error(err, "Failed to marshal result")
+		sp.fail(ctx, log, 1, err, &req, mc)
+		return
+	}
+
+	res := response{
 		Dialog: Dialog{
 			Id:  req.Id,
 			Src: mc.Id(),
 			Dst: req.Src,
 		},
-		Error:  &Error{Code: code, Message: err.Error()},
-		Result: nil,
+		Result: resultRaw,
 	}
+
 	outMsg, err := json.Marshal(res)
 	if err != nil {
-		// response carries only strings and ints; this cannot happen
+		log.Error(err, "Failed to marshal response")
+		sp.fail(ctx, log, 1, err, &req, mc)
+		return
+	}
+	log.Info("Publishing response", "dst", res.Dst, "topic", ClientTopic(req.Src), "request_id", res.Id)
+	if err := mc.Publish(ctx, ClientTopic(req.Src), outMsg, mqtt.AtLeastOnce, false, InstanceName+".rpc/Server"); err != nil {
+		log.Error(err, "Failed to publish response", "dst", res.Dst, "request_id", res.Id)
+	}
+}
+
+func (sp *server) fail(ctx context.Context, log logr.Logger, code int, err error, req *request, mc mqtt.Client) {
+	res := response{
+		Dialog: Dialog{
+			Id:  req.Id,
+			Src: mc.Id(),
+			Dst: req.Src,
+		},
+		Error: &Error{Code: code, Message: err.Error()},
+	}
+	outMsg, merr := json.Marshal(res)
+	if merr != nil {
+		// response carries only strings, ints and raw bytes; this cannot happen,
+		// but don't silently swallow it if it ever does.
+		log.Error(merr, "Failed to marshal error response", "dst", res.Dst, "request_id", res.Id)
 		return
 	}
 	// Best-effort: the requester will time out if this error response is lost.
-	_ = mc.Publish(ctx, ClientTopic(res.Dst), outMsg, mqtt.AtLeastOnce, false, InstanceName+".rpc/Server")
+	if perr := mc.Publish(ctx, ClientTopic(res.Dst), outMsg, mqtt.AtLeastOnce, false, InstanceName+".rpc/Server"); perr != nil {
+		log.Error(perr, "Failed to publish error response", "dst", res.Dst, "request_id", res.Id)
+	}
 }
 
 func (sp *server) MethodE(method Verb) (*Method, error) {

--- a/internal/myhome/server_test.go
+++ b/internal/myhome/server_test.go
@@ -23,8 +23,10 @@ func (s *stubServer) MethodE(_ Verb) (*Method, error) {
 	return s.method, s.err
 }
 
+// noopAction returns "ok" without inspecting params.
+func noopAction(_ context.Context, _ json.RawMessage) (any, error) { return "ok", nil }
+
 // newServerCtx returns a context with a discarded logr.Logger.
-// NewServerE panics if the context carries no logger.
 func newServerCtx() context.Context {
 	return logr.NewContext(context.Background(), logr.Discard())
 }
@@ -65,14 +67,7 @@ func TestNewServerE_SubscribesToServerTopic(t *testing.T) {
 
 	mc := mqtt.NewRecordingMockClient()
 	handler := &stubServer{
-		method: &Method{
-			Name: "test.noop",
-			Signature: MethodSignature{
-				NewParams: func() any { return nil },
-				NewResult: func() any { return nil },
-			},
-			ActionE: func(_ context.Context, _ any) (any, error) { return "ok", nil },
-		},
+		method: &Method{Name: "test.noop", Action: noopAction},
 	}
 
 	_, err := NewServerE(ctx, mc, handler)
@@ -97,16 +92,12 @@ func TestServer_DispatchKnownMethod(t *testing.T) {
 	defer cancel()
 
 	mc := mqtt.NewRecordingMockClient()
-	called := false
+	called := make(chan struct{}, 1)
 	handler := &stubServer{
 		method: &Method{
 			Name: "test.dispatch",
-			Signature: MethodSignature{
-				NewParams: func() any { return nil },
-				NewResult: func() any { return nil },
-			},
-			ActionE: func(_ context.Context, _ any) (any, error) {
-				called = true
+			Action: func(_ context.Context, _ json.RawMessage) (any, error) {
+				called <- struct{}{}
 				return "dispatched", nil
 			},
 		},
@@ -126,8 +117,10 @@ func TestServer_DispatchKnownMethod(t *testing.T) {
 
 	raw := waitPublished(t, mc, ClientTopic(src))
 
-	if !called {
-		t.Error("handler ActionE was not called")
+	select {
+	case <-called:
+	default:
+		t.Error("handler Action was not called")
 	}
 
 	var res response
@@ -277,4 +270,83 @@ func TestServer_ContextCancellation(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Error("Feed after context cancellation deadlocked")
 	}
+}
+
+// TestServer_SlowHandlerDoesNotBlockConcurrentRPC proves that the server
+// dispatches messages concurrently: a request whose handler blocks until
+// released must not delay the response to a second, unrelated, fast request
+// fed immediately afterward. Before per-message dispatch, the server
+// processed inMsg strictly sequentially in one goroutine, so a slow handler
+// head-of-line-blocked every other RPC (see #361).
+func TestServer_SlowHandlerDoesNotBlockConcurrentRPC(t *testing.T) {
+	ctx, cancel := context.WithCancel(newServerCtx())
+	defer cancel()
+
+	mc := mqtt.NewRecordingMockClient()
+
+	release := make(chan struct{})
+	slowStarted := make(chan struct{})
+	handler := &stubServer{
+		method: &Method{
+			Name: "test.slow-or-fast",
+			Action: func(ctx context.Context, raw json.RawMessage) (any, error) {
+				var p struct {
+					Slow bool `json:"slow"`
+				}
+				_ = json.Unmarshal(raw, &p)
+				if p.Slow {
+					close(slowStarted)
+					select {
+					case <-release:
+					case <-ctx.Done():
+					}
+					return "slow-done", nil
+				}
+				return "fast-done", nil
+			},
+		},
+	}
+
+	_, err := NewServerE(ctx, mc, handler)
+	if err != nil {
+		t.Fatalf("NewServerE: %v", err)
+	}
+
+	const slowSrc = "slow-client"
+	const fastSrc = "fast-client"
+
+	feedRequest(t, mc, request{
+		Dialog: Dialog{Id: "slow-1", Src: slowSrc, Dst: InstanceName},
+		Method: "test.slow-or-fast",
+		Params: json.RawMessage(`{"slow":true}`),
+	})
+
+	select {
+	case <-slowStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow handler never started")
+	}
+
+	feedRequest(t, mc, request{
+		Dialog: Dialog{Id: "fast-1", Src: fastSrc, Dst: InstanceName},
+		Method: "test.slow-or-fast",
+		Params: json.RawMessage(`{"slow":false}`),
+	})
+
+	// The fast response must arrive well before the slow handler is released.
+	fastRaw := waitPublished(t, mc, ClientTopic(fastSrc))
+	var fastRes response
+	if err := json.Unmarshal(fastRaw, &fastRes); err != nil {
+		t.Fatalf("unmarshal fast response: %v", err)
+	}
+	var fastResult string
+	if err := json.Unmarshal(fastRes.Result, &fastResult); err != nil {
+		t.Fatalf("unmarshal fast result: %v", err)
+	}
+	if fastResult != "fast-done" {
+		t.Errorf("fast result: got %q, want %q", fastResult, "fast-done")
+	}
+
+	close(release)
+	waitPublished(t, mc, ClientTopic(slowSrc))
 }

--- a/internal/myhome/shelly/script/heater.go
+++ b/internal/myhome/shelly/script/heater.go
@@ -50,12 +50,8 @@ func NewHeaterService(log logr.Logger, provider DeviceProvider) *HeaterService {
 
 // RegisterHandlers registers the heater RPC handlers
 func (s *HeaterService) RegisterHandlers() {
-	myhome.RegisterMethodHandler(myhome.HeaterGetConfig, func(ctx context.Context, in any) (any, error) {
-		return s.HandleGetConfig(ctx, in.(*myhome.HeaterGetConfigParams))
-	})
-	myhome.RegisterMethodHandler(myhome.HeaterSetConfig, func(ctx context.Context, in any) (any, error) {
-		return s.HandleSetConfig(ctx, in.(*myhome.HeaterSetConfigParams))
-	})
+	myhome.Register(myhome.HeaterGetConfig, s.HandleGetConfig)
+	myhome.Register(myhome.HeaterSetConfig, s.HandleSetConfig)
 }
 
 // HandleGetConfig returns the heater configuration for a device

--- a/internal/myhome/shelly/sswitch/service.go
+++ b/internal/myhome/shelly/sswitch/service.go
@@ -38,21 +38,11 @@ func NewService(log logr.Logger, provider DeviceProvider) *Service {
 
 // RegisterHandlers registers the switch RPC handlers
 func (s *Service) RegisterHandlers() {
-	myhome.RegisterMethodHandler(myhome.SwitchToggle, func(ctx context.Context, in any) (any, error) {
-		return s.HandleToggle(ctx, in.(*myhome.SwitchParams))
-	})
-	myhome.RegisterMethodHandler(myhome.SwitchOn, func(ctx context.Context, in any) (any, error) {
-		return s.HandleOn(ctx, in.(*myhome.SwitchParams))
-	})
-	myhome.RegisterMethodHandler(myhome.SwitchOff, func(ctx context.Context, in any) (any, error) {
-		return s.HandleOff(ctx, in.(*myhome.SwitchParams))
-	})
-	myhome.RegisterMethodHandler(myhome.SwitchStatus, func(ctx context.Context, in any) (any, error) {
-		return s.HandleStatus(ctx, in.(*myhome.SwitchParams))
-	})
-	myhome.RegisterMethodHandler(myhome.SwitchAll, func(ctx context.Context, in any) (any, error) {
-		return s.HandleAll(ctx, in.(*myhome.SwitchAllParams))
-	})
+	myhome.Register(myhome.SwitchToggle, s.HandleToggle)
+	myhome.Register(myhome.SwitchOn, s.HandleOn)
+	myhome.Register(myhome.SwitchOff, s.HandleOff)
+	myhome.Register(myhome.SwitchStatus, s.HandleStatus)
+	myhome.Register(myhome.SwitchAll, s.HandleAll)
 }
 
 // HandleToggle handles switch.toggle RPC method

--- a/internal/myhome/ui/htmx.go
+++ b/internal/myhome/ui/htmx.go
@@ -195,8 +195,7 @@ func (h *HTMXHandler) RoomsList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := mh.Signature.NewParams()
-	res, err := mh.ActionE(h.ctx, params)
+	res, err := mh.Call(h.ctx, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -245,7 +244,7 @@ func (h *HTMXHandler) SwitchButton(w http.ResponseWriter, r *http.Request) {
 		SwitchId:   sid,
 	}
 
-	res, err := mh.ActionE(h.ctx, params)
+	res, err := mh.Call(h.ctx, params)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/myhome/ui/rpc.go
+++ b/internal/myhome/ui/rpc.go
@@ -32,20 +32,11 @@ func RpcHandler(ctx context.Context, log logr.Logger) func(w http.ResponseWriter
 			return
 		}
 
-		// Decode params into the expected type for this method
-		params := mh.Signature.NewParams()
-		if len(req.Params) > 0 {
-			if err := json.Unmarshal(req.Params, &params); err != nil {
-				log.Error(err, "invalid params", "method", req.Method)
-				http.Error(w, "invalid params: "+err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-
-		var res any
-
-		// Call method
-		res, err = mh.ActionE(ctx, params)
+		// mh.Action decodes req.Params directly into the handler's declared
+		// parameter type — exactly the same raw-JSON entry point the server
+		// uses for a wire request, so there is no separate NewParams/Unmarshal
+		// step here anymore.
+		res, err := mh.Action(ctx, req.Params)
 		if err != nil {
 			log.Error(err, "method failed", "method", req.Method)
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/myhome/ui/template.go
+++ b/internal/myhome/ui/template.go
@@ -87,7 +87,7 @@ func applyPoolStatus(ctx context.Context, views []DeviceView) {
 	if err != nil {
 		return // pool RPC not registered (pool tracking disabled)
 	}
-	res, err := mh.ActionE(ctx, nil)
+	res, err := mh.Call(ctx, nil)
 	if err != nil {
 		return // device unreachable / KVS misconfigured — leave fields blank
 	}

--- a/myhome/ctl/db/export.go
+++ b/myhome/ctl/db/export.go
@@ -77,27 +77,21 @@ Examples:
 		// Export temperature tables unless --devices-only is set
 		if !exportFlags.DevicesOnly {
 			// Get temperature rooms
-			roomsResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureList, nil)
-			if err == nil {
-				if rooms, ok := roomsResult.(*myhome.TemperatureRoomList); ok && len(*rooms) > 0 {
-					export.TemperatureRooms = *rooms
-				}
+			rooms, err := myhome.Call[any, *myhome.TemperatureRoomList](ctx, myhome.TheClient, myhome.TemperatureList, nil)
+			if err == nil && rooms != nil && len(*rooms) > 0 {
+				export.TemperatureRooms = *rooms
 			}
 
 			// Get weekday defaults
-			weekdayResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetWeekdayDefaults, &myhome.TemperatureGetWeekdayDefaultsParams{})
-			if err == nil {
-				if weekdayDefaults, ok := weekdayResult.(*myhome.TemperatureWeekdayDefaults); ok && len(weekdayDefaults.Defaults) > 0 {
-					export.WeekdayDefaults = weekdayDefaults.Defaults
-				}
+			weekdayDefaults, err := myhome.Call[*myhome.TemperatureGetWeekdayDefaultsParams, *myhome.TemperatureWeekdayDefaults](ctx, myhome.TheClient, myhome.TemperatureGetWeekdayDefaults, &myhome.TemperatureGetWeekdayDefaultsParams{})
+			if err == nil && weekdayDefaults != nil && len(weekdayDefaults.Defaults) > 0 {
+				export.WeekdayDefaults = weekdayDefaults.Defaults
 			}
 
 			// Get kind schedules
-			kindSchedulesResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetKindSchedules, &myhome.TemperatureGetKindSchedulesParams{})
-			if err == nil {
-				if kindSchedules, ok := kindSchedulesResult.(*myhome.TemperatureKindScheduleList); ok && len(*kindSchedules) > 0 {
-					export.KindSchedules = *kindSchedules
-				}
+			kindSchedules, err := myhome.Call[*myhome.TemperatureGetKindSchedulesParams, *myhome.TemperatureKindScheduleList](ctx, myhome.TheClient, myhome.TemperatureGetKindSchedules, &myhome.TemperatureGetKindSchedulesParams{})
+			if err == nil && kindSchedules != nil && len(*kindSchedules) > 0 {
+				export.KindSchedules = *kindSchedules
 			}
 		}
 

--- a/myhome/ctl/db/import.go
+++ b/myhome/ctl/db/import.go
@@ -102,7 +102,7 @@ Examples:
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				_, err := myhome.TheClient.CallE(ctx, myhome.DeviceUpdate, &device)
+				_, err := myhome.Call[*myhome.Device, any](ctx, myhome.TheClient, myhome.DeviceUpdate, &device)
 				if err != nil {
 					// Check if this is a context cancellation error
 					if ctx.Err() != nil {
@@ -126,7 +126,7 @@ Examples:
 					Kinds:  roomConfig.Kinds,
 					Levels: roomConfig.Levels,
 				}
-				_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
+				_, err := myhome.Call[*myhome.TemperatureSetParams, *myhome.TemperatureSetResult](ctx, myhome.TheClient, myhome.TemperatureSet, params)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "⚠ Failed to import room %s: %v\n", roomID, err)
 					continue
@@ -141,7 +141,7 @@ Examples:
 					Weekday: weekday,
 					DayType: dayType,
 				}
-				_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSetWeekdayDefault, params)
+				_, err := myhome.Call[*myhome.TemperatureSetWeekdayDefaultParams, *myhome.TemperatureSetWeekdayDefaultResult](ctx, myhome.TheClient, myhome.TemperatureSetWeekdayDefault, params)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "⚠ Failed to import weekday default %d: %v\n", weekday, err)
 					continue
@@ -166,7 +166,7 @@ Examples:
 					DayType: schedule.DayType,
 					Ranges:  rangeStrs,
 				}
-				_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSetKindSchedule, params)
+				_, err := myhome.Call[*myhome.TemperatureSetKindScheduleParams, *myhome.TemperatureSetKindScheduleResult](ctx, myhome.TheClient, myhome.TemperatureSetKindSchedule, params)
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "⚠ Failed to import kind schedule %s/%s: %v\n", schedule.Kind, schedule.DayType, err)
 					continue

--- a/myhome/ctl/db/pull.go
+++ b/myhome/ctl/db/pull.go
@@ -118,7 +118,7 @@ Examples:
 		// Import each device
 		imported := 0
 		for _, device := range devices {
-			_, err := myhome.TheClient.CallE(cmd.Context(), myhome.DeviceUpdate, &device)
+			_, err := myhome.Call[*myhome.Device, any](cmd.Context(), myhome.TheClient, myhome.DeviceUpdate, &device)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "⚠ Failed to import %s: %v\n", device.Id(), err)
 				continue

--- a/myhome/ctl/events/events.go
+++ b/myhome/ctl/events/events.go
@@ -66,14 +66,12 @@ var listCmd = &cobra.Command{
 			Limit:     listLimit,
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.EventList, req)
+		resp, err := myhome.Call[*myhome.EventListRequest, *myhome.EventListResponse](ctx, myhome.TheClient, myhome.EventList, req)
 		if err != nil {
 			return err
 		}
-
-		resp, ok := result.(*myhome.EventListResponse)
-		if !ok {
-			return fmt.Errorf("unexpected result type: %T", result)
+		if resp == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		if listJSON || options.Flags.Json {

--- a/myhome/ctl/heater/setup.go
+++ b/myhome/ctl/heater/setup.go
@@ -122,7 +122,7 @@ func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device she
 			Identifier: sd.Id(),
 			RoomId:     setupFlags.RoomId,
 		}
-		_, err := myhome.TheClient.CallE(ctx, myhome.DeviceSetRoom, params)
+		_, err := myhome.Call[*myhome.DeviceSetRoomParams, any](ctx, myhome.TheClient, myhome.DeviceSetRoom, params)
 		if err != nil {
 			fmt.Printf("  ⚠ Failed to set device room in DB: %v\n", err)
 		} else {
@@ -205,12 +205,12 @@ func discoverDoorSensorsInRoom(ctx context.Context, roomId string) ([]string, er
 	params := &myhome.DeviceListByRoomParams{
 		RoomId: roomId,
 	}
-	result, err := myhome.TheClient.CallE(ctx, myhome.DeviceListByRoom, params)
+	result, err := myhome.Call[*myhome.DeviceListByRoomParams, *myhome.DeviceListByRoomResult](ctx, myhome.TheClient, myhome.DeviceListByRoom, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list devices in room: %w", err)
 	}
 
-	devices := result.(*myhome.DeviceListByRoomResult).Devices
+	devices := result.Devices
 	var topics []string
 
 	for _, d := range devices {

--- a/myhome/ctl/pool/status.go
+++ b/myhome/ctl/pool/status.go
@@ -85,15 +85,14 @@ With a device identifier pattern, queries only matching devices.`,
 // best-effort addition: if the daemon has pool tracking disabled or is
 // unreachable, it prints a short note instead of failing the whole command.
 func printFiltrationStatus(ctx context.Context) {
-	out, err := myhome.TheClient.CallE(ctx, myhome.PoolGetStatus, nil)
+	status, err := myhome.Call[any, *myhome.PoolGetStatusResult](ctx, myhome.TheClient, myhome.PoolGetStatus, nil)
 	if err != nil {
 		fmt.Println("Filtration Status")
 		fmt.Println("=================")
 		fmt.Printf("  (unavailable: %v)\n\n", err)
 		return
 	}
-	status, ok := out.(*myhome.PoolGetStatusResult)
-	if !ok {
+	if status == nil {
 		return
 	}
 

--- a/myhome/ctl/room/clear.go
+++ b/myhome/ctl/room/clear.go
@@ -21,7 +21,7 @@ var clearCmd = &cobra.Command{
 			RoomId:     "", // Empty string clears the room
 		}
 
-		_, err := myhome.TheClient.CallE(cmd.Context(), myhome.DeviceSetRoom, params)
+		_, err := myhome.Call[*myhome.DeviceSetRoomParams, any](cmd.Context(), myhome.TheClient, myhome.DeviceSetRoom, params)
 		if err != nil {
 			return err
 		}

--- a/myhome/ctl/room/list.go
+++ b/myhome/ctl/room/list.go
@@ -24,12 +24,12 @@ If no room-id is provided, lists all devices that have a room assignment.`,
 				RoomId: roomId,
 			}
 
-			result, err := myhome.TheClient.CallE(cmd.Context(), myhome.DeviceListByRoom, params)
+			result, err := myhome.Call[*myhome.DeviceListByRoomParams, *myhome.DeviceListByRoomResult](cmd.Context(), myhome.TheClient, myhome.DeviceListByRoom, params)
 			if err != nil {
 				return err
 			}
 
-			devices := result.(*myhome.DeviceListByRoomResult).Devices
+			devices := result.Devices
 			if len(devices) == 0 {
 				fmt.Printf("No devices in room %s\n", roomId)
 				return nil
@@ -41,17 +41,15 @@ If no room-id is provided, lists all devices that have a room assignment.`,
 			}
 		} else {
 			// List all devices with room assignments via DevicesMatch
-			result, err := myhome.TheClient.CallE(cmd.Context(), myhome.DevicesMatch, "*")
+			devices, err := myhome.Call[string, []myhome.DeviceSummary](cmd.Context(), myhome.TheClient, myhome.DevicesMatch, "*")
 			if err != nil {
 				return err
 			}
 
-			devices := result.(*[]myhome.DeviceSummary)
-
 			// We need full device info to get room_id, so we'll list by room instead
 			// For now, just show a message
 			fmt.Println("Use 'myhome ctl room list <room-id>' to list devices in a specific room")
-			fmt.Printf("Found %d devices total\n", len(*devices))
+			fmt.Printf("Found %d devices total\n", len(devices))
 		}
 		return nil
 	},

--- a/myhome/ctl/room/set.go
+++ b/myhome/ctl/room/set.go
@@ -25,7 +25,7 @@ Use an empty string "" to remove the room assignment.`,
 			RoomId:     roomId,
 		}
 
-		_, err := myhome.TheClient.CallE(cmd.Context(), myhome.DeviceSetRoom, params)
+		_, err := myhome.Call[*myhome.DeviceSetRoomParams, any](cmd.Context(), myhome.TheClient, myhome.DeviceSetRoom, params)
 		if err != nil {
 			return err
 		}

--- a/myhome/ctl/shelly/setup/main.go
+++ b/myhome/ctl/shelly/setup/main.go
@@ -117,7 +117,7 @@ func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device she
 		// Save name to DB if provided (via RPC to daemon)
 		if targetName != "" && targetName != sd.Name() && myhome.TheClient != nil {
 			fmt.Printf("  . Updating device name in DB: %s\n", targetName)
-			_, err := myhome.TheClient.CallE(ctx, myhome.DeviceSetup, &myhome.DeviceSetupParams{
+			_, err := myhome.Call[*myhome.DeviceSetupParams, any](ctx, myhome.TheClient, myhome.DeviceSetup, &myhome.DeviceSetupParams{
 				Identifier: sd.Id(),
 				Name:       targetName,
 			})
@@ -215,7 +215,7 @@ func doSetup(ctx context.Context, log logr.Logger, via types.Channel, device she
 
 	// Trigger device refresh via myhome RPC to sync DB (if client is available)
 	if myhome.TheClient != nil {
-		if _, refreshErr := myhome.TheClient.CallE(ctx, myhome.DeviceRefresh, sd.Id()); refreshErr != nil {
+		if _, refreshErr := myhome.Call[string, *myhome.Device](ctx, myhome.TheClient, myhome.DeviceRefresh, sd.Id()); refreshErr != nil {
 			log.V(1).Info("Could not trigger device refresh via RPC", "error", refreshErr)
 		} else {
 			fmt.Printf("  ✓ Device refresh triggered\n")

--- a/myhome/ctl/show/shelly.go
+++ b/myhome/ctl/show/shelly.go
@@ -48,14 +48,13 @@ var showShellyCmd = &cobra.Command{
 			// Fetch full device info for each matched device
 			fullDevices := make([]*myhome.Device, 0, len(*devices))
 			for _, dev := range *devices {
-				out, err := myhome.TheClient.CallE(ctx, myhome.DeviceShow, &myhome.DeviceShowParams{Identifier: dev.Id()})
+				device, err := myhome.Call[*myhome.DeviceShowParams, *myhome.Device](ctx, myhome.TheClient, myhome.DeviceShow, &myhome.DeviceShowParams{Identifier: dev.Id()})
 				if err != nil {
 					log.Error(err, "failed to fetch device details", "id", dev.Id())
 					continue
 				}
-				device, ok := out.(*myhome.Device)
-				if !ok {
-					log.Error(fmt.Errorf("unexpected type: expected *myhome.Device"), "id", dev.Id())
+				if device == nil {
+					log.Error(fmt.Errorf("nil device"), "id", dev.Id())
 					continue
 				}
 				fullDevices = append(fullDevices, device)

--- a/myhome/ctl/show/show.go
+++ b/myhome/ctl/show/show.go
@@ -26,12 +26,11 @@ var Cmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log := hlog.Logger
 
-		out, err := myhome.TheClient.CallE(cmd.Context(), myhome.DeviceShow, &myhome.DeviceShowParams{Identifier: args[0]})
+		device, err := myhome.Call[*myhome.DeviceShowParams, *myhome.Device](cmd.Context(), myhome.TheClient, myhome.DeviceShow, &myhome.DeviceShowParams{Identifier: args[0]})
 		if err != nil {
 			return err
 		}
-		log.Info("result", "out", out, "type", reflect.TypeOf(out))
-		device := out.(*myhome.Device)
+		log.Info("result", "device", device, "type", reflect.TypeOf(device))
 		if options.Flags.Json {
 			s, err := json.Marshal(device)
 			if err != nil {

--- a/myhome/ctl/temperature/save_load.go
+++ b/myhome/ctl/temperature/save_load.go
@@ -37,33 +37,30 @@ Examples:
 		ctx := cmd.Context()
 
 		// Get all rooms
-		roomsResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureList, nil)
+		rooms, err := myhome.Call[any, *myhome.TemperatureRoomList](ctx, myhome.TheClient, myhome.TemperatureList, nil)
 		if err != nil {
 			return fmt.Errorf("failed to get rooms: %w", err)
 		}
-		rooms, ok := roomsResult.(*myhome.TemperatureRoomList)
-		if !ok {
-			return fmt.Errorf("unexpected result type for rooms")
+		if rooms == nil {
+			return fmt.Errorf("unexpected nil result for rooms")
 		}
 
 		// Get weekday defaults
-		weekdayResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetWeekdayDefaults, &myhome.TemperatureGetWeekdayDefaultsParams{})
+		weekdayDefaults, err := myhome.Call[*myhome.TemperatureGetWeekdayDefaultsParams, *myhome.TemperatureWeekdayDefaults](ctx, myhome.TheClient, myhome.TemperatureGetWeekdayDefaults, &myhome.TemperatureGetWeekdayDefaultsParams{})
 		if err != nil {
 			return fmt.Errorf("failed to get weekday defaults: %w", err)
 		}
-		weekdayDefaults, ok := weekdayResult.(*myhome.TemperatureWeekdayDefaults)
-		if !ok {
-			return fmt.Errorf("unexpected result type for weekday defaults")
+		if weekdayDefaults == nil {
+			return fmt.Errorf("unexpected nil result for weekday defaults")
 		}
 
 		// Get kind schedules
-		kindSchedulesResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetKindSchedules, &myhome.TemperatureGetKindSchedulesParams{})
+		kindSchedules, err := myhome.Call[*myhome.TemperatureGetKindSchedulesParams, *myhome.TemperatureKindScheduleList](ctx, myhome.TheClient, myhome.TemperatureGetKindSchedules, &myhome.TemperatureGetKindSchedulesParams{})
 		if err != nil {
 			return fmt.Errorf("failed to get kind schedules: %w", err)
 		}
-		kindSchedules, ok := kindSchedulesResult.(*myhome.TemperatureKindScheduleList)
-		if !ok {
-			return fmt.Errorf("unexpected result type for kind schedules")
+		if kindSchedules == nil {
+			return fmt.Errorf("unexpected nil result for kind schedules")
 		}
 
 		// Build complete config
@@ -120,7 +117,7 @@ Examples:
 				Kinds:  roomConfig.Kinds,
 				Levels: roomConfig.Levels,
 			}
-			_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
+			_, err := myhome.Call[*myhome.TemperatureSetParams, *myhome.TemperatureSetResult](ctx, myhome.TheClient, myhome.TemperatureSet, params)
 			if err != nil {
 				return fmt.Errorf("failed to set room %s: %w", roomID, err)
 			}
@@ -134,7 +131,7 @@ Examples:
 				Weekday: weekday,
 				DayType: dayType,
 			}
-			_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSetWeekdayDefault, params)
+			_, err := myhome.Call[*myhome.TemperatureSetWeekdayDefaultParams, *myhome.TemperatureSetWeekdayDefaultResult](ctx, myhome.TheClient, myhome.TemperatureSetWeekdayDefault, params)
 			if err != nil {
 				return fmt.Errorf("failed to set weekday default for weekday %d: %w", weekday, err)
 			}
@@ -156,7 +153,7 @@ Examples:
 				DayType: schedule.DayType,
 				Ranges:  rangeStrs,
 			}
-			_, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSetKindSchedule, params)
+			_, err := myhome.Call[*myhome.TemperatureSetKindScheduleParams, *myhome.TemperatureSetKindScheduleResult](ctx, myhome.TheClient, myhome.TemperatureSetKindSchedule, params)
 			if err != nil {
 				return fmt.Errorf("failed to set kind schedule for %s/%s: %w", schedule.Kind, schedule.DayType, err)
 			}

--- a/myhome/ctl/temperature/temperature.go
+++ b/myhome/ctl/temperature/temperature.go
@@ -49,14 +49,12 @@ var getCmd = &cobra.Command{
 			RoomID: roomID,
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGet, params)
+		config, err := myhome.Call[*myhome.TemperatureGetParams, *myhome.TemperatureRoomConfig](ctx, myhome.TheClient, myhome.TemperatureGet, params)
 		if err != nil {
 			return err
 		}
-
-		config, ok := result.(*myhome.TemperatureRoomConfig)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if config == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		// Use JSON/YAML output if flag is set
@@ -121,13 +119,12 @@ Examples:
 		awaySet := cmd.Flags().Changed("away")
 
 		// Get list of all rooms to find matches
-		listResult, err := myhome.TheClient.CallE(ctx, myhome.TemperatureList, nil)
+		allRooms, err := myhome.Call[any, *myhome.TemperatureRoomList](ctx, myhome.TheClient, myhome.TemperatureList, nil)
 		if err != nil {
 			return fmt.Errorf("failed to list rooms: %w", err)
 		}
-		allRooms, ok := listResult.(*myhome.TemperatureRoomList)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if allRooms == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		// Find matching rooms
@@ -142,14 +139,12 @@ Examples:
 				return err
 			}
 
-			result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
+			setResult, err := myhome.Call[*myhome.TemperatureSetParams, *myhome.TemperatureSetResult](ctx, myhome.TheClient, myhome.TemperatureSet, params)
 			if err != nil {
 				return err
 			}
-
-			setResult, ok := result.(*myhome.TemperatureSetResult)
-			if !ok {
-				return fmt.Errorf("unexpected result type")
+			if setResult == nil {
+				return fmt.Errorf("unexpected nil result")
 			}
 
 			fmt.Printf("✓ Temperature configuration saved for room: %s\n", setResult.RoomID)
@@ -168,7 +163,7 @@ Examples:
 				return err
 			}
 
-			_, err = myhome.TheClient.CallE(ctx, myhome.TemperatureSet, params)
+			_, err = myhome.Call[*myhome.TemperatureSetParams, *myhome.TemperatureSetResult](ctx, myhome.TheClient, myhome.TemperatureSet, params)
 			if err != nil {
 				fmt.Printf("✗ Failed to update room %s: %v\n", roomID, err)
 				continue
@@ -191,14 +186,12 @@ var listCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureList, nil)
+		rooms, err := myhome.Call[any, *myhome.TemperatureRoomList](ctx, myhome.TheClient, myhome.TemperatureList, nil)
 		if err != nil {
 			return err
 		}
-
-		rooms, ok := result.(*myhome.TemperatureRoomList)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if rooms == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		if len(*rooms) == 0 {
@@ -238,14 +231,12 @@ var deleteCmd = &cobra.Command{
 			RoomID: roomID,
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureDelete, params)
+		deleteResult, err := myhome.Call[*myhome.TemperatureDeleteParams, *myhome.TemperatureDeleteResult](ctx, myhome.TheClient, myhome.TemperatureDelete, params)
 		if err != nil {
 			return err
 		}
-
-		deleteResult, ok := result.(*myhome.TemperatureDeleteResult)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if deleteResult == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		fmt.Printf("✓ Temperature configuration deleted for room: %s\n", deleteResult.RoomID)
@@ -279,14 +270,12 @@ Date format: YYYY-MM-DD (defaults to today if not specified)`,
 			params.Date = &date
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetSchedule, params)
+		schedule, err := myhome.Call[*myhome.TemperatureGetScheduleParams, *myhome.TemperatureScheduleResult](ctx, myhome.TheClient, myhome.TemperatureGetSchedule, params)
 		if err != nil {
 			return err
 		}
-
-		schedule, ok := result.(*myhome.TemperatureScheduleResult)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if schedule == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		// Display result
@@ -336,14 +325,12 @@ Examples:
 
 		params := &myhome.TemperatureGetWeekdayDefaultsParams{}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetWeekdayDefaults, params)
+		defaults, err := myhome.Call[*myhome.TemperatureGetWeekdayDefaultsParams, *myhome.TemperatureWeekdayDefaults](ctx, myhome.TheClient, myhome.TemperatureGetWeekdayDefaults, params)
 		if err != nil {
 			return err
 		}
-
-		defaults, ok := result.(*myhome.TemperatureWeekdayDefaults)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if defaults == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		fmt.Printf("Global Weekday Defaults:\n\n")
@@ -393,14 +380,12 @@ Examples:
 			DayType: dayType,
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSetWeekdayDefault, params)
+		setResult, err := myhome.Call[*myhome.TemperatureSetWeekdayDefaultParams, *myhome.TemperatureSetWeekdayDefaultResult](ctx, myhome.TheClient, myhome.TemperatureSetWeekdayDefault, params)
 		if err != nil {
 			return err
 		}
-
-		setResult, ok := result.(*myhome.TemperatureSetWeekdayDefaultResult)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if setResult == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		fmt.Printf("✓ Set %s to %s (global default)\n", formatWeekday(setResult.Weekday), setResult.DayType)
@@ -449,14 +434,12 @@ Examples:
 			params.DayType = &dayType
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureGetKindSchedules, params)
+		schedules, err := myhome.Call[*myhome.TemperatureGetKindSchedulesParams, *myhome.TemperatureKindScheduleList](ctx, myhome.TheClient, myhome.TemperatureGetKindSchedules, params)
 		if err != nil {
 			return err
 		}
-
-		schedules, ok := result.(*myhome.TemperatureKindScheduleList)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if schedules == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		if len(*schedules) == 0 {
@@ -538,14 +521,12 @@ Examples:
 			Ranges:  ranges,
 		}
 
-		result, err := myhome.TheClient.CallE(ctx, myhome.TemperatureSetKindSchedule, params)
+		setResult, err := myhome.Call[*myhome.TemperatureSetKindScheduleParams, *myhome.TemperatureSetKindScheduleResult](ctx, myhome.TheClient, myhome.TemperatureSetKindSchedule, params)
 		if err != nil {
 			return err
 		}
-
-		setResult, ok := result.(*myhome.TemperatureSetKindScheduleResult)
-		if !ok {
-			return fmt.Errorf("unexpected result type")
+		if setResult == nil {
+			return fmt.Errorf("unexpected nil result")
 		}
 
 		fmt.Printf("✓ Set comfort ranges for room kind '%s' on %s\n", setResult.Kind, setResult.DayType)

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -465,11 +465,7 @@ func (d *daemon) Run() error {
 
 		// Register EventList RPC handler if events service is running
 		if eventsStore != nil {
-			myhome.RegisterMethodHandler(myhome.EventList, func(ctx context.Context, in any) (any, error) {
-				req, ok := in.(*myhome.EventListRequest)
-				if !ok {
-					return nil, fmt.Errorf("unexpected param type: %T", in)
-				}
+			myhome.Register(myhome.EventList, func(ctx context.Context, req *myhome.EventListRequest) (*myhome.EventListResponse, error) {
 				q := events.Query{
 					DeviceID:  req.DeviceID,
 					EventType: req.EventType,

--- a/myhome/daemon/pool_rpc.go
+++ b/myhome/daemon/pool_rpc.go
@@ -27,11 +27,11 @@ func NewPoolRPCHandler(log logr.Logger, pool *PoolNotices) *PoolRPCHandler {
 
 // RegisterHandlers registers the pool.getstatus RPC method.
 func (h *PoolRPCHandler) RegisterHandlers() {
-	myhome.RegisterMethodHandler(myhome.PoolGetStatus, h.handleGetStatus)
+	myhome.Register(myhome.PoolGetStatus, h.handleGetStatus)
 	h.log.Info("Pool RPC handler registered")
 }
 
-func (h *PoolRPCHandler) handleGetStatus(ctx context.Context, _ any) (any, error) {
+func (h *PoolRPCHandler) handleGetStatus(ctx context.Context, _ any) (*myhome.PoolGetStatusResult, error) {
 	if h.pool == nil {
 		return nil, fmt.Errorf("pool status unavailable: pool device not configured or unreachable")
 	}

--- a/myhome/devices/impl/manager.go
+++ b/myhome/devices/impl/manager.go
@@ -75,8 +75,7 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 		sseBroadcaster: sseBroadcaster,
 	}
 
-	myhome.RegisterMethodHandler(myhome.DevicesMatch, func(ctx context.Context, in any) (any, error) {
-		name := in.(string)
+	myhome.Register(myhome.DevicesMatch, func(ctx context.Context, name string) (*[]devices.Device, error) {
 		devices := make([]devices.Device, 0)
 
 		var ds []*myhome.Device
@@ -100,9 +99,7 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 		}
 		return &devices, nil
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceLookup, func(ctx context.Context, in any) (any, error) {
-		name := in.(string)
-
+	myhome.Register(myhome.DeviceLookup, func(ctx context.Context, name string) (*[]devices.Device, error) {
 		devices := make([]devices.Device, 0)
 		device, err := dm.GetDeviceByAny(ctx, name)
 		if err == nil {
@@ -113,16 +110,14 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 
 		return nil, fmt.Errorf("failed to get device by identifier: %w", err)
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceShow, func(ctx context.Context, in any) (any, error) {
-		params := in.(*myhome.DeviceShowParams)
+	myhome.Register(myhome.DeviceShow, func(ctx context.Context, params *myhome.DeviceShowParams) (*myhome.Device, error) {
 		return dm.GetDeviceByAny(ctx, params.Identifier)
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceForget, func(ctx context.Context, in any) (any, error) {
-		return nil, dm.ForgetDevice(ctx, in.(string))
+	myhome.Register(myhome.DeviceForget, func(ctx context.Context, identifier string) (any, error) {
+		return nil, dm.ForgetDevice(ctx, identifier)
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceRefresh, func(ctx context.Context, in any) (any, error) {
+	myhome.Register(myhome.DeviceRefresh, func(ctx context.Context, ident string) (*myhome.Device, error) {
 		log := dm.log.WithName("rpc/device.refresh")
-		ident := in.(string)
 		log.V(1).Info("New", "ident", ident)
 		device, err := dm.GetDeviceByAny(ctx, ident)
 		if err != nil {
@@ -162,8 +157,7 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 
 		return device, nil
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceSetup, func(ctx context.Context, in any) (any, error) {
-		params := in.(*myhome.DeviceSetupParams)
+	myhome.Register(myhome.DeviceSetup, func(ctx context.Context, params *myhome.DeviceSetupParams) (any, error) {
 		log := dm.log.WithName("rpc/device.setup")
 		log.V(1).Info("New", "params", params)
 		device, err := dm.GetDeviceByAny(ctx, params.Identifier)
@@ -245,8 +239,7 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 		log.V(1).Info("Setup complete", "device", device.Id())
 		return nil, nil
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceUpdate, func(ctx context.Context, in any) (any, error) {
-		device := in.(*myhome.Device)
+	myhome.Register(myhome.DeviceUpdate, func(ctx context.Context, device *myhome.Device) (any, error) {
 		log := dm.log.WithName("rpc/device.update")
 		log.V(1).Info("New", "id", device.Id(), "name", device.Name())
 
@@ -264,10 +257,9 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 
 		return nil, nil
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceSetRoom, func(ctx context.Context, in any) (any, error) {
+	myhome.Register(myhome.DeviceSetRoom, func(ctx context.Context, params *myhome.DeviceSetRoomParams) (any, error) {
 		var err error
 
-		params := in.(*myhome.DeviceSetRoomParams)
 		log := dm.log.WithName("rpc/device.setroom")
 		log.V(1).Info("New", "identifier", params.Identifier, "room_id", params.RoomId)
 		// Save room to database
@@ -310,8 +302,7 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 
 		return nil, nil
 	})
-	myhome.RegisterMethodHandler(myhome.DeviceListByRoom, func(ctx context.Context, in any) (any, error) {
-		params := in.(*myhome.DeviceListByRoomParams)
+	myhome.Register(myhome.DeviceListByRoom, func(ctx context.Context, params *myhome.DeviceListByRoomParams) (*myhome.DeviceListByRoomResult, error) {
 		log := dm.log.WithName("rpc/device.listbyroom")
 		log.V(1).Info("New", "room_id", params.RoomId)
 		devices, err := dm.dr.GetDevicesByRoom(ctx, params.RoomId)
@@ -321,10 +312,10 @@ func NewDeviceManager(ctx context.Context, s *storage.DeviceStorage, resolver my
 		}
 		return &myhome.DeviceListByRoomResult{Devices: devices}, nil
 	})
-	myhome.RegisterMethodHandler(myhome.ThermometerList, func(ctx context.Context, in any) (any, error) {
+	myhome.Register(myhome.ThermometerList, func(ctx context.Context, _ any) (*myhome.ThermometerListResult, error) {
 		return dm.HandleThermometerList(ctx)
 	})
-	myhome.RegisterMethodHandler(myhome.DoorList, func(ctx context.Context, in any) (any, error) {
+	myhome.Register(myhome.DoorList, func(ctx context.Context, _ any) (*myhome.DoorListResult, error) {
 		return dm.HandleDoorList(ctx)
 	})
 
@@ -803,17 +794,11 @@ func (dm *DeviceManager) CallE(ctx context.Context, method myhome.Verb, params a
 	if err != nil {
 		return nil, err
 	}
-	// if mh.InType != reflect.TypeOf(params) {
-	// 	return nil, fmt.Errorf("invalid parameters for method %s: got %v, want %v", method, reflect.TypeOf(params), mh.InType)
-	// }
-	result, err := mh.ActionE(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-	// if mh.OutType != reflect.TypeOf(result) {
-	// 	return nil, fmt.Errorf("invalid type for method %s: got %v, want %v", method, reflect.TypeOf(result), mh.OutType)
-	// }
-	return result, nil
+	// Method.Call marshals params once (mirroring the wire path) and
+	// delegates to the registered handler's generic Action, so this
+	// in-process short-circuit decodes through the exact same logic a real
+	// MQTT request would.
+	return mh.Call(ctx, params)
 }
 
 func (dm *DeviceManager) MethodE(method myhome.Verb) (*myhome.Method, error) {

--- a/myhome/occupancy/rpc.go
+++ b/myhome/occupancy/rpc.go
@@ -25,12 +25,12 @@ func NewRPCHandler(log logr.Logger, service *Service) *RPCHandler {
 
 // RegisterHandlers registers occupancy RPC methods
 func (h *RPCHandler) RegisterHandlers() {
-	myhome.RegisterMethodHandler(myhome.OccupancyGetStatus, h.handleGetStatus)
+	myhome.Register(myhome.OccupancyGetStatus, h.handleGetStatus)
 	h.log.Info("Occupancy RPC handler registered")
 }
 
 // handleGetStatus returns the current occupancy status
-func (h *RPCHandler) handleGetStatus(ctx context.Context, params any) (any, error) {
+func (h *RPCHandler) handleGetStatus(ctx context.Context, params any) (*myhome.OccupancyStatusResult, error) {
 	// Get occupancy status using the service's IsOccupied method
 	occupied := h.service.IsOccupied(ctx)
 

--- a/myhome/occupancy/rpc_test.go
+++ b/myhome/occupancy/rpc_test.go
@@ -14,20 +14,20 @@ import (
 // myhome exposes no Unregister API, so when there was no prior registration
 // this intentionally leaves h registered afterward. Tests using this must
 // not call t.Parallel(), since the registry is a package-level global.
-func withRegisteredHandler(t *testing.T, verb myhome.Verb, h myhome.MethodHandler) {
+func withRegisteredHandler[P, R any](t *testing.T, verb myhome.Verb, h func(ctx context.Context, p P) (R, error)) {
 	t.Helper()
 	prev, err := myhome.Methods(verb)
-	myhome.RegisterMethodHandler(verb, h)
+	myhome.Register(verb, h)
 	t.Cleanup(func() {
 		if err == nil && prev != nil {
-			myhome.RegisterMethodHandler(verb, prev.ActionE)
+			myhome.RestoreMethod(verb, prev)
 		}
 	})
 }
 
 // TestOccupancyGetStatus_Dispatch verifies that RegisterHandlers wires
 // myhome.OccupancyGetStatus to handleGetStatus, and that dispatching through
-// the shared myhome.Methods/ActionE table (as the RPC server does) returns
+// the shared myhome.Methods/Action table (as the RPC server does) returns
 // the occupancy service's current status.
 func TestOccupancyGetStatus_Dispatch(t *testing.T) {
 	svc, _, cancel := newTestService(t, &fakeLanChecker{})
@@ -45,9 +45,9 @@ func TestOccupancyGetStatus_Dispatch(t *testing.T) {
 		t.Fatalf("Methods(OccupancyGetStatus): %v", err)
 	}
 
-	out, err := dispatched.ActionE(context.Background(), nil)
+	out, err := dispatched.Action(context.Background(), nil)
 	if err != nil {
-		t.Fatalf("ActionE: %v", err)
+		t.Fatalf("Action: %v", err)
 	}
 	result, ok := out.(*myhome.OccupancyStatusResult)
 	if !ok {
@@ -75,9 +75,9 @@ func TestOccupancyGetStatus_Dispatch_Occupied(t *testing.T) {
 		t.Fatalf("Methods(OccupancyGetStatus): %v", err)
 	}
 
-	out, err := dispatched.ActionE(context.Background(), nil)
+	out, err := dispatched.Action(context.Background(), nil)
 	if err != nil {
-		t.Fatalf("ActionE: %v", err)
+		t.Fatalf("Action: %v", err)
 	}
 	result, ok := out.(*myhome.OccupancyStatusResult)
 	if !ok {

--- a/myhome/temperature/temperature.go
+++ b/myhome/temperature/temperature.go
@@ -77,45 +77,23 @@ func NewService(ctx context.Context, log logr.Logger, mqttClient mqtt.Client, st
 
 // RegisterHandlers registers all temperature RPC method handlers
 func (s *Service) RegisterHandlers() {
-	myhome.RegisterMethodHandler(myhome.TemperatureGet, func(ctx context.Context, params any) (any, error) {
-		return s.HandleGet(ctx, params.(*myhome.TemperatureGetParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureSet, func(ctx context.Context, params any) (any, error) {
-		return s.HandleSet(ctx, params.(*myhome.TemperatureSetParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureList, func(ctx context.Context, params any) (any, error) {
+	myhome.Register(myhome.TemperatureGet, s.HandleGet)
+	myhome.Register(myhome.TemperatureSet, s.HandleSet)
+	myhome.Register(myhome.TemperatureList, func(ctx context.Context, _ any) (*myhome.TemperatureRoomList, error) {
 		return s.HandleList(ctx)
 	})
-	myhome.RegisterMethodHandler(myhome.TemperatureDelete, func(ctx context.Context, params any) (any, error) {
-		return s.HandleDelete(ctx, params.(*myhome.TemperatureDeleteParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureGetSchedule, func(ctx context.Context, params any) (any, error) {
-		return s.HandleGetSchedule(ctx, params.(*myhome.TemperatureGetScheduleParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureGetWeekdayDefaults, func(ctx context.Context, params any) (any, error) {
-		return s.HandleGetWeekdayDefaults(ctx, params.(*myhome.TemperatureGetWeekdayDefaultsParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureSetWeekdayDefault, func(ctx context.Context, params any) (any, error) {
-		return s.HandleSetWeekdayDefault(ctx, params.(*myhome.TemperatureSetWeekdayDefaultParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureGetKindSchedules, func(ctx context.Context, params any) (any, error) {
-		return s.HandleGetKindSchedules(ctx, params.(*myhome.TemperatureGetKindSchedulesParams))
-	})
-	myhome.RegisterMethodHandler(myhome.TemperatureSetKindSchedule, func(ctx context.Context, params any) (any, error) {
-		return s.HandleSetKindSchedule(ctx, params.(*myhome.TemperatureSetKindScheduleParams))
-	})
-	myhome.RegisterMethodHandler(myhome.RoomList, func(ctx context.Context, params any) (any, error) {
+	myhome.Register(myhome.TemperatureDelete, s.HandleDelete)
+	myhome.Register(myhome.TemperatureGetSchedule, s.HandleGetSchedule)
+	myhome.Register(myhome.TemperatureGetWeekdayDefaults, s.HandleGetWeekdayDefaults)
+	myhome.Register(myhome.TemperatureSetWeekdayDefault, s.HandleSetWeekdayDefault)
+	myhome.Register(myhome.TemperatureGetKindSchedules, s.HandleGetKindSchedules)
+	myhome.Register(myhome.TemperatureSetKindSchedule, s.HandleSetKindSchedule)
+	myhome.Register(myhome.RoomList, func(ctx context.Context, _ any) (*myhome.RoomListResult, error) {
 		return s.HandleRoomList(ctx)
 	})
-	myhome.RegisterMethodHandler(myhome.RoomCreate, func(ctx context.Context, params any) (any, error) {
-		return s.HandleRoomCreate(ctx, params.(*myhome.RoomCreateParams))
-	})
-	myhome.RegisterMethodHandler(myhome.RoomEdit, func(ctx context.Context, params any) (any, error) {
-		return s.HandleRoomEdit(ctx, params.(*myhome.RoomEditParams))
-	})
-	myhome.RegisterMethodHandler(myhome.RoomDelete, func(ctx context.Context, params any) (any, error) {
-		return s.HandleRoomDelete(ctx, params.(*myhome.RoomDeleteParams))
-	})
+	myhome.Register(myhome.RoomCreate, s.HandleRoomCreate)
+	myhome.Register(myhome.RoomEdit, s.HandleRoomEdit)
+	myhome.Register(myhome.RoomDelete, s.HandleRoomDelete)
 }
 
 // loadFromStorage loads all data from persistent storage into memory


### PR DESCRIPTION
Closes #361. Part of umbrella #368 (Wave 3).

## What

- **Core registry rewrite** (`internal/myhome/{methods,proxy,server,client}.go`): `Register[P, R any]` replaces the `signatures` map of `func() any` constructors; `request.Params`/`response.Result` become `json.RawMessage`, eliminating the double-unmarshal/marshal round-trip. `server.go` now does a single-unmarshal decode with bounded per-message goroutine dispatch (`maxConcurrentRPCs`) instead of blocking the dispatch loop per request; `client.go` drops the `reflect.TypeOf` runtime check. The #356 concurrency work (Dialog.Id correlation, dispatch goroutine, ctx-guarded timeout) is preserved and re-verified under `-race`, plus a new `TestServer_SlowHandlerDoesNotBlockConcurrentRPC`.
- **Mechanical migration**: ~30 `RegisterMethodHandler` call sites → `Register`, ~40 `TheClient.CallE` call sites → the generic `Call[P, R]` wrapper, across `myhome/devices/impl`, `myhome/temperature`, `myhome/occupancy`, `myhome/daemon`, `internal/myhome/shelly/{script,sswitch}`, `internal/myhome/ui/*`, `myhome/ctl/**`.
- **Docs**: CLAUDE.md's "RPC System" and AGENTS.md's "Adding New RPC Methods" updated — the method-registration ritual drops from 4 steps to 2 (no more separate `signatures` map entry or manual type check).

## Verification

- `make generate && make build && make test` (incl. `check-boundaries`) ✅
- `make lint`: 0 issues ✅
- `make test-race`: root + pkg/shelly + pkg/sfr pass, including `internal/myhome` itself (10.9s) — the #356 tests and the new slow-handler test hold under `-race`; `pkg/beem` skip is pre-existing (#374), unrelated
- Wire-format check: `Params`/`Result` moving `any` → `json.RawMessage` doesn't change the MQTT JSON payload (RawMessage marshals its bytes verbatim); no RPC envelope is persisted in `myhome.db`

## Flagged for reviewer judgment

1. **`Register` double-registration behavior**: does *not* panic on re-registering a verb (I initially added a panic matching `pkg/shelly`'s sibling `Registrar`, then reverted — `myhome/occupancy/rpc_test.go` relies on re-registering a verb to swap in a test handler, and there's no `Unregister` API). This matches the *actual* old behavior (`RegisterMethodHandler` only ever panicked on an *unknown* verb, a check that no longer applies without the `signatures` map). Added `myhome.RestoreMethod(verb, *Method)` for test cleanup. A stricter panic-on-duplicate + real `Unregister` is a viable follow-up if preferred, but would need to touch the occupancy test helper too.
2. **`Call[P, R]` runtime type-switch**: `Client.CallE` intentionally stays untyped (`(any, error)`) to keep satisfying the `Client` interface across the real wire client, `FakeClient`, and `DeviceManager`'s in-process short-circuit. The generic `Call[P, R]` wrapper distinguishes three cases at runtime: already-typed `R` (test doubles / in-process), `json.RawMessage` (real wire client, single unmarshal), and a defensive marshal-then-unmarshal fallback. Not explicitly specified by the issue but follows directly from its own `Call[P, R]` sketch.

## Notes

- Base branch has since moved (two main-merge commits, `campaign/main-merge-2`) — no rebase performed yet; will resolve at merge time if needed (the moved commits only touch go.mod/go.sum, pool-pump.js, and linux packaging files, none of which this PR touches).
- Pre-existing, out-of-scope: `internal/myhome/ui/rpc.go`'s `DeviceLookup`/`DeviceListByRoom` UI-conversion code appears to have never matched its actual result types even before this change — left untouched.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- rpc: generics-based method registry + json.RawMessage wire types (#361) ([e7ac764](https://github.com/asnowfix/home-automation/commit/e7ac7640d6653a741ecbb4261c824fc04b6aeca4))
- rpc: migrate all method registrations and call sites to Register/Call[P,R] (#361) ([f721e99](https://github.com/asnowfix/home-automation/commit/f721e99ff57e4af72ba2eb6ee151439770b9baa0))
- docs: update RPC method registration steps for Register/Call[P,R] (#361) ([d07b9d2](https://github.com/asnowfix/home-automation/commit/d07b9d23594d1e7ea5b7a485e2436bfe08140487))
- docs(rpc): fix Call[P,R] example in proxy.go doc comment ([af859d9](https://github.com/asnowfix/home-automation/commit/af859d9c8e8610c1ef6b3c78eb3ccf55fb41fe68))
<!-- END-AUTO-GENERATED-COMMITS -->