### PR TITLE
feat(daemon): minimal energy-claimers registry + solar.claimerslist RPC (#404)

### DIFF
--- a/internal/myhome/const.go
+++ b/internal/myhome/const.go
@@ -48,6 +48,7 @@ const (
 	SwitchAll                     Verb = "switch.all"
 	EventList                     Verb = "event.list"
 	PoolGetStatus                 Verb = "pool.getstatus"
+	SolarClaimersList             Verb = "solar.claimerslist"
 )
 
 type Key string

--- a/internal/myhome/energy/registry.go
+++ b/internal/myhome/energy/registry.go
@@ -1,0 +1,68 @@
+// Package energy is a minimal, static identity registry of things that may
+// claim solar energy — today, only the pool pump. It is deliberately *not* a
+// live-arbitration engine: no priority ordering, no partial allocation, no
+// per-consumer wattage reporting. It exists so a future "solar router" issue
+// (multi-consumer arbitration, see #401's follow-up) has an existing
+// substrate to build on rather than starting from nothing.
+//
+// Structurally this mirrors internal/myhome/accounts (a sync-guarded map
+// with Register/Snapshot methods), used here only as a concurrency-pattern
+// template — the two packages track conceptually unrelated things.
+package energy
+
+import "sync"
+
+// Claimer is a static identity record for something that may consume solar
+// energy. This registry does not track live wattage or arbitrate between
+// claimers — see the follow-up "solar router" issue for that.
+type Claimer struct {
+	Name     string `json:"name"`
+	DeviceID string `json:"device_id,omitempty"`
+}
+
+// Registry holds the set of known claimers, keyed by name. Safe for
+// concurrent use: Register is expected to be called once per claimer at
+// daemon startup, Snapshot from RPC handlers.
+type Registry struct {
+	mu     sync.RWMutex
+	byName map[string]Claimer
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{byName: make(map[string]Claimer)}
+}
+
+// Register records (or replaces) the identity of a claimer. Calling it again
+// with the same name overwrites the previous entry.
+func (r *Registry) Register(name, deviceID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.byName[name] = Claimer{Name: name, DeviceID: deviceID}
+}
+
+// Snapshot returns a stable, name-sorted copy of every registered claimer.
+// Never returns the internal map, so callers can't mutate registry state
+// through the result.
+func (r *Registry) Snapshot() []Claimer {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out := make([]Claimer, 0, len(r.byName))
+	for _, c := range r.byName {
+		out = append(out, c)
+	}
+	sortByName(out)
+	return out
+}
+
+// sortByName is a tiny insertion sort — the claimer count is a handful, so
+// avoiding a sort.Slice import keeps this file dependency-free (mirrors
+// internal/myhome/accounts.sortByName).
+func sortByName(c []Claimer) {
+	for i := 1; i < len(c); i++ {
+		for j := i; j > 0 && c[j].Name < c[j-1].Name; j-- {
+			c[j], c[j-1] = c[j-1], c[j]
+		}
+	}
+}

--- a/internal/myhome/energy/registry_test.go
+++ b/internal/myhome/energy/registry_test.go
@@ -1,0 +1,66 @@
+package energy
+
+import "testing"
+
+func TestRegistryRegisterSnapshotRoundTrip(t *testing.T) {
+	r := NewRegistry()
+	r.Register("pool-pump", "abc123")
+
+	snap := r.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(snap))
+	}
+	if snap[0].Name != "pool-pump" || snap[0].DeviceID != "abc123" {
+		t.Fatalf("unexpected claimer: %+v", snap[0])
+	}
+}
+
+func TestRegistryRegisterOverwritesExistingName(t *testing.T) {
+	r := NewRegistry()
+	r.Register("pool-pump", "old-id")
+	r.Register("pool-pump", "new-id")
+
+	snap := r.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("expected 1 entry after re-register, got %d", len(snap))
+	}
+	if snap[0].DeviceID != "new-id" {
+		t.Fatalf("expected overwritten device_id 'new-id', got %q", snap[0].DeviceID)
+	}
+}
+
+func TestRegistrySnapshotSortedByName(t *testing.T) {
+	r := NewRegistry()
+	r.Register("water-heater", "wh1")
+	r.Register("pool-pump", "pp1")
+	r.Register("ev-charger", "ev1")
+
+	snap := r.Snapshot()
+	if len(snap) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(snap))
+	}
+	if snap[0].Name != "ev-charger" || snap[1].Name != "pool-pump" || snap[2].Name != "water-heater" {
+		t.Fatalf("expected sorted order, got %v", snap)
+	}
+}
+
+func TestRegistrySnapshotIsACopy(t *testing.T) {
+	r := NewRegistry()
+	r.Register("pool-pump", "abc123")
+
+	snap := r.Snapshot()
+	snap[0].DeviceID = "mutated"
+
+	snap2 := r.Snapshot()
+	if snap2[0].DeviceID != "abc123" {
+		t.Fatalf("expected registry to be unaffected by mutation of snapshot, got %q", snap2[0].DeviceID)
+	}
+}
+
+func TestRegistrySnapshotEmpty(t *testing.T) {
+	r := NewRegistry()
+	snap := r.Snapshot()
+	if len(snap) != 0 {
+		t.Fatalf("expected empty snapshot, got %v", snap)
+	}
+}

--- a/internal/myhome/methods.go
+++ b/internal/myhome/methods.go
@@ -313,4 +313,12 @@ var signatures map[Verb]MethodSignature = map[Verb]MethodSignature{
 			return &PoolGetStatusResult{}
 		},
 	},
+	SolarClaimersList: {
+		NewParams: func() any {
+			return nil
+		},
+		NewResult: func() any {
+			return &SolarClaimersListResult{}
+		},
+	},
 }

--- a/internal/myhome/solar.go
+++ b/internal/myhome/solar.go
@@ -1,0 +1,18 @@
+package myhome
+
+// SolarClaimer reports one registered energy claimer (see
+// internal/myhome/energy.Registry) enriched, where possible, with a live
+// active/speed read. This is a static-identity + best-effort-live-status
+// view, not a live-arbitration result — see the follow-up "solar router"
+// issue for multi-consumer arbitration.
+type SolarClaimer struct {
+	Name        string `json:"name" yaml:"name"`
+	DeviceID    string `json:"device_id,omitempty" yaml:"device_id,omitempty"`
+	Active      bool   `json:"active" yaml:"active"`
+	ActiveSpeed string `json:"active_speed,omitempty" yaml:"active_speed,omitempty"`
+}
+
+// SolarClaimersListResult is the result of the solar.claimerslist RPC verb.
+type SolarClaimersListResult struct {
+	Claimers []SolarClaimer `json:"claimers" yaml:"claimers"`
+}

--- a/myhome/ctl/ctl.go
+++ b/myhome/ctl/ctl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/asnowfix/home-automation/myhome/ctl/sfr"
 	"github.com/asnowfix/home-automation/myhome/ctl/shelly"
 	"github.com/asnowfix/home-automation/myhome/ctl/show"
+	"github.com/asnowfix/home-automation/myhome/ctl/solar"
 	"github.com/asnowfix/home-automation/myhome/ctl/sswitch"
 	"github.com/asnowfix/home-automation/myhome/ctl/temperature"
 	mqttclient "github.com/asnowfix/home-automation/myhome/mqtt"
@@ -158,6 +159,7 @@ func init() {
 	Cmd.AddCommand(temperature.Cmd)
 	Cmd.AddCommand(heater.Cmd)
 	Cmd.AddCommand(pool.PoolCmd())
+	Cmd.AddCommand(solar.SolarCmd())
 	Cmd.AddCommand(garden.GardenCmd())
 	Cmd.AddCommand(room.Cmd)
 	Cmd.AddCommand(eventsctl.Cmd)

--- a/myhome/ctl/solar/claimers.go
+++ b/myhome/ctl/solar/claimers.go
@@ -1,0 +1,56 @@
+package solar
+
+import (
+	"fmt"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+
+	"github.com/spf13/cobra"
+)
+
+// claimersCmd calls the myhome.SolarClaimersList RPC (registered by the
+// daemon; see myhome/daemon/solar_rpc.go) and prints each registered
+// energy claimer's static identity plus, where available, a live
+// active/speed read. This is a static-identity registry, not a
+// live-arbitration view — see issue #404.
+var claimersCmd = &cobra.Command{
+	Use:   "claimers",
+	Short: "List registered solar-energy claimers",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		out, err := myhome.TheClient.CallE(ctx, myhome.SolarClaimersList, nil)
+		if err != nil {
+			return fmt.Errorf("failed to list solar claimers: %w", err)
+		}
+		result, ok := out.(*myhome.SolarClaimersListResult)
+		if !ok {
+			return fmt.Errorf("unexpected result type %T", out)
+		}
+
+		if len(result.Claimers) == 0 {
+			fmt.Println("No solar-energy claimers registered.")
+			return nil
+		}
+
+		fmt.Println("Solar-Energy Claimers")
+		fmt.Println("=====================")
+		for _, c := range result.Claimers {
+			status := "idle"
+			if c.Active {
+				status = "active"
+				if c.ActiveSpeed != "" {
+					status = fmt.Sprintf("active (%s)", c.ActiveSpeed)
+				}
+			}
+			fmt.Printf("• %s (%s) — %s\n", c.Name, c.DeviceID, status)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	solarCmd.AddCommand(claimersCmd)
+}

--- a/myhome/ctl/solar/main.go
+++ b/myhome/ctl/solar/main.go
@@ -1,0 +1,17 @@
+package solar
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// solarCmd is the root command for solar-energy related queries.
+var solarCmd = &cobra.Command{
+	Use:   "solar",
+	Short: "Query solar-energy claimers",
+	Long:  `Query the daemon's minimal energy-claimers registry (see issue #404).`,
+}
+
+// SolarCmd returns the solar command (exported for registration).
+func SolarCmd() *cobra.Command {
+	return solarCmd
+}

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -10,6 +10,7 @@ import (
 	"github.com/asnowfix/home-automation/internal/global"
 	"github.com/asnowfix/home-automation/internal/myhome"
 	"github.com/asnowfix/home-automation/internal/myhome/accounts"
+	"github.com/asnowfix/home-automation/internal/myhome/energy"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
 	myhomesfr "github.com/asnowfix/home-automation/internal/myhome/sfr"
 	shellygen2l "github.com/asnowfix/home-automation/internal/myhome/shelly/gen2"
@@ -368,6 +369,14 @@ func (d *daemon) Run() error {
 			poolNotices = NewPoolNotices(d.ctx, log.WithName("pool"), eventsSvc, options.Flags.PoolDeviceID)
 		}
 
+		// Minimal static identity registry of things that may claim solar
+		// energy (today: only the pool pump). Not a live-arbitration engine —
+		// see internal/myhome/energy and #401's follow-up "solar router" issue.
+		claimerRegistry := energy.NewRegistry()
+		if options.Flags.PoolDeviceID != "" {
+			claimerRegistry.Register("pool-pump", options.Flags.PoolDeviceID)
+		}
+
 		// Start solar automation if enabled
 		if options.Flags.PoolSolarEnabled && options.Flags.PoolDeviceID != "" && beemWatcher != nil {
 			if options.Flags.PoolSolarMaxVolumeTurnover < options.Flags.PoolSolarMinVolumeTurnover {
@@ -517,6 +526,12 @@ func (d *daemon) Run() error {
 		// a clear error if poolNotices is nil (pool disabled/unreachable).
 		poolRPCHandler := NewPoolRPCHandler(log, poolNotices)
 		poolRPCHandler.RegisterHandlers()
+
+		// Register Solar RPC methods (static energy-claimers registry).
+		// Always registered — claimerRegistry may simply be empty when no
+		// pool device is configured.
+		solarRPCHandler := NewSolarRPCHandler(log, claimerRegistry, poolNotices)
+		solarRPCHandler.RegisterHandlers()
 
 		// Publish a hostname for the DeviceManager host: myhome.local
 		if !options.Flags.NoMdnsPublish {

--- a/myhome/daemon/pool_notices.go
+++ b/myhome/daemon/pool_notices.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	poolscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/events"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
@@ -16,12 +17,26 @@ import (
 // day). kvsKeyRuntimeToday and kvsKeyTurnoverToday are the on-device
 // runtime/turnover accumulators pool-pump.js maintains and mirrors to KVS
 // (see #402) — the Go side just reads them back instead of re-deriving flow
-// rate from the (non-numeric) preferred-speed KVS key.
+// rate from the (non-numeric) preferred-speed KVS key. kvsKeyActiveOutput is
+// the switch id (or -1 when off) the pump is currently driving, read back by
+// ActiveSpeed for the solar.claimerslist RPC (see #404/solar_rpc.go).
 const (
 	kvsKeyTurnover      = "script/pool-pump/turnover"
 	kvsKeyRuntimeToday  = "script/pool-pump/runtime-sec"
 	kvsKeyTurnoverToday = "script/pool-pump/turnover-today"
+	kvsKeyActiveOutput  = "script/pool-pump/active-output"
 )
+
+// defaultSpeedSwitchIDs are the eco/mid/high switch indices used when a
+// controller has no speed mapping configured in KVS yet. Mirrors
+// internal/myhome/shelly/script.defaultSpeedMappings (unexported there), so
+// ActiveSpeed's best-effort read degrades to the same fallback.
+var defaultSpeedSwitchIDs = map[string]int64{"eco": 0, "mid": 1, "high": 2}
+
+// speedNameOrder is the display order ActiveSpeed checks switch-id matches
+// in — only matters when a misconfiguration maps two speeds to the same
+// switch id, in which case the first match wins.
+var speedNameOrder = []string{"eco", "mid", "high"}
 
 // PoolNotices records a companion "pool.turnover_today" notice whenever the
 // pool pump stops — either via the device's own pool.pump_stop (schedule or
@@ -157,6 +172,46 @@ func (p *PoolNotices) WaterSupplyActive(ctx context.Context) (bool, error) {
 	}
 	active, _ := m["state"].(bool)
 	return active, nil
+}
+
+// ActiveSpeed reports whether the pool pump is currently running and, if so,
+// which named speed (eco/mid/high) its active switch output maps to. It is a
+// best-effort live read used to enrich the "pool-pump" entry in the
+// solar.claimerslist RPC (see solar_rpc.go) — callers should apply their own
+// timeout via ctx and treat a returned error as "unknown" rather than a
+// reason to fail the whole request. ActiveSpeed on a nil *PoolNotices is a
+// safe no-op (mirrors OnEvent), reporting inactive with no error.
+func (p *PoolNotices) ActiveSpeed(ctx context.Context) (active bool, speedName string, err error) {
+	if p == nil {
+		return false, "", nil
+	}
+
+	via := types.ChannelMqtt
+
+	activeOutput, err := readPoolKVSInt(ctx, p.log, p.device, via, kvsKeyActiveOutput)
+	if err != nil {
+		return false, "", fmt.Errorf("read active-output: %w", err)
+	}
+	if activeOutput < 0 {
+		return false, "", nil
+	}
+
+	for _, name := range speedNameOrder {
+		key := poolscript.PoolKVSKeys[name+"_speed"]
+		switchID, err := readPoolKVSInt(ctx, p.log, p.device, via, key)
+		if err != nil {
+			// Best-effort: fall back to the same default mapping
+			// internal/myhome/shelly/script uses when a controller has no
+			// speed mapping configured in KVS yet, rather than failing the
+			// whole lookup over one missing/unreachable key.
+			switchID = defaultSpeedSwitchIDs[name]
+		}
+		if switchID == activeOutput {
+			return true, name, nil
+		}
+	}
+
+	return true, fmt.Sprintf("switch-%d", activeOutput), nil
 }
 
 // roundTo rounds v to the given number of decimal places.

--- a/myhome/daemon/solar_rpc.go
+++ b/myhome/daemon/solar_rpc.go
@@ -1,0 +1,81 @@
+package daemon
+
+import (
+	"context"
+	"time"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/internal/myhome/energy"
+	"github.com/go-logr/logr"
+)
+
+// solarClaimerLiveReadTimeout bounds the live device KVS reads
+// handleClaimersList performs to enrich the "pool-pump" entry. Solar
+// aggregation is daemon-side only (see #401); a slow or unreachable device
+// must degrade the single claimer's status, not hang or fail the whole RPC.
+const solarClaimerLiveReadTimeout = 3 * time.Second
+
+// SolarRPCHandler exposes the daemon's static energy-claimers registry via
+// the myhome.SolarClaimersList RPC verb (mirrors PoolRPCHandler). It is
+// deliberately not a live-arbitration engine: no priority ordering, no
+// partial allocation — see the follow-up "solar router" issue (#401) for
+// that. It best-effort-enriches the "pool-pump" claimer with a live
+// active/speed read via PoolNotices.ActiveSpeed.
+type SolarRPCHandler struct {
+	log      logr.Logger
+	registry *energy.Registry
+	pool     *PoolNotices
+}
+
+// NewSolarRPCHandler builds a SolarRPCHandler. pool may be nil (pool
+// tracking disabled or the device unreachable at startup) — handleClaimersList
+// then reports the pool-pump claimer's identity without live status,
+// mirroring how PoolNotices.OnEvent on a nil receiver is already a no-op.
+func NewSolarRPCHandler(log logr.Logger, registry *energy.Registry, pool *PoolNotices) *SolarRPCHandler {
+	return &SolarRPCHandler{log: log.WithName("SolarRPCHandler"), registry: registry, pool: pool}
+}
+
+// RegisterHandlers registers the solar.claimerslist RPC method.
+func (h *SolarRPCHandler) RegisterHandlers() {
+	myhome.RegisterMethodHandler(myhome.SolarClaimersList, h.handleClaimersList)
+	h.log.Info("Solar RPC handler registered")
+}
+
+func (h *SolarRPCHandler) handleClaimersList(ctx context.Context, _ any) (any, error) {
+	claimers := h.registry.Snapshot()
+
+	out := make([]myhome.SolarClaimer, 0, len(claimers))
+	for _, c := range claimers {
+		sc := myhome.SolarClaimer{
+			Name:     c.Name,
+			DeviceID: c.DeviceID,
+		}
+
+		// Only the pool pump has a live-status source today. A future
+		// multi-consumer solar router would generalize this per-claimer
+		// lookup; out of scope here (see #401's follow-up).
+		if c.Name == "pool-pump" {
+			active, speed, err := h.readPoolActiveSpeed(ctx)
+			if err != nil {
+				h.log.Info("Live active/speed read failed, reporting claimer without live status",
+					"device_id", c.DeviceID, "error", err.Error())
+			} else {
+				sc.Active = active
+				sc.ActiveSpeed = speed
+			}
+		}
+
+		out = append(out, sc)
+	}
+
+	return &myhome.SolarClaimersListResult{Claimers: out}, nil
+}
+
+// readPoolActiveSpeed wraps PoolNotices.ActiveSpeed with a bounded timeout,
+// so an unreachable pool device degrades this one claimer's live status
+// instead of hanging or failing the whole solar.claimerslist RPC.
+func (h *SolarRPCHandler) readPoolActiveSpeed(ctx context.Context) (active bool, speed string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, solarClaimerLiveReadTimeout)
+	defer cancel()
+	return h.pool.ActiveSpeed(ctx)
+}

--- a/myhome/daemon/solar_rpc_test.go
+++ b/myhome/daemon/solar_rpc_test.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/asnowfix/home-automation/internal/myhome"
+	"github.com/asnowfix/home-automation/internal/myhome/energy"
+	"github.com/go-logr/logr"
+)
+
+// TestSolarRPCHandler_ClaimersList_EnrichesPoolPump verifies the
+// solar.claimerslist handler walks the registry and enriches the
+// "pool-pump" entry with a live active/speed read from a (fake) device KVS,
+// mapping the active switch id back to its configured speed name — using
+// the same fakeKVSDevice stub as pool_notices_test.go's ComputeTurnover
+// tests, so no live hardware or MQTT broker is touched.
+func TestSolarRPCHandler_ClaimersList_EnrichesPoolPump(t *testing.T) {
+	dev := &fakeKVSDevice{
+		id: "pool-device-claimers",
+		kvs: map[string]string{
+			"script/pool-pump/active-output": "1",
+			"script/pool-pump/eco-speed":     "0",
+			"script/pool-pump/mid-speed":     "1",
+			"script/pool-pump/high-speed":    "2",
+		},
+	}
+	pool := &PoolNotices{log: logr.Discard(), device: dev, deviceID: dev.id}
+
+	registry := energy.NewRegistry()
+	registry.Register("pool-pump", dev.id)
+
+	h := NewSolarRPCHandler(logr.Discard(), registry, pool)
+
+	out, err := h.handleClaimersList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleClaimersList: %v", err)
+	}
+	result, ok := out.(*myhome.SolarClaimersListResult)
+	if !ok {
+		t.Fatalf("unexpected result type %T", out)
+	}
+	if len(result.Claimers) != 1 {
+		t.Fatalf("expected 1 claimer, got %d", len(result.Claimers))
+	}
+	c := result.Claimers[0]
+	if c.Name != "pool-pump" || c.DeviceID != dev.id {
+		t.Fatalf("unexpected claimer identity: %+v", c)
+	}
+	if !c.Active {
+		t.Fatalf("expected pool-pump to be reported active, got %+v", c)
+	}
+	if c.ActiveSpeed != "mid" {
+		t.Fatalf("expected active_speed=mid (switch 1), got %q", c.ActiveSpeed)
+	}
+}
+
+// TestSolarRPCHandler_ClaimersList_PoolInactive verifies an active-output of
+// -1 (pump off) is reported as an inactive claimer with no speed, not an
+// error.
+func TestSolarRPCHandler_ClaimersList_PoolInactive(t *testing.T) {
+	dev := &fakeKVSDevice{
+		id: "pool-device-inactive",
+		kvs: map[string]string{
+			"script/pool-pump/active-output": "-1",
+		},
+	}
+	pool := &PoolNotices{log: logr.Discard(), device: dev, deviceID: dev.id}
+
+	registry := energy.NewRegistry()
+	registry.Register("pool-pump", dev.id)
+
+	h := NewSolarRPCHandler(logr.Discard(), registry, pool)
+
+	out, err := h.handleClaimersList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleClaimersList: %v", err)
+	}
+	result := out.(*myhome.SolarClaimersListResult)
+	if len(result.Claimers) != 1 {
+		t.Fatalf("expected 1 claimer, got %d", len(result.Claimers))
+	}
+	c := result.Claimers[0]
+	if c.Active {
+		t.Fatalf("expected pool-pump to be reported inactive, got %+v", c)
+	}
+	if c.ActiveSpeed != "" {
+		t.Fatalf("expected empty active_speed when inactive, got %q", c.ActiveSpeed)
+	}
+}
+
+// TestSolarRPCHandler_ClaimersList_NilPoolNotices verifies the RPC degrades
+// gracefully — returning the claimer's static identity with Active=false —
+// when PoolNotices is nil (pool tracking disabled or device unreachable at
+// startup), rather than panicking or failing the whole request. Mirrors the
+// nil-receiver safety already required of PoolNotices.OnEvent.
+func TestSolarRPCHandler_ClaimersList_NilPoolNotices(t *testing.T) {
+	registry := energy.NewRegistry()
+	registry.Register("pool-pump", "some-device-id")
+
+	h := NewSolarRPCHandler(logr.Discard(), registry, nil)
+
+	out, err := h.handleClaimersList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleClaimersList: %v", err)
+	}
+	result := out.(*myhome.SolarClaimersListResult)
+	if len(result.Claimers) != 1 {
+		t.Fatalf("expected 1 claimer, got %d", len(result.Claimers))
+	}
+	c := result.Claimers[0]
+	if c.Name != "pool-pump" || c.DeviceID != "some-device-id" {
+		t.Fatalf("unexpected claimer identity: %+v", c)
+	}
+	if c.Active {
+		t.Fatalf("expected inactive when PoolNotices is nil, got %+v", c)
+	}
+}
+
+// TestSolarRPCHandler_ClaimersList_LiveReadErrorDoesNotFailRPC verifies that
+// a KVS read failure for the pool-pump claimer (e.g. device unreachable) is
+// logged and the claimer reported with Active=false, rather than the whole
+// solar.claimerslist RPC returning an error.
+func TestSolarRPCHandler_ClaimersList_LiveReadErrorDoesNotFailRPC(t *testing.T) {
+	dev := &fakeKVSDevice{
+		id:  "pool-device-unreachable",
+		kvs: map[string]string{ /* active-output deliberately absent */ },
+	}
+	pool := &PoolNotices{log: logr.Discard(), device: dev, deviceID: dev.id}
+
+	registry := energy.NewRegistry()
+	registry.Register("pool-pump", dev.id)
+
+	h := NewSolarRPCHandler(logr.Discard(), registry, pool)
+
+	out, err := h.handleClaimersList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleClaimersList should not fail on a live-read error, got: %v", err)
+	}
+	result := out.(*myhome.SolarClaimersListResult)
+	if len(result.Claimers) != 1 {
+		t.Fatalf("expected 1 claimer, got %d", len(result.Claimers))
+	}
+	if result.Claimers[0].Active {
+		t.Fatalf("expected inactive claimer on live-read error, got %+v", result.Claimers[0])
+	}
+}
+
+// TestSolarRPCHandler_ClaimersList_EmptyRegistry verifies an empty registry
+// (no pool device configured) yields an empty, non-nil claimers list rather
+// than an error.
+func TestSolarRPCHandler_ClaimersList_EmptyRegistry(t *testing.T) {
+	registry := energy.NewRegistry()
+	h := NewSolarRPCHandler(logr.Discard(), registry, nil)
+
+	out, err := h.handleClaimersList(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("handleClaimersList: %v", err)
+	}
+	result := out.(*myhome.SolarClaimersListResult)
+	if result.Claimers == nil {
+		t.Fatalf("expected non-nil empty claimers slice")
+	}
+	if len(result.Claimers) != 0 {
+		t.Fatalf("expected 0 claimers, got %d", len(result.Claimers))
+	}
+}


### PR DESCRIPTION
Part of #401. Closes #404.

Adds a minimal, static energy-claimers registry as the identity substrate a future
multi-consumer "solar router" (#407, out of scope here) can build on. Deliberately
**not** a live-arbitration engine: no priority ordering, no partial allocation, no
per-consumer wattage reporting.

## What's here

- **`internal/myhome/energy`** (new package) — `Registry` with `Register`/`Snapshot`,
  guarded by a `sync.RWMutex`, following `internal/myhome/accounts` as a concurrency
  pattern template (not a functional dependency). `Snapshot()` returns a copy, never
  the internal map.
- **`solar.claimerslist` RPC verb** — `Verb` const in `internal/myhome/const.go`, result
  types in the new `internal/myhome/solar.go`, and a `signatures` map entry in
  `internal/myhome/methods.go`, following the existing `PoolGetStatus` template.
- **`myhome/daemon/solar_rpc.go`** (new) — `SolarRPCHandler`, mirroring `PoolRPCHandler`.
  Walks `registry.Snapshot()` and best-effort-enriches the `pool-pump` entry with a live
  active/speed read.
- **`PoolNotices.ActiveSpeed`** — reads `script/pool-pump/active-output` and maps the
  switch id back to a named speed via the existing `PoolKVSKeys` eco/mid/high entries.
- **`ctl solar claimers`** — CLI-only: parses args, makes the RPC call, prints. No logic.

## Resilience

Per this repo's conventions (and #401's premise), the live device read cannot be allowed
to degrade the daemon:

- The KVS reads are bounded by a 3s `context.WithTimeout` in `readPoolActiveSpeed`. An
  unreachable pool device degrades that single claimer's live status — the RPC still
  returns every claimer's identity rather than hanging or erroring out.
- `ActiveSpeed` on a nil `*PoolNotices` is a safe no-op reporting inactive with no error,
  mirroring how `OnEvent` on a nil receiver already behaves, so pool-disabled daemons work.
- A missing or unreadable per-speed KVS key falls back to the same default mapping
  (`eco:0, mid:1, high:2`) that `internal/myhome/shelly/script.defaultSpeedMappings` uses,
  rather than failing the whole lookup over one key.
- This registry is daemon-side only and nothing on-device depends on it, so the
  daemon-optional-per-device rule is preserved.

## Verification

- `make generate && make build` — pass
- `make test` — pass, all workspace sub-modules including the new `internal/myhome/energy`
- `golangci-lint run` — zero findings in new/modified files (note: this repo's `Makefile`
  has no `lint` target, so the linter was invoked directly)
- `go test -race -count=3` on `internal/myhome/energy` and the new/touched `myhome/daemon`
  tests — clean

### Pre-existing issue, not introduced here

There is a data race in `solar_automation.go` / `solar_automation_test.go` (legacy
`SolarAutomation`) that reproduces identically on unmodified `main` at `40f8b54`. It is
unrelated to this change and left untouched — that file is deleted in #406.

## Deviations from the issue

- `Registry.Snapshot()` sorts by name, which the issue's snippet didn't specify, matching
  `internal/myhome/accounts`'s determinism and keeping RPC output stable.
- Reused `internal/myhome/shelly/script.PoolKVSKeys`'s eco/mid/high entries directly rather
  than the much heavier `getDeviceStatus`; the issue explicitly offered this as an
  alternative "if reusable".

## Follow-up for the maintainer

Live verification against a real device (`solar.claimerslist` returning the pool pump with
an accurate active/speed reading) was **not** performed — no hardware was touched. Worth
confirming against `filtration-hiver` / `filtration-piscine-ete` alongside #401's other
device-side verification.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(daemon): minimal energy-claimers registry (identity substrate for future solar router) ([14278d5](https://github.com/asnowfix/home-automation/commit/14278d50f85c00e3be3fc8bcf408b1bcd1eed66e))
- Merge remote-tracking branch 'origin/main' into worktree-agent-a3196ed7c4ce1936f ([413487b](https://github.com/asnowfix/home-automation/commit/413487b1265df4a6caec9028def674b5588c142e))
<!-- END-AUTO-GENERATED-COMMITS -->