### PR TITLE
fix(script): cut upload chunks on UTF-8 rune boundaries (#423)

### DIFF
--- a/pkg/shelly/script/chunk.go
+++ b/pkg/shelly/script/chunk.go
@@ -1,0 +1,47 @@
+package script
+
+import "unicode/utf8"
+
+// SplitChunks splits buf into chunks of at most max bytes each, for use by
+// the script-upload RPC loop (each chunk becomes one PutCode call, glued
+// back together on the device via Append: true).
+//
+// Chunks are cut on UTF-8 rune boundaries, never in the middle of a
+// multi-byte rune: when the prospective end-of-chunk byte offset lands on a
+// UTF-8 continuation byte, the boundary is walked back to the start of that
+// rune, so the whole rune moves into the next chunk instead. Chunks then
+// come out slightly smaller than max, which is harmless — the device
+// imposes no fixed chunk size, and Append: true stitches them back
+// together (see issue #423: byte-oriented slicing bisected a multi-byte
+// rune, producing a chunk that was not valid UTF-8 on its own; the device
+// then rejected the RPC call with "Missing or bad argument 'code'!").
+//
+// Defensively guards against a rune wider than max (impossible for
+// well-formed UTF-8 with any realistic max, since the widest UTF-8 rune is
+// 4 bytes, but guarded anyway): rather than loop forever or emit a
+// zero-length chunk, such a rune is allowed to be split.
+func SplitChunks(buf []byte, max int) [][]byte {
+	if max <= 0 {
+		panic("SplitChunks: max must be positive")
+	}
+
+	var chunks [][]byte
+	for i := 0; i < len(buf); {
+		end := i + max
+		if end >= len(buf) {
+			end = len(buf)
+		} else {
+			// end < len(buf): don't split a multi-byte rune across chunks.
+			// Walk end back to the start of the rune it landed inside, but
+			// never below i+1 — that would produce a zero-length chunk and
+			// make no progress (only possible if a single rune is wider
+			// than max, which cannot happen with valid UTF-8 in practice).
+			for end > i+1 && !utf8.RuneStart(buf[end]) {
+				end--
+			}
+		}
+		chunks = append(chunks, buf[i:end])
+		i = end
+	}
+	return chunks
+}

--- a/pkg/shelly/script/chunk_embedded_test.go
+++ b/pkg/shelly/script/chunk_embedded_test.go
@@ -1,0 +1,52 @@
+package script_test
+
+// This file lives in an external test package (script_test, not script) so
+// it can import internal/shelly/scripts without creating an import cycle:
+// internal/shelly/scripts already imports pkg/shelly/script.
+
+import (
+	"io/fs"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/asnowfix/home-automation/internal/shelly/scripts"
+	"github.com/asnowfix/home-automation/pkg/shelly/script"
+)
+
+// TestSplitChunks_PoolPumpEmbedded is a regression test for issue #423: it
+// chunks the real, unminified internal/shelly/scripts/pool-pump.js (read
+// from the embedded FS, the same source used by real uploads) and asserts
+// every chunk is individually valid UTF-8. This keeps the bug from
+// silently returning as the script's comments (which contain non-ASCII
+// punctuation like em dashes and ellipses) change over time.
+func TestSplitChunks_PoolPumpEmbedded(t *testing.T) {
+	buf, err := fs.ReadFile(scripts.GetFS(), "pool-pump.js")
+	if err != nil {
+		t.Fatalf("failed to read embedded pool-pump.js: %v", err)
+	}
+	if len(buf) == 0 {
+		t.Fatal("embedded pool-pump.js is empty")
+	}
+
+	const chunkSize = 2048
+	chunks := script.SplitChunks(buf, chunkSize)
+
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+
+	var recombined []byte
+	for i, chunk := range chunks {
+		if len(chunk) == 0 {
+			t.Errorf("chunk %d is empty", i)
+		}
+		if !utf8.Valid(chunk) {
+			t.Errorf("chunk %d is not valid UTF-8 (len=%d)", i, len(chunk))
+		}
+		recombined = append(recombined, chunk...)
+	}
+
+	if string(recombined) != string(buf) {
+		t.Errorf("recombined chunks (%d bytes) do not reproduce pool-pump.js (%d bytes) byte-for-byte", len(recombined), len(buf))
+	}
+}

--- a/pkg/shelly/script/chunk_test.go
+++ b/pkg/shelly/script/chunk_test.go
@@ -1,0 +1,168 @@
+package script
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// assertChunksValid asserts that every chunk produced by SplitChunks is
+// itself valid UTF-8, and that concatenating them reproduces buf exactly.
+func assertChunksValid(t *testing.T, buf []byte, max int, chunks [][]byte) {
+	t.Helper()
+
+	var recombined []byte
+	for i, chunk := range chunks {
+		if len(chunk) == 0 {
+			t.Errorf("chunk %d is empty", i)
+		}
+		if !utf8.Valid(chunk) {
+			t.Errorf("chunk %d is not valid UTF-8: %q", i, chunk)
+		}
+		recombined = append(recombined, chunk...)
+	}
+
+	if !bytes.Equal(recombined, buf) {
+		t.Errorf("recombined chunks do not reproduce input byte-for-byte\nwant: %q\ngot:  %q", buf, recombined)
+	}
+}
+
+// TestSplitChunks_MultiByteCharStraddlesBoundary reproduces the exact defect
+// from issue #423: a multi-byte UTF-8 character positioned so that a naive
+// byte-offset boundary at `max` falls inside it. This mirrors the real
+// pool-pump.js failure, where a U+2026 (HORIZONTAL ELLIPSIS, 3 bytes:
+// 0xE2 0x80 0xA6) straddled a 2048-byte boundary.
+func TestSplitChunks_MultiByteCharStraddlesBoundary(t *testing.T) {
+	// "ABCDEFG" (7 bytes) + "…" (U+2026, 3 bytes: indices 7,8,9) + "HIJKLMN".
+	// With max=8, a naive slice buf[0:8] would end at index 8, which is the
+	// *second* byte of the 3-byte ellipsis (a UTF-8 continuation byte) —
+	// exactly the bug: it bisects the rune.
+	buf := []byte("ABCDEFG" + "…" + "HIJKLMN")
+	const max = 8
+
+	// Sanity-check the fixture actually reproduces the hazard before
+	// asserting anything about SplitChunks: byte 8 must be a UTF-8
+	// continuation byte (0x80-0xBF), i.e. NOT a rune start.
+	if utf8.RuneStart(buf[max]) {
+		t.Fatalf("test fixture is broken: byte %d is not a continuation byte (%#x)", max, buf[max])
+	}
+
+	chunks := SplitChunks(buf, max)
+	assertChunksValid(t, buf, max, chunks)
+}
+
+// TestSplitChunks_TableDriven covers the edge cases called out in #423's
+// test plan: empty input, input shorter than one chunk, input exactly one
+// chunk long, and a multi-byte character at the very last byte.
+func TestSplitChunks_TableDriven(t *testing.T) {
+	tests := []struct {
+		name       string
+		buf        []byte
+		max        int
+		wantChunks int // -1 means "don't check exact count"
+	}{
+		{
+			name:       "empty input",
+			buf:        []byte{},
+			max:        2048,
+			wantChunks: 0,
+		},
+		{
+			name:       "input shorter than one chunk",
+			buf:        []byte("hello"),
+			max:        2048,
+			wantChunks: 1,
+		},
+		{
+			name:       "input exactly one chunk long",
+			buf:        bytes.Repeat([]byte("x"), 8),
+			max:        8,
+			wantChunks: 1,
+		},
+		{
+			name:       "multi-byte char at the very last byte",
+			buf:        []byte(strings.Repeat("A", 7) + "é"), // 7 ASCII bytes + 2-byte 'é'
+			max:        8,                                    // boundary at byte 8 lands inside 'é' (index 7,8)
+			wantChunks: -1,
+		},
+		{
+			name:       "multi-byte char straddling boundary (ellipsis)",
+			buf:        []byte("ABCDEFG" + "…" + "HIJKLMN"),
+			max:        8,
+			wantChunks: -1,
+		},
+		{
+			name:       "pure ASCII, many chunks",
+			buf:        bytes.Repeat([]byte("z"), 5000),
+			max:        2048,
+			wantChunks: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			chunks := SplitChunks(tt.buf, tt.max)
+
+			if tt.wantChunks >= 0 && len(chunks) != tt.wantChunks {
+				t.Errorf("got %d chunks, want %d", len(chunks), tt.wantChunks)
+			}
+
+			if len(tt.buf) == 0 {
+				if len(chunks) != 0 {
+					t.Errorf("expected no chunks for empty input, got %d", len(chunks))
+				}
+				return
+			}
+
+			assertChunksValid(t, tt.buf, tt.max, chunks)
+
+			// No chunk should exceed max... except when a single rune is
+			// pathologically wider than max (not exercised by these cases),
+			// so also assert the specific expectation for the sane cases
+			// here: every chunk length is <= max.
+			for i, c := range chunks {
+				if len(c) > tt.max {
+					t.Errorf("chunk %d has length %d, exceeds max %d", i, len(c), tt.max)
+				}
+			}
+		})
+	}
+}
+
+// TestSplitChunks_SingleRuneWiderThanMax guards against the pathological
+// case called out in #423: a single character larger than the chunk size
+// must not cause an infinite loop or a zero-length chunk.
+func TestSplitChunks_SingleRuneWiderThanMax(t *testing.T) {
+	// U+1F600 GRINNING FACE is 4 bytes in UTF-8; max=1 forces the walk-back
+	// to have nowhere valid to land.
+	buf := []byte("\U0001F600")
+	const max = 1
+
+	done := make(chan [][]byte, 1)
+	go func() {
+		done <- SplitChunks(buf, max)
+	}()
+
+	select {
+	case chunks := <-done:
+		if len(chunks) == 0 {
+			t.Fatal("expected at least one chunk")
+		}
+		for i, c := range chunks {
+			if len(c) == 0 {
+				t.Errorf("chunk %d is zero-length", i)
+			}
+		}
+		var recombined []byte
+		for _, c := range chunks {
+			recombined = append(recombined, c...)
+		}
+		if !bytes.Equal(recombined, buf) {
+			t.Errorf("recombined chunks do not reproduce input: want %q got %q", buf, recombined)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("SplitChunks did not return: suspected infinite loop")
+	}
+}

--- a/pkg/shelly/script/main.go
+++ b/pkg/shelly/script/main.go
@@ -386,26 +386,24 @@ func doUpload(ctx context.Context, via types.Channel, device types.Device, name 
 		log.Info("Stopped script", "name", name, "id", id, "out", out)
 	}
 
-	// upload chunks of 2048
-	append := false // first chunk is a replacement
-	chunkSize := 2048
-	for i := 0; i < len(buf); i += chunkSize {
-		end := i + chunkSize
-		if end > len(buf) {
-			end = len(buf)
-		}
-		chunk := buf[i:end]
+	// Upload in chunks of at most 2048 bytes, cut on UTF-8 rune boundaries
+	// (never bisecting a multi-byte character — see issue #423).
+	const chunkSize = 2048
+	appendFlag := false // first chunk is a replacement
+	offset := 0
+	for i, chunk := range SplitChunks(buf, chunkSize) {
 		out, err := device.CallE(ctx, via, string(PutCode), &PutCodeRequest{
 			Id:     id,
 			Code:   string(chunk),
-			Append: append,
+			Append: appendFlag,
 		})
 		if err != nil {
-			log.Error(err, "Unable to upload script", "id", id, "name", name, "index", i, "device", device.Name())
+			log.Error(err, "Unable to upload script", "id", id, "name", name, "chunk", i, "offset", offset, "device", device.Name())
 			return 0, err
 		}
-		log.Info("Uploaded script chunk", "name", name, "id", id, "index", i, "out", out)
-		append = true
+		log.Info("Uploaded script chunk", "name", name, "id", id, "chunk", i, "offset", offset, "out", out)
+		appendFlag = true
+		offset += len(chunk)
 	}
 	log.Info("Uploaded script", "name", name, "id", id, "device", device.Name())
 


### PR DESCRIPTION
Fixes #423.

## Problem

`ctl shelly script upload --no-minify` failed deterministically part-way through the chunked
upload, with the device replying `Missing or bad argument 'code'!` (RPC -103). It was previously
assumed to be a device storage-size limit on the Pro1; it is not. It reproduces on a Shelly Plus 1
as well, at the same byte offset, and is a **client-side bug** whose trigger depends only on the
content of the file being uploaded.

## Root cause

The upload loop sliced the script into 2048-**byte** chunks (`chunk := buf[i:end]`), ignoring UTF-8
character boundaries. When a boundary bisects a multi-byte rune, `string(chunk)` holds invalid
UTF-8, `encoding/json` rewrites the truncated bytes to U+FFFD when marshalling `Code`, and the
device receives something that is not the source we intended.

Concretely, on `internal/shelly/scripts/pool-pump.js` (76614 bytes, 177 non-ASCII bytes) exactly one
2048-byte boundary bisects a rune: byte **55296**, inside `\xe2\x80\xa6` (U+2026 `…`) in
`prefix "…/status`. So the chunk starting at byte **53248** ends with the truncated bytes
`\xe2\x80` and fails to decode as UTF-8 — and 53248 is precisely the offset at which live uploads
failed.

Minified uploads only succeeded by luck: minification strips comments, which is where nearly all
the non-ASCII bytes live.

## Fix

Extract the splitting into `SplitChunks(buf []byte, max int) [][]byte` so it is testable without a
device, and walk the chunk end back to a rune start (`utf8.RuneStart`) when it lands on a
continuation byte. Chunks come out slightly under 2048 bytes, which is harmless — the device
imposes no fixed chunk size, and `Append: true` stitches them back together.

Guarded against emitting a zero-length chunk or looping forever in the (practically impossible)
case of a rune wider than the chunk size.

## Tests

- `TestSplitChunks_MultiByteCharStraddlesBoundary` — the exact #423 scenario.
- `TestSplitChunks_TableDriven` — empty input, shorter than one chunk, exactly one chunk, multi-byte
  char at the very last byte, ellipsis straddling a boundary, pure-ASCII multi-chunk.
- `TestSplitChunks_SingleRuneWiderThanMax` — the defensive guard.
- `TestSplitChunks_PoolPumpEmbedded` — regression test over the **real** embedded `pool-pump.js`,
  asserting every chunk is individually valid UTF-8 and that concatenating them reproduces the file
  byte-for-byte. Keeps the bug from silently returning as the script's comments change.

All assert both per-chunk UTF-8 validity and byte-for-byte round-tripping, so a fix that avoided
invalid UTF-8 by dropping or reordering bytes would still fail.

`make test`: 47 packages ok, 0 failures — unchanged from the pre-change baseline.

## Why this matters

`--no-minify` is the documented way to debug device scripts (`CLAUDE.md`: "Upload with
`--no-minify` when debugging"), and minified stack traces are markedly harder to read — see the
mangled frames in #421's crash traces. This restores that workflow.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(script): cut upload chunks on UTF-8 rune boundaries (#423) ([210b2f7](https://github.com/asnowfix/home-automation/commit/210b2f7558981e75a9d876686f04e8e6d22a1674))
<!-- END-AUTO-GENERATED-COMMITS -->