### PR TITLE
feat(daemon): aggregate solar-energy sources, publish myhome/energy/solar/available

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -534,6 +534,16 @@ Integration is enabled automatically when both `beem.email` and `beem.password` 
 | `beem.password` | `MYHOME_BEEM_PASSWORD` | — | Beem Energy account password |
 | `beem.poll_interval` | — | `60s` | How often to poll the Beem REST API (config file only) |
 
+## Solar Aggregator
+
+The daemon sums the last-known reading from every known solar-energy source (today: only Beem) and republishes the total, retained, to `myhome/energy/solar/available` — a source-agnostic signal that Shelly device scripts (e.g. `pool-pump.js`) subscribe to directly and act on themselves. This is a pure additive publisher: it has no dependency on `pool.device_id` and is not gated behind any pool-related flag. It starts automatically whenever at least one solar source is configured (today: Beem credentials); there is no separate enable flag.
+
+A source whose last reading is older than `solar.stale_after` is excluded from the sum but does not block other, fresher sources from being summed and republished.
+
+| Key | Env var | Flag | Default | Description |
+|-----|---------|------|---------|-------------|
+| `solar.stale_after` | `MYHOME_SOLAR_STALE_AFTER` | `--solar-stale-after` | `5m` | Exclude a source's last reading from the total once it is older than this |
+
 ## SFR Box
 
 Credentials for the SFR home gateway. Authentication is skipped when either value is empty.

--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -215,6 +215,17 @@ beem:
   password:      "secret"
   poll_interval: 60s
 
+# Solar aggregator: sums whatever solar-energy sources are known (today: only
+# Beem) and republishes the total, retained, to myhome/energy/solar/available
+# for Shelly device scripts (e.g. pool-pump.js) to subscribe to directly.
+# Starts automatically once at least one source is configured — no separate
+# enable flag. Not pool-specific: has no dependency on pool.device_id.
+solar:
+  # A source's last reading older than this is excluded from the total, but
+  # doesn't block other, fresher sources from being summed.
+  # Default: 5m
+  # stale_after: 5m
+
 # SFR box credentials — used to authenticate when the box requires a password.
 # Leave empty to skip authentication (works for boxes with no password policy).
 sfr:

--- a/myhome/ctl/options/options.go
+++ b/myhome/ctl/options/options.go
@@ -44,6 +44,11 @@ const MQTT_RECONNECT_INTERVAL time.Duration = 2 * time.Hour
 
 const SHELLY_DEFAULT_RATE_LIMIT time.Duration = 200 * time.Millisecond
 
+// SOLAR_STALE_AFTER is the default for --solar-stale-after: roughly 5x
+// Beem's default 60s poll interval, so one or two missed polls don't
+// immediately drop the source out of the aggregate sum.
+const SOLAR_STALE_AFTER time.Duration = 5 * time.Minute
+
 // ViperConfig holds the Viper configuration instance
 var ViperConfig *viper.Viper
 
@@ -87,6 +92,7 @@ var Flags struct {
 	BeemEmail                   string        // Beem Energy account email
 	BeemPassword                string        // Beem Energy account password
 	BeemPollInterval            time.Duration // Beem Energy poll interval
+	SolarStaleAfter             time.Duration // solar aggregator: a source's last reading older than this is excluded from the sum
 	SFRUsername                 string        // SFR box account username; from .env, never a flag
 	SFRPassword                 string        // SFR box account password; from .env, never a flag
 	PoolSolarEnabled            bool          // whether to enable solar-driven pool pump automation

--- a/myhome/daemon/daemon.go
+++ b/myhome/daemon/daemon.go
@@ -245,6 +245,23 @@ func (d *daemon) Run() error {
 		log.Info("Beem Energy integration disabled")
 	}
 
+	// Solar aggregator: sums whatever solar-energy sources are known (today:
+	// only Beem) and republishes the total on a retained MQTT topic for
+	// Shelly device scripts to consume directly. Generic and additive — no
+	// dependency on PoolDeviceID/pool tracking, so it is not gated behind any
+	// pool-related flag.
+	var solarAgg *SolarAggregator
+	if beemWatcher != nil {
+		solarAgg = NewSolarAggregator(log.WithName("solar"), mc, options.Flags.SolarStaleAfter,
+			newBeemSolarSource(beemWatcher),
+			// future: append additional SolarSource adapters here
+		)
+		solarAgg.Start(d.ctx)
+		log.Info("Solar aggregator started", "topic", SolarAvailableTopic, "stale_after", options.Flags.SolarStaleAfter)
+	} else {
+		log.Info("Solar aggregator disabled: no solar sources configured (Beem credentials absent)")
+	}
+
 	// SFR box: the device manager (below) starts a periodic refresh loop via
 	// myhomesfr.GetRouter regardless of credentials — auth is skipped
 	// internally when username/password are empty. Report status from every

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -76,6 +76,7 @@ func init() {
 	runCmd.PersistentFlags().DurationVar(&options.Flags.EventsRetention, "events-retention", 90*24*time.Hour, "Retention period for event records (default 90 days)")
 	runCmd.PersistentFlags().BoolVar(&disableEventsService, "disable-events-service", false, "Disable the event recording service")
 	runCmd.PersistentFlags().StringVar(&options.Flags.RemoteProxy, "remote-proxy", "", "Forward /devices/... requests to a remote myhome daemon (e.g. http://home-pi:6080) instead of connecting directly")
+	runCmd.PersistentFlags().DurationVar(&options.Flags.SolarStaleAfter, "solar-stale-after", options.SOLAR_STALE_AFTER, "Solar aggregator: exclude a source's reading from the total once it is older than this")
 	runCmd.PersistentFlags().StringVar(&options.Flags.PoolDeviceID, "pool-device-id", "", "Pool Shelly device ID")
 	runCmd.PersistentFlags().BoolVar(&options.Flags.PoolEnabled, "enable-pool", false, "Enable pool runtime tracking")
 	runCmd.PersistentFlags().BoolVar(&options.Flags.PoolSolarEnabled, "enable-pool-solar", false, "Enable solar-driven pool pump automation")
@@ -291,6 +292,11 @@ var runCmd = &cobra.Command{
 		options.Flags.BeemEmail = v.GetString("beem.email")
 		options.Flags.BeemPassword = v.GetString("beem.password")
 		options.Flags.BeemPollInterval = v.GetDuration("beem.poll_interval")
+
+		// Solar aggregator: generic, not gated behind pool/Beem-specific flags.
+		if v.IsSet("solar.stale_after") && !cmd.Flags().Changed("solar-stale-after") {
+			options.Flags.SolarStaleAfter = v.GetDuration("solar.stale_after")
+		}
 
 		// SFR box credentials — Viper reads MYHOME_SFR_USERNAME / MYHOME_SFR_PASSWORD
 		// from the environment or config file; auth is skipped if either is empty.

--- a/myhome/daemon/solar_aggregate.go
+++ b/myhome/daemon/solar_aggregate.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"sync"
+	"time"
+
+	mqttclient "github.com/asnowfix/home-automation/myhome/mqtt"
+	"github.com/go-logr/logr"
+)
+
+// SolarAvailableTopic is the retained MQTT topic where the daemon publishes
+// the sum of all known solar-energy sources. Shelly device scripts (e.g.
+// pool-pump.js) subscribe to it directly and decide for themselves whether to
+// act on it — the daemon itself never issues a start/stop RPC based on this
+// value, keeping devices daemon-optional (see AGENTS.md "Resilience Rules").
+const SolarAvailableTopic = "myhome/energy/solar/available"
+
+// SolarAvailablePayload is published (retained, QoS AtLeastOnce) to
+// SolarAvailableTopic every time any registered source reports a reading.
+//
+// TS uses unix-epoch-seconds (not RFC3339): pool-pump.js parses this
+// on-device with mJS, where epoch arithmetic is cheaper/less error-prone than
+// ISO-8601 parsing.
+//
+// Staleness contract: the aggregator only recomputes and republishes when a
+// reading arrives (see SolarAggregator doc comment). If every source stops
+// reporting — e.g. Beem's REST API becomes unreachable because the internet
+// is down — nothing republishes, so the retained topic keeps serving its
+// last value indefinitely, with TS growing arbitrarily old. Because MQTT
+// delivers a retained message to a new subscriber immediately regardless of
+// its age, TS is not decorative: a subscriber (e.g. pool-pump.js in #405)
+// MUST compare TS against its own staleness threshold before trusting
+// AvailableW, rather than assuming a received message is fresh.
+type SolarAvailablePayload struct {
+	AvailableW float64            `json:"available_w"`
+	TS         int64              `json:"ts"`
+	Sources    []SolarSourceDebug `json:"sources,omitempty"`
+}
+
+// SolarSourceDebug reports one source's contribution to AvailableW, for
+// observability (e.g. debugging via `mosquitto_sub` or the web UI). Not
+// consumed by pool-pump.js today — informational only.
+type SolarSourceDebug struct {
+	Name  string  `json:"name"`
+	Watts float64 `json:"watts"`
+	Stale bool    `json:"stale"`
+}
+
+// SolarAggregator sums the last-known reading from every registered
+// SolarSource and republishes the total to SolarAvailableTopic on every
+// incoming reading (i.e. on whatever cadence sources report — currently
+// Beem's ~60s poll interval). A source whose last reading is older than
+// staleAfter is excluded from the sum but doesn't block other sources from
+// reporting or being summed.
+type SolarAggregator struct {
+	log        logr.Logger
+	mc         mqttclient.Client
+	sources    []SolarSource
+	staleAfter time.Duration
+
+	mu   sync.Mutex
+	last map[string]SolarReading
+}
+
+// NewSolarAggregator builds an aggregator over the given sources. Call Start
+// to begin consuming readings and publishing the aggregate.
+func NewSolarAggregator(log logr.Logger, mc mqttclient.Client, staleAfter time.Duration, sources ...SolarSource) *SolarAggregator {
+	return &SolarAggregator{
+		log:        log,
+		mc:         mc,
+		sources:    sources,
+		staleAfter: staleAfter,
+		last:       make(map[string]SolarReading),
+	}
+}
+
+// Start launches one forwarder goroutine per registered source. Every
+// goroutine exits when ctx is done (or its source's channel closes on its
+// own), so Start never leaks goroutines past ctx's lifetime.
+func (a *SolarAggregator) Start(ctx context.Context) {
+	for _, src := range a.sources {
+		go a.forward(ctx, src)
+	}
+}
+
+func (a *SolarAggregator) forward(ctx context.Context, src SolarSource) {
+	ch := src.Subscribe(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case reading, ok := <-ch:
+			if !ok {
+				return
+			}
+			a.record(ctx, reading)
+		}
+	}
+}
+
+// record updates the last-known reading for reading.Source, recomputes the
+// sum over all non-stale sources, and publishes the result.
+//
+// Publish-ordering caveat: the payload is built under a.mu but published
+// (network I/O) outside it, so two sources reporting concurrently can race:
+// each builds its own payload under the lock, but the two publishes can then
+// land in either order, momentarily leaving the retained topic showing the
+// older of the two totals. Harmless with a single source (today: just Beem)
+// and intentionally not fixed here — holding the mutex across a network
+// publish would block every other source's forwarder goroutine for the
+// duration of an MQTT round-trip, which is worse. Whoever adds a second
+// SolarSource should be aware of this before relying on strict ordering.
+func (a *SolarAggregator) record(ctx context.Context, reading SolarReading) {
+	a.mu.Lock()
+	a.last[reading.Source] = reading
+	payload := a.buildPayloadLocked()
+	a.mu.Unlock()
+
+	a.publish(ctx, payload)
+}
+
+// buildPayloadLocked computes the current aggregate payload from a.last.
+// Callers must hold a.mu.
+func (a *SolarAggregator) buildPayloadLocked() SolarAvailablePayload {
+	now := time.Now()
+	var total float64
+	sources := make([]SolarSourceDebug, 0, len(a.last))
+	for name, reading := range a.last {
+		stale := now.Sub(reading.TS) > a.staleAfter
+		if !stale {
+			total += reading.Watts
+		}
+		sources = append(sources, SolarSourceDebug{
+			Name:  name,
+			Watts: reading.Watts,
+			Stale: stale,
+		})
+	}
+	// Deterministic ordering: map iteration order is randomized, and a
+	// stable Sources order makes published payloads easier to diff/test.
+	sort.Slice(sources, func(i, j int) bool { return sources[i].Name < sources[j].Name })
+
+	return SolarAvailablePayload{
+		AvailableW: total,
+		TS:         now.Unix(),
+		Sources:    sources,
+	}
+}
+
+func (a *SolarAggregator) publish(ctx context.Context, payload SolarAvailablePayload) {
+	b, err := json.Marshal(payload)
+	if err != nil {
+		a.log.Error(err, "Solar aggregator: failed to marshal payload")
+		return
+	}
+	if err := a.mc.Publish(ctx, SolarAvailableTopic, b, mqttclient.AtLeastOnce, true /*retain*/, "solar-aggregator"); err != nil {
+		a.log.Error(err, "Solar aggregator: failed to publish", "topic", SolarAvailableTopic)
+		return
+	}
+	a.log.V(1).Info("Solar aggregator: published",
+		"topic", SolarAvailableTopic,
+		"available_w", payload.AvailableW,
+		"sources", len(payload.Sources),
+	)
+}

--- a/myhome/daemon/solar_aggregate_test.go
+++ b/myhome/daemon/solar_aggregate_test.go
@@ -1,0 +1,245 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	mqttclient "github.com/asnowfix/home-automation/myhome/mqtt"
+	"github.com/go-logr/logr"
+)
+
+// fakeSolarSource is a channel-backed SolarSource test double: readings
+// pushed onto readingsCh are delivered to whatever Subscribe returns.
+type fakeSolarSource struct {
+	name       string
+	readingsCh chan SolarReading
+}
+
+func newFakeSolarSource(name string) *fakeSolarSource {
+	return &fakeSolarSource{
+		name:       name,
+		readingsCh: make(chan SolarReading, 8),
+	}
+}
+
+func (f *fakeSolarSource) Name() string { return f.name }
+
+func (f *fakeSolarSource) Subscribe(ctx context.Context) <-chan SolarReading {
+	out := make(chan SolarReading, 8)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case r, ok := <-f.readingsCh:
+				if !ok {
+					return
+				}
+				select {
+				case out <- r:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out
+}
+
+func (f *fakeSolarSource) send(r SolarReading) {
+	f.readingsCh <- r
+}
+
+// waitForPublish polls mc.Published(topic) until it has at least n entries or
+// the deadline elapses. Polling (rather than a fixed sleep) keeps the test
+// robust under CI load — see AGENTS.md "Avoid time.Sleep in async-protocol
+// tests."
+func waitForPublish(t *testing.T, mc *mqttclient.RecordingMockClient, topic string, n int, timeout time.Duration) [][]byte {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if payloads := mc.Published(topic); len(payloads) >= n {
+			return payloads
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d publish(es) to %q, got %d", n, topic, len(mc.Published(topic)))
+	return nil
+}
+
+// TestSolarAggregator_SumsAcrossSources verifies that readings from two
+// distinct sources are summed into a single AvailableW total.
+func TestSolarAggregator_SumsAcrossSources(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mc := mqttclient.NewRecordingMockClient()
+	src1 := newFakeSolarSource("alpha")
+	src2 := newFakeSolarSource("beta")
+
+	agg := NewSolarAggregator(logr.Discard(), mc, 5*time.Minute, src1, src2)
+	agg.Start(ctx)
+
+	now := time.Now()
+	src1.send(SolarReading{Source: "alpha", Watts: 300, TS: now})
+	payloads := waitForPublish(t, mc, SolarAvailableTopic, 1, 2*time.Second)
+	var got SolarAvailablePayload
+	if err := json.Unmarshal(payloads[len(payloads)-1], &got); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if got.AvailableW != 300 {
+		t.Errorf("AvailableW after 1 source = %v, want 300", got.AvailableW)
+	}
+
+	src2.send(SolarReading{Source: "beta", Watts: 450, TS: now})
+	payloads = waitForPublish(t, mc, SolarAvailableTopic, 2, 2*time.Second)
+	if err := json.Unmarshal(payloads[len(payloads)-1], &got); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if got.AvailableW != 750 {
+		t.Errorf("AvailableW after 2 sources = %v, want 750", got.AvailableW)
+	}
+}
+
+// TestSolarAggregator_StaleSourceExcludedButDoesNotBlockOthers verifies that
+// a source whose last reading is older than staleAfter is dropped from the
+// sum, while a fresher source still contributes and still triggers publishes.
+func TestSolarAggregator_StaleSourceExcludedButDoesNotBlockOthers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mc := mqttclient.NewRecordingMockClient()
+	staleSrc := newFakeSolarSource("stale-source")
+	freshSrc := newFakeSolarSource("fresh-source")
+
+	staleAfter := 50 * time.Millisecond
+	agg := NewSolarAggregator(logr.Discard(), mc, staleAfter, staleSrc, freshSrc)
+	agg.Start(ctx)
+
+	// Old reading, timestamped well before staleAfter's window.
+	staleSrc.send(SolarReading{Source: "stale-source", Watts: 1000, TS: time.Now().Add(-10 * time.Minute)})
+	waitForPublish(t, mc, SolarAvailableTopic, 1, 2*time.Second)
+
+	// Fresh reading from the other source.
+	freshSrc.send(SolarReading{Source: "fresh-source", Watts: 200, TS: time.Now()})
+	payloads := waitForPublish(t, mc, SolarAvailableTopic, 2, 2*time.Second)
+
+	var got SolarAvailablePayload
+	if err := json.Unmarshal(payloads[len(payloads)-1], &got); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if got.AvailableW != 200 {
+		t.Errorf("AvailableW = %v, want 200 (stale source excluded)", got.AvailableW)
+	}
+
+	var staleDebug, freshDebug *SolarSourceDebug
+	for i := range got.Sources {
+		switch got.Sources[i].Name {
+		case "stale-source":
+			staleDebug = &got.Sources[i]
+		case "fresh-source":
+			freshDebug = &got.Sources[i]
+		}
+	}
+	if staleDebug == nil || !staleDebug.Stale {
+		t.Errorf("stale-source Sources entry = %+v, want Stale=true", staleDebug)
+	}
+	if freshDebug == nil || freshDebug.Stale {
+		t.Errorf("fresh-source Sources entry = %+v, want Stale=false", freshDebug)
+	}
+}
+
+// TestSolarAggregator_RepublishesOnEveryReading verifies the aggregator
+// publishes once per incoming reading (not batched/debounced), and that
+// every publish uses the retained + AtLeastOnce QoS convention.
+func TestSolarAggregator_RepublishesOnEveryReading(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mc := mqttclient.NewRecordingMockClient()
+	src := newFakeSolarSource("only-source")
+
+	agg := NewSolarAggregator(logr.Discard(), mc, 5*time.Minute, src)
+	agg.Start(ctx)
+
+	for i := 0; i < 3; i++ {
+		src.send(SolarReading{Source: "only-source", Watts: float64(100 * (i + 1)), TS: time.Now()})
+	}
+
+	payloads := waitForPublish(t, mc, SolarAvailableTopic, 3, 2*time.Second)
+	if len(payloads) != 3 {
+		t.Fatalf("published %d times, want exactly 3", len(payloads))
+	}
+}
+
+// TestSolarAggregator_PayloadShape verifies the JSON field names/shape of the
+// published payload match the documented contract pool-pump.js depends on.
+func TestSolarAggregator_PayloadShape(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	mc := mqttclient.NewRecordingMockClient()
+	src := newFakeSolarSource("shape-source")
+
+	agg := NewSolarAggregator(logr.Discard(), mc, 5*time.Minute, src)
+	agg.Start(ctx)
+
+	before := time.Now().Unix()
+	src.send(SolarReading{Source: "shape-source", Watts: 555, TS: time.Now()})
+	payloads := waitForPublish(t, mc, SolarAvailableTopic, 1, 2*time.Second)
+	after := time.Now().Unix()
+
+	var raw map[string]any
+	if err := json.Unmarshal(payloads[0], &raw); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	for _, field := range []string{"available_w", "ts", "sources"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("payload missing field %q: %v", field, raw)
+		}
+	}
+
+	var got SolarAvailablePayload
+	if err := json.Unmarshal(payloads[0], &got); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	if got.TS < before || got.TS > after {
+		t.Errorf("ts = %d, want between %d and %d (unix-epoch-seconds)", got.TS, before, after)
+	}
+	if len(got.Sources) != 1 || got.Sources[0].Name != "shape-source" || got.Sources[0].Watts != 555 {
+		t.Errorf("Sources = %+v, want one entry {shape-source 555 false}", got.Sources)
+	}
+}
+
+// TestSolarAggregator_StopsOnContextCancel verifies forwarder goroutines
+// exit promptly when ctx is cancelled, rather than leaking.
+func TestSolarAggregator_StopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mc := mqttclient.NewRecordingMockClient()
+	src := newFakeSolarSource("cancel-source")
+
+	agg := NewSolarAggregator(logr.Discard(), mc, 5*time.Minute, src)
+	agg.Start(ctx)
+
+	src.send(SolarReading{Source: "cancel-source", Watts: 42, TS: time.Now()})
+	waitForPublish(t, mc, SolarAvailableTopic, 1, 2*time.Second)
+
+	cancel()
+
+	// After cancellation, further sends should not produce more publishes
+	// (the forwarder goroutine has exited). Give it a brief window to settle.
+	deadline := time.Now().Add(200 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		select {
+		case src.readingsCh <- SolarReading{Source: "cancel-source", Watts: 99, TS: time.Now()}:
+		default:
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := len(mc.Published(SolarAvailableTopic)); got != 1 {
+		t.Errorf("published %d times after ctx cancel, want exactly 1 (no further publishes)", got)
+	}
+}

--- a/myhome/daemon/solar_beem_source.go
+++ b/myhome/daemon/solar_beem_source.go
@@ -1,0 +1,44 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/asnowfix/home-automation/pkg/beem"
+)
+
+// beemSolarSource adapts beem.Watcher.PowerCh to the generic SolarSource
+// interface, so SolarAggregator doesn't need to know anything about the Beem
+// REST API or its polling loop.
+type beemSolarSource struct {
+	watcher *beem.Watcher
+}
+
+// newBeemSolarSource wraps an already-constructed (and started) beem.Watcher
+// as a SolarSource.
+func newBeemSolarSource(w *beem.Watcher) *beemSolarSource {
+	return &beemSolarSource{watcher: w}
+}
+
+func (b *beemSolarSource) Name() string { return "beem" }
+
+func (b *beemSolarSource) Subscribe(ctx context.Context) <-chan SolarReading {
+	out := make(chan SolarReading, 4)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case sample, ok := <-b.watcher.PowerCh:
+				if !ok {
+					return
+				}
+				select {
+				case out <- SolarReading{Source: "beem", Watts: sample.SolarW, TS: sample.TS}:
+				default: // non-blocking, matches beem.Watcher's own drop-on-full policy
+				}
+			}
+		}
+	}()
+	return out
+}

--- a/myhome/daemon/solar_source.go
+++ b/myhome/daemon/solar_source.go
@@ -1,0 +1,29 @@
+package daemon
+
+import (
+	"context"
+	"time"
+)
+
+// SolarReading is a single instantaneous power reading from a solar-energy
+// source (e.g. a Beem PnP kit, or some other inverter brand in the future).
+type SolarReading struct {
+	Source string
+	Watts  float64
+	TS     time.Time
+}
+
+// SolarSource is a generic solar-energy source that SolarAggregator can sum
+// over. Implementations adapt a specific vendor watcher/API (e.g.
+// pkg/beem.Watcher, via beemSolarSource) to this interface so the aggregator
+// never needs to know how many sources exist or where they come from.
+type SolarSource interface {
+	// Name identifies the source (e.g. "beem"). Used as the key in
+	// SolarAggregator's last-reading map and in SolarSourceDebug.Name.
+	Name() string
+
+	// Subscribe returns a channel of readings tied to ctx's lifetime: the
+	// returned channel is closed once ctx is done (or the underlying source
+	// stops on its own).
+	Subscribe(ctx context.Context) <-chan SolarReading
+}


### PR DESCRIPTION
Part of #401. Closes #403.

## Summary

Adds a source-agnostic solar-energy aggregation layer to the daemon:

- `SolarSource` interface (`myhome/daemon/solar_source.go`) — any solar source (inverter, kit, etc.) implements `Name()` + `Subscribe(ctx) <-chan SolarReading`.
- `beemSolarSource` (`myhome/daemon/solar_beem_source.go`) — adapts the existing `pkg/beem.Watcher.PowerCh` to `SolarSource`, non-blocking forward, exits on `ctx.Done()`.
- `SolarAggregator` (`myhome/daemon/solar_aggregate.go`) — sums the last-known reading from every registered source and republishes the total (retained, QoS `AtLeastOnce`) to the new topic `myhome/energy/solar/available` on every incoming reading. A source whose last reading is older than `staleAfter` is excluded from the sum without blocking fresher sources. One forwarder goroutine per source, all exit on `ctx.Done()`.
- Wiring in `myhome/daemon/daemon.go`, immediately after the existing Beem watcher construction, gated only on `beemWatcher != nil` — **no dependency on `PoolDeviceID`/pool tracking**, matches the issue's snippet almost verbatim.
- New config option `SolarStaleAfter` (`--solar-stale-after`, viper key `solar.stale_after`, env `MYHOME_SOLAR_STALE_AFTER`, default `5m`), added across all 4 required files: `myhome/ctl/options/options.go`, `myhome/daemon/run.go`, `docs/configuration.md`, `myhome-example.yaml`.

This is a pure additive change — nothing subscribes to the new topic yet; a sibling issue (#405) wires a consumer into `pool-pump.js`.

## Design notes / deviations

- **Staleness is a payload contract, not a liveness guarantee.** The aggregator only recomputes/republishes when a reading arrives. If every source goes fully unreachable (e.g. internet down for Beem's REST poll — exactly the #401 resilience case), nothing republishes, so the retained topic keeps serving its last value indefinitely with an aging `ts`. This is intentional per the issue (no periodic republish ticker added) — documented explicitly in `SolarAvailablePayload`'s doc comment so the future `pool-pump.js` consumer (#405) knows it must judge freshness from `ts`, since a late MQTT subscriber receives the retained message immediately regardless of age.
- **Multi-source publish ordering** is documented as a known, accepted race on `SolarAggregator.record`: two sources reporting concurrently build their payload under the mutex but publish (network I/O) outside it, so the retained value can momentarily reflect the older of two concurrent updates. Harmless with one source today; intentionally not fixed here (holding the mutex across a network publish would serialize all sources' forwarder goroutines behind an MQTT round-trip).
- `Sources` in the payload is sorted by name before marshaling for deterministic/diffable output (not specified by the issue, but harmless and simplifies testing).

## Build / test / lint results

- `make build` — pass.
- `make test` — pass (exit 0, full root + workspace sub-module run). One pre-existing, unrelated flaky failure was observed in an earlier `-race` run of `TestTimerTimingWithRuntime` (`pkg/shelly/script`, a timing-sensitive test unrelated to this change) and reproduces in isolation as flaky; not caused by this PR.
- `go test -race -run TestSolarAggregator -v ./myhome/daemon/...` — pass (5/5).
- Separately confirmed and reproduced (before this PR's changes, at `main` HEAD `40f8b54`) a **pre-existing data race** in `myhome/daemon/solar_automation.go` / `solar_automation_test.go` (`TestSolarAutomation_NoNoticesWithoutWithEvents`, unguarded `mockPumpController` field access across goroutines). That file is unrelated to this change and is slated for deletion in sibling issue #406 — not touched or fixed here.
- `make lint` — **no such target exists in this repo** (no `lint` target in the root `Makefile`, no lint step in `.github/workflows/`). Ran `golangci-lint run ./myhome/daemon/... ./myhome/ctl/options/...` directly instead: zero issues in any of the 4 new files or in the 3 modified files' new lines. All 9 reported issues (6 errcheck, 3 staticcheck) are pre-existing in `daemon.go`/`install.go`, reproduced identically with this PR's changes stashed out.

## Files touched

- `myhome/daemon/solar_source.go` (new)
- `myhome/daemon/solar_beem_source.go` (new)
- `myhome/daemon/solar_aggregate.go` (new)
- `myhome/daemon/solar_aggregate_test.go` (new)
- `myhome/daemon/daemon.go` (wiring)
- `myhome/daemon/run.go`, `myhome/ctl/options/options.go`, `docs/configuration.md`, `myhome-example.yaml` (new config key)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(daemon): aggregate solar-energy sources, publish myhome/energy/solar/available ([ae5a6dc](https://github.com/asnowfix/home-automation/commit/ae5a6dce779360cbdfd996f5407aa7ad0384eb88))
- Merge remote-tracking branch 'origin/main' into worktree-agent-a9ceec4cc8c2740a8 ([078bd4b](https://github.com/asnowfix/home-automation/commit/078bd4be08937a35b69cc71a9be0c8a5f402bd3c))
<!-- END-AUTO-GENERATED-COMMITS -->