### PR TITLE
fix(build): scope git-describe version derivation to v* tags

### DIFF
--- a/.github/workflows/on-tag-main.yml
+++ b/.github/workflows/on-tag-main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Show previous tag
         id: previous-tag
         run: |
-          echo "previous=$(git describe --tags --abbrev=0 HEAD^)" | tee -a "$GITHUB_OUTPUT"
+          echo "previous=$(git describe --tags --match 'v*' --abbrev=0 HEAD^)" | tee -a "$GITHUB_OUTPUT"
       - name: Setup Go
         uses: actions/setup-go@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ generate:
 # If VERSION is not specified, uses git describe
 ifeq ($(OS),Linux)
 ARCH := $(shell dpkg --print-architecture 2>/dev/null || uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
-VERSION ?= $(shell git describe --tags --always 2>/dev/null | sed 's/^v//')
+VERSION ?= $(shell git describe --tags --match 'v*' --always 2>/dev/null | sed 's/^v//')
 DEBPKG_DIR := .debpkg
 DEB_FILE := myhome_$(VERSION)_$(ARCH).deb
 
@@ -320,7 +320,7 @@ upload-release-notes:
 	@echo "Uploading release notes to GitHub..."
 	@echo "Fetching latest tags..."; \
 	git fetch --tags --quiet; \
-	VERSION=$${VERSION:-$$(git describe --tags --abbrev=0 2>/dev/null)}; \
+	VERSION=$${VERSION:-$$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null)}; \
 	if [ -z "$$VERSION" ]; then \
 		echo "Error: No version specified and no git tags found" >&2; \
 		exit 1; \

--- a/myhome/Makefile
+++ b/myhome/Makefile
@@ -7,7 +7,7 @@ VERSION_PKG := github.com/asnowfix/home-automation/pkg/version
 
 GO_LDFLAGS += -X $(VERSION_PKG).Program=$(notdir $(PWD))
 GO_LDFLAGS += -X $(VERSION_PKG).Repo=$(shell git config --get remote.$(shell git remote).url)
-GO_LDFLAGS += -X $(VERSION_PKG).Version=$(shell git describe --tags --exact-match 2>/dev/null || git describe --always)$(shell git diff-index --quiet HEAD -- || echo '-dirty')
+GO_LDFLAGS += -X $(VERSION_PKG).Version=$(shell git describe --tags --match 'v*' --exact-match 2>/dev/null || git describe --tags --match 'v*' --always)$(shell git diff-index --quiet HEAD -- || echo '-dirty')
 GO_LDFLAGS += -X $(VERSION_PKG).Commit=$(shell git rev-parse HEAD)
 
 GOFLAGS = -ldflags="$(GO_LDFLAGS)"


### PR DESCRIPTION
## Problem

Discovered while running the #401 campaign: pushing an annotated \`campaign/401-*\` tag onto \`main\` (per the campaign-tagging convention) broke the \`build-pr-deb\` CI job on the very next PR (#411).

\`Makefile:242\`'s \`VERSION ?= $(shell git describe --tags --always ...)\` picks the *nearest* tag reachable from HEAD — annotated tags are always considered regardless of \`--tags\`. Once \`campaign/401-pool-pump-runtime-accumulator\` became an ancestor of \`main\` (unlike earlier campaign tags, which lived only on integration branches that got squash-merged and dropped from \`main\`'s ancestry), \`git describe\` started returning it instead of the nearest \`v*\` release tag. That produces a Debian package version like \`campaign/401-pool-pump-runtime-accumulator-2-g5175f65\`, which \`dpkg-deb\` rejects: \`version number does not start with digit\`.

Verified by A/B: \`build-pr-deb\` passed on PR #410 (opened before the tag existed) and failed on PR #411 (opened after), same job.

Three more call sites derive versions the same fragile way and would hit the identical bug the next time a non-\`v*\` tag lands on \`main\`:
- \`Makefile:323\` (\`upload-release-notes\` fallback)
- \`myhome/Makefile:10\` (embedded \`myhome version\` string via \`GO_LDFLAGS\`) — this one is the most consequential, since \`.github/workflows/on-tag-main.yml\`'s \"Validate version command\" step compares \`myhome version\`'s output against the expected release tag; an errant nearest-tag pickup here would fail that check on the next patch release.
- \`.github/workflows/on-tag-main.yml:19\` (\`previous\` tag for release-notes diffing)

## Fix

Add \`--match 'v*'\` to all four \`git describe --tags\` call sites, so only release tags (\`vX.Y.Z\`) are ever considered for version derivation. Campaign/feature progress tags remain free to be pushed onto any branch, including \`main\`, without affecting packaging or release automation.

The release-branch auto-tag workflow (\`auto-tag-patch.yml\`) already scopes its own tag search to \`vMAJOR.MINOR.*\` and is unaffected either way.

## Verification

- \`git describe --tags --always\` at \`origin/main\` (post #410 merge): returns \`campaign/401-pool-pump-runtime-accumulator\` (broken)
- \`git describe --tags --match 'v*' --always\` at the same commit: returns \`v0.11.0-98-g40f8b54\` (correct)<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(build): scope git-describe version derivation to v* tags ([76de575](https://github.com/asnowfix/home-automation/commit/76de57516e34946a0fdd980cbdb036b9778a41ec))
<!-- END-AUTO-GENERATED-COMMITS -->