### PR TITLE
fix(pool-pump): bound in-flight RPCs, catch up on restart, and fit the device heap (#421)

### DIFF
--- a/docs/421-pool-pump-crash-and-catchup-plan.md
+++ b/docs/421-pool-pump-crash-and-catchup-plan.md
@@ -1,0 +1,86 @@
+# Plan: issue #421 — pool-pump "Too many calls in progress" crash + restart catch-up
+
+Tracks implementation of https://github.com/asnowfix/home-automation/issues/421.
+Two independent bugs in `internal/shelly/scripts/pool-pump.js`, plus the minimal
+emulator capability (a slice of #250) needed to reproduce Bug A in
+`pkg/shelly/script/run.go`.
+
+Method: TDD / Prove-It. Emulator capability first, then failing tests proving
+both bugs reproduce against current `main`, only then the fixes.
+
+## Phase 1 — Emulator capability (prerequisite for reproducing Bug A)
+
+- [x] `pkg/shelly/script/device_state.go`: `ExecutionMode` type
+      (`DeviceTestMode` zero value / `DeviceExtensionMode`), `MaxConcurrentCalls`
+      const, `DeviceState.Mode` and `DeviceState.CallDelay` fields.
+- [x] `pkg/shelly/script/run.go`: per-VM `callsInFlight` counter around the
+      `Shelly.call` dispatch closure. `DeviceTestMode` panics with a message
+      matching the real device's `Too many calls in progress` once 5 calls are
+      already in flight. `CallDelay` (only meaningful in `DeviceTestMode`)
+      defers the *release* of a call's in-flight slot rather than the call's
+      dispatch/callback — this lets tests create realistic overlapping
+      in-flight calls without disturbing any script's existing synchronous
+      callback-ordering assumptions. Inert (zero overhead, zero behavior
+      change) in `DeviceExtensionMode` and whenever `CallDelay == 0`.
+- [x] `pkg/shelly/script/run.go`: `RunWithDeviceState`'s event loop now treats
+      *any* handler `Handle()` error as a full script crash (stops the loop,
+      returns the error) instead of logging and continuing. This is required
+      infrastructure, not scope creep: on real Shelly firmware an uncaught
+      exception in *any* callback (timer tick, event handler, MQTT message)
+      kills the whole script, and Bug A's real crash happens inside a
+      `Timer`-driven task-queue tick, not during the initial synchronous
+      script evaluation — the emulator can't observe "the script crashed"
+      for that path without this fix.
+- [x] Do NOT implement the rest of #250 (timer/event-handler/status-handler/
+      MQTT-subscription count ceilings) — only the concurrent-call slice
+      needed here. Cross-referenced in code comments.
+
+## Phase 2 — Bug A: reproduce, then fix
+
+- [x] `internal/shelly/scripts/pool_pump_test.go`: new test drives a normal
+      boot (reuses the existing `TestPoolPump_InitVerifiesSchedules` fixture
+      shape) with `Mode: DeviceTestMode` (default) and a `CallDelay` long
+      enough that config-loading's sequential `KVS.Get` calls (one dispatched
+      per 200ms task-queue tick, ~14 of them) overlap past the 5-concurrent
+      ceiling before the fix exists. Confirm it fails against current `main`
+      with a "Too many calls in progress" error — report the exact output.
+- [x] Fix (`pool-pump.js`): a single choke point (`Shelly.call` is reassigned
+      once, near `TASK_QUEUE`, to wrap every callback via `trackCall`) tracks
+      real script-wide `CALLS_IN_FLIGHT`. `processTaskQueue` throttles its own
+      dispatch to `MAX_CALLS_IN_FLIGHT` (4, one below the real ceiling),
+      retrying the same task on the next tick instead of assuming 200ms was
+      "long enough". This is the root-cause fix — no call site needed manual
+      edits.
+- [x] Second, independent layer of defense: `task()` in `processTaskQueue` is
+      wrapped in `try/catch` — a queued task throwing no longer kills the
+      whole script.
+- [x] Re-run the new test — now passes (init completes, no crash).
+
+## Phase 3 — Bug B: reproduce, then fix
+
+- [x] New test: boot with a schedule window (`Schedule.List` fixture) that
+      excludes "now" and the switch already "on" in `ComponentStatus`. Assert
+      the fixed `enforceOutputState()` path calls `doStop()` and
+      `active-output` ends up `-1` without waiting for any schedule tick
+      (there is no cron emulation in this harness).
+- [x] Fix (`pool-pump.js`): new `restartCatchUp()`, queued right after the
+      existing init steps complete (after `verifySchedules`, so it reads a
+      validated `Schedule.List`), compares current time-of-day against the
+      currently active mode's window (mode-aware: summer →
+      handleMorningStart/handleEveningStop, winter →
+      handleNightStart/handleNightStop) and calls `doStart()`/`doStop()` if
+      the physical state disagrees. Skips gracefully (no action) when the
+      window can't be resolved (e.g. still-symbolic `@sunrise` timespecs on a
+      schedule that has never had `updateScheduleMode()` run against it).
+- [x] Regression guard: three existing tests intentionally leave the pump
+      "on" in `ComponentStatus` at boot to test *other* behavior (water-supply
+      protection, runtime-accounting continuity). Bug B's fix would otherwise
+      immediately stop them, since their shared schedule fixture's night
+      window (23:15–00:15) essentially never contains real test-run wall-clock
+      time. Added `activeNightWindowSchedules()` (widens that window to
+      bracket `time.Now()`) and pointed those three tests at it.
+
+## Phase 4 — Full regression pass
+
+- [x] Re-run all of `pool_pump_test.go`.
+- [x] `make test` (canonical, root + all workspace sub-modules).

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -438,10 +438,12 @@ var STATE_KEYS = {
 // arguments it always did (trackCall forwards result/error_code/
 // error_message/userdata unchanged), so this is purely additive bookkeeping.
 var CALLS_IN_FLIGHT = 0;
+var CALLS_TRACKED = 0;       // lifetime count — proves tracking actually runs
 var MAX_CALLS_IN_FLIGHT = 4; // stay one below the real 5-call device ceiling
 
 function trackCall(onDone) {
   CALLS_IN_FLIGHT++;
+  CALLS_TRACKED++;
   return function (result, error_code, error_message, userdata) {
     // Decrement unconditionally before invoking onDone, so a slot is always
     // freed even if onDone itself throws (caught by processTaskQueue's
@@ -457,6 +459,73 @@ var RAW_SHELLY_CALL = Shelly.call;
 Shelly.call = function (method, params, callback, userdata) {
   return RAW_SHELLY_CALL(method, params, trackCall(callback), userdata);
 };
+
+// --- Self-check: fail LOUDLY, never silently (#421) ---------------------
+// This whole mechanism depends on reassigning a method on the native Shelly
+// object, which is not guaranteed to be permitted on every firmware. If the
+// assignment is ever rejected, CALLS_IN_FLIGHT stays 0 forever, the throttle
+// in processTaskQueue never engages, and the crash this fix exists to prevent
+// comes back — while every emulator test still passes, because goja allows
+// the reassignment that the device refused. That silent-inert failure is the
+// dangerous case, so it is asserted here rather than assumed.
+//
+// print() is used deliberately instead of log(): log() is gated on
+// CONFIG.enableLogging and would hide this exact message in production.
+// It also must not call log() at all — no hoisting on Espruino, and log() is
+// defined further down this file, so it does not exist yet at this point.
+// NOTE: the device truncates each UDP debug line at ~128 chars, so this
+// diagnostic is deliberately split into short lines — a single long print
+// loses exactly the part a reader needs (the cause and the issue pointer).
+function printWrapperFailure() {
+  print("[pool-pump] FATAL #421: Shelly.call wrapper did NOT install.");
+  print("[pool-pump] #421: in-flight RPC throttling is INERT.");
+  print("[pool-pump] #421: >5 concurrent calls => 'Too many calls in progress'.");
+  print("[pool-pump] #421: that error is uncaught and kills the WHOLE script.");
+  print("[pool-pump] #421: schedules stop firing; pump strands as-is.");
+  print("[pool-pump] #421: cause: firmware refused reassigning Shelly.call,");
+  print("[pool-pump] #421:   or refused calling it detached from Shelly.");
+  print("[pool-pump] #421: DO NOT re-investigate -- read issue #421 first.");
+  print("[pool-pump] #421: alt fix: add a completion callback to storeValue()");
+  print("[pool-pump] #421:   and advance processTaskQueue on completion,");
+  print("[pool-pump] #421:   instead of trusting a fixed 200ms timer tick.");
+}
+
+var WRAPPER_INSTALLED = (Shelly.call !== RAW_SHELLY_CALL);
+if (!WRAPPER_INSTALLED) {
+  printWrapperFailure();
+}
+
+// Runtime counterpart to the check above: the assignment can succeed while
+// tracking still never happens (e.g. something captured Shelly.call before
+// this point and calls the original directly). A healthy boot makes dozens of
+// KVS.Get calls, so CALLS_TRACKED must be well above zero by the end of init.
+// Called from continueInit(), by which time log()/Shelly.emitEvent() exist.
+function verifyCallTracking() {
+  if (!WRAPPER_INSTALLED) {
+    // Repeated here as well as at install time: the install-time prints fire
+    // before a debug capture attached after boot would see anything, so this
+    // guarantees the diagnostic is in the log of anyone watching a restart.
+    printWrapperFailure();
+    Shelly.emitEvent("pool.call_tracking_broken", {
+      reason: "Shelly.call wrapper did not install; #421 RPC throttling is inert",
+      calls_tracked: CALLS_TRACKED
+    });
+    return;
+  }
+  if (CALLS_TRACKED === 0) {
+    print("[pool-pump] FATAL #421: wrapper installed but tracked 0 calls.");
+    print("[pool-pump] #421: in-flight RPC throttling is INERT.");
+    print("[pool-pump] #421: something is calling the unwrapped Shelly.call,");
+    print("[pool-pump] #421:   captured before the wrapper was installed.");
+    print("[pool-pump] #421: DO NOT re-investigate -- read issue #421 first.");
+    Shelly.emitEvent("pool.call_tracking_broken", {
+      reason: "wrapper installed but CALLS_TRACKED==0 after init; #421 RPC throttling is inert",
+      calls_tracked: 0
+    });
+    return;
+  }
+  log("In-flight RPC tracking OK (#421): tracked", CALLS_TRACKED, "calls during init, max in flight", MAX_CALLS_IN_FLIGHT);
+}
 
 // === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
 var TASK_QUEUE = [];
@@ -2498,6 +2567,10 @@ function continueInit() {
       log('✓ All initialization steps complete - script is now running');
       log('Current mode:', STATE.scheduleMode || 'winter');
       log('Should I run?', isMyTurnToRun());
+      // #421: assert the in-flight RPC tracking this script's crash-safety
+      // depends on is actually live, and shout if it is not (see the
+      // self-check block near CALLS_IN_FLIGHT for why silence is dangerous).
+      verifyCallTracking();
       // #421 Bug B: correct any stale physical state against the current
       // schedule window immediately, before the (possibly hours-away) next
       // schedule tick or today's forecast-driven mode re-check.

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -438,26 +438,25 @@ var STATE_KEYS = {
 // arguments it always did (trackCall forwards result/error_code/
 // error_message/userdata unchanged), so this is purely additive bookkeeping.
 var CALLS_IN_FLIGHT = 0;
-var CALLS_TRACKED = 0;       // lifetime count — proves tracking actually runs
+var N_SEEN = 0;       // lifetime count — proves tracking actually runs
 var MAX_CALLS_IN_FLIGHT = 4; // stay one below the real 5-call device ceiling
 
-function trackCall(onDone) {
-  CALLS_IN_FLIGHT++;
-  CALLS_TRACKED++;
-  return function (result, error_code, error_message, userdata) {
-    // Decrement unconditionally before invoking onDone, so a slot is always
-    // freed even if onDone itself throws (caught by processTaskQueue's
-    // try/catch below, or by the script's top-level error handling).
-    CALLS_IN_FLIGHT--;
-    if (typeof onDone === 'function') {
-      onDone(result, error_code, error_message, userdata);
-    }
-  };
-}
-
-var RAW_SHELLY_CALL = Shelly.call;
+// trackCall's returned closure is inlined directly into the Shelly.call
+// wrapper below (one function, not two) — same bookkeeping, one less named
+// function object retained on the heap for the lifetime of the script.
+var RAW_CALL = Shelly.call;
 Shelly.call = function (method, params, callback, userdata) {
-  return RAW_SHELLY_CALL(method, params, trackCall(callback), userdata);
+  CALLS_IN_FLIGHT++;
+  N_SEEN++;
+  return RAW_CALL(method, params, function (result, error_code, error_message, userdata2) {
+    // Decrement unconditionally before invoking callback, so a slot is
+    // always freed even if callback itself throws (caught by
+    // processTaskQueue's try/catch below, or top-level error handling).
+    CALLS_IN_FLIGHT--;
+    if (typeof callback === 'function') {
+      callback(result, error_code, error_message, userdata2);
+    }
+  }, userdata);
 };
 
 // --- Self-check: fail LOUDLY, never silently (#421) ---------------------
@@ -473,58 +472,63 @@ Shelly.call = function (method, params, callback, userdata) {
 // CONFIG.enableLogging and would hide this exact message in production.
 // It also must not call log() at all — no hoisting on Espruino, and log() is
 // defined further down this file, so it does not exist yet at this point.
-// NOTE: the device truncates each UDP debug line at ~128 chars, so this
-// diagnostic is deliberately split into short lines — a single long print
-// loses exactly the part a reader needs (the cause and the issue pointer).
-function printWrapperFailure() {
-  print("[pool-pump] FATAL #421: Shelly.call wrapper did NOT install.");
-  print("[pool-pump] #421: in-flight RPC throttling is INERT.");
-  print("[pool-pump] #421: >5 concurrent calls => 'Too many calls in progress'.");
-  print("[pool-pump] #421: that error is uncaught and kills the WHOLE script.");
-  print("[pool-pump] #421: schedules stop firing; pump strands as-is.");
-  print("[pool-pump] #421: cause: firmware refused reassigning Shelly.call,");
-  print("[pool-pump] #421:   or refused calling it detached from Shelly.");
-  print("[pool-pump] #421: DO NOT re-investigate -- read issue #421 first.");
-  print("[pool-pump] #421: alt fix: add a completion callback to storeValue()");
-  print("[pool-pump] #421:   and advance processTaskQueue on completion,");
-  print("[pool-pump] #421:   instead of trusting a fixed 200ms timer tick.");
+// NOTE: the device truncates each UDP debug line at ~128 chars, so every
+// line below is kept short — text is factored through P421/printHit so the
+// two failure modes below share their common lines verbatim instead of
+// duplicating them (duplicated string literals cost real script memory).
+var P421 = "[pool-pump] #421: ";
+
+// Lines shared by both failure modes: what breaks, and the standing
+// instruction not to re-litigate the root cause each time this is seen.
+function printHit() {
+  print(P421 + "throttle INERT; >5 calls kills whole script as-is.");
+  print(P421 + "DO NOT re-investigate -- read issue #421 first.");
 }
 
-var WRAPPER_INSTALLED = (Shelly.call !== RAW_SHELLY_CALL);
-if (!WRAPPER_INSTALLED) {
-  printWrapperFailure();
+function printFail() {
+  print(P421 + "FATAL: Shelly.call wrapper did NOT install.");
+  printHit();
+  print(P421 + "alt fix: storeValue() callback should drive queue.");
+}
+
+var WRAP_OK = (Shelly.call !== RAW_CALL);
+if (!WRAP_OK) {
+  printFail();
+}
+
+// One shared emitter for both failure modes below — same event name/shape,
+// only the reason code differs (the print() diagnostics above/below already
+// carry the full English explanation; this event just needs to be machine-
+// detectable, so the reason strings stay short on purpose).
+function emitBroken(reason) {
+  Shelly.emitEvent("pool.call_tracking_broken", {
+    reason: reason,
+    calls_tracked: N_SEEN
+  });
 }
 
 // Runtime counterpart to the check above: the assignment can succeed while
 // tracking still never happens (e.g. something captured Shelly.call before
 // this point and calls the original directly). A healthy boot makes dozens of
-// KVS.Get calls, so CALLS_TRACKED must be well above zero by the end of init.
+// KVS.Get calls, so N_SEEN must be well above zero by the end of init.
 // Called from continueInit(), by which time log()/Shelly.emitEvent() exist.
-function verifyCallTracking() {
-  if (!WRAPPER_INSTALLED) {
+function checkTrack() {
+  if (!WRAP_OK) {
     // Repeated here as well as at install time: the install-time prints fire
     // before a debug capture attached after boot would see anything, so this
     // guarantees the diagnostic is in the log of anyone watching a restart.
-    printWrapperFailure();
-    Shelly.emitEvent("pool.call_tracking_broken", {
-      reason: "Shelly.call wrapper did not install; #421 RPC throttling is inert",
-      calls_tracked: CALLS_TRACKED
-    });
+    printFail();
+    emitBroken("wrapper-not-installed");
     return;
   }
-  if (CALLS_TRACKED === 0) {
-    print("[pool-pump] FATAL #421: wrapper installed but tracked 0 calls.");
-    print("[pool-pump] #421: in-flight RPC throttling is INERT.");
-    print("[pool-pump] #421: something is calling the unwrapped Shelly.call,");
-    print("[pool-pump] #421:   captured before the wrapper was installed.");
-    print("[pool-pump] #421: DO NOT re-investigate -- read issue #421 first.");
-    Shelly.emitEvent("pool.call_tracking_broken", {
-      reason: "wrapper installed but CALLS_TRACKED==0 after init; #421 RPC throttling is inert",
-      calls_tracked: 0
-    });
+  if (N_SEEN === 0) {
+    print(P421 + "FATAL: wrapper OK but tracked 0 calls -- something");
+    print(P421 + "calls the unwrapped Shelly.call, captured earlier.");
+    printHit();
+    emitBroken("zero-calls-tracked");
     return;
   }
-  log("In-flight RPC tracking OK (#421): tracked", CALLS_TRACKED, "calls during init, max in flight", MAX_CALLS_IN_FLIGHT);
+  log("Tracking OK (#421): seen", N_SEEN, "max", MAX_CALLS_IN_FLIGHT);
 }
 
 // === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
@@ -2354,7 +2358,7 @@ function handleNightStop() {
 // (e.g. still-symbolic "@sunrise" specs on a schedule that has never had
 // updateScheduleMode() compute real times for it yet) — those windows are
 // left alone rather than guessed at.
-function parseTimespecHM(timespec) {
+function parseHM(timespec) {
   if (!timespec || timespec.indexOf('@') === 0) return null;
   var parts = timespec.split(' ');
   if (parts.length < 3) return null;
@@ -2364,20 +2368,8 @@ function parseTimespecHM(timespec) {
   return h * 60 + m;
 }
 
-function nowMinutesOfDay() {
-  var d = new Date();
-  return d.getHours() * 60 + d.getMinutes();
-}
-
-// True if nowMin falls in [startMin, stopMin), handling windows that wrap
-// past midnight (e.g. the fixed winter night-run 23:15 -> 00:15).
-function isWithinWindow(nowMin, startMin, stopMin) {
-  if (startMin === null || stopMin === null) return false;
-  if (startMin <= stopMin) {
-    return nowMin >= startMin && nowMin < stopMin;
-  }
-  return nowMin >= startMin || nowMin < stopMin;
-}
+var RC = 'Restart catch-up: '; // shared log/reason prefix, factored out to
+                                // avoid repeating this literal at every call
 
 function restartCatchUp() {
   if (!isMyTurnToRun()) {
@@ -2393,13 +2385,12 @@ function restartCatchUp() {
   var stopCode = mode === 'summer' ? 'handleEveningStop()' : 'handleNightStop()';
 
   Shelly.call('Schedule.List', {}, function (result, err) {
-    if (err) {
-      log('Restart catch-up: Schedule.List failed, skipping:', err);
+    // A failed lookup or an empty schedule is not the "unresolvable
+    // timespec" case below — it just means there is nothing to catch up
+    // against, so bail out quietly rather than guessing.
+    if (err || !result || !result.jobs) {
+      log(RC + 'lookup failed');
       if (err && false) {}
-      return;
-    }
-    if (!result || !result.jobs) {
-      log('Restart catch-up: no schedules found, skipping');
       return;
     }
 
@@ -2410,29 +2401,36 @@ function restartCatchUp() {
       if (!job.enable || !job.calls || job.calls.length === 0) continue;
       var code = job.calls[0].params && job.calls[0].params.code;
       if (code === startCode) {
-        startMin = parseTimespecHM(job.timespec);
+        startMin = parseHM(job.timespec);
       } else if (code === stopCode) {
-        stopMin = parseTimespecHM(job.timespec);
+        stopMin = parseHM(job.timespec);
       }
     }
 
+    // Unresolvable timespec (e.g. still-symbolic "@sunrise", see parseHM
+    // above) — skip rather than act on a guess (#421 Bug B requirement).
     if (startMin === null || stopMin === null) {
-      log('Restart catch-up: could not resolve', mode, 'window, skipping');
+      log(RC + 'unresolved', mode);
       return;
     }
 
-    var nowMin = nowMinutesOfDay();
-    var shouldRun = isWithinWindow(nowMin, startMin, stopMin);
+    var d = new Date();
+    var nowMin = d.getHours() * 60 + d.getMinutes();
+    // Handles windows that wrap past midnight (the fixed winter night-run
+    // 23:15 -> 00:15) by treating a start > stop pair as wrapping.
+    var shouldRun = startMin <= stopMin
+      ? (nowMin >= startMin && nowMin < stopMin)
+      : (nowMin >= startMin || nowMin < stopMin);
     var isRunning = STATE.activeOutput !== -1;
 
-    log('Restart catch-up:', mode, 'now=', nowMin, 'window=[', startMin, ',', stopMin, ') shouldRun=', shouldRun, 'isRunning=', isRunning);
+    log(RC, mode, nowMin, startMin, stopMin, shouldRun, isRunning);
 
     if (shouldRun && !isRunning) {
-      doStart(CONFIG.preferredSpeed, 'Restart catch-up: inside scheduled window');
+      doStart(CONFIG.preferredSpeed, RC + 'inside window');
     } else if (!shouldRun && isRunning) {
-      doStop('Restart catch-up: outside scheduled window');
+      doStop(RC + 'outside window');
     } else {
-      log('Restart catch-up: state already consistent with schedule');
+      log(RC + 'state OK');
     }
   });
 }
@@ -2570,7 +2568,7 @@ function continueInit() {
       // #421: assert the in-flight RPC tracking this script's crash-safety
       // depends on is actually live, and shout if it is not (see the
       // self-check block near CALLS_IN_FLIGHT for why silence is dangerous).
-      verifyCallTracking();
+      checkTrack();
       // #421 Bug B: correct any stale physical state against the current
       // schedule window immediately, before the (possibly hours-away) next
       // schedule tick or today's forecast-driven mode re-check.

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -34,182 +34,165 @@ var SCRIPT_PREFIX = "[" + SCRIPT_NAME + "] ";
 // Configuration schema
 // Both Pro3 and Pro1 run this same script with shared KVS configuration
 // Script compares preferred_device_id against its own device ID to decide if it should run
+//
+// NOTE (#421 peak-heap follow-up): "description" fields were deliberately
+// removed from every entry below. They were pure documentation — nothing in
+// this script or in tools/extract-pool-defaults/main.go (which regex-parses
+// this object at build time, matching on "key"/"default"/"type"/"cliOnly"
+// only) ever reads schema.description. CONFIG_SCHEMA stays fully allocated
+// on the heap for the entire async loadConfig() KVS round-trip sequence at
+// boot (freed only after the last key loads — see loadConfig below), so
+// every byte of dead weight here is retained heap for that whole window, not
+// just extra script size. If you need the human-readable text, see
+// docs/pool-pump.md, or `git log -p` this hunk to recover the old strings.
 var CONFIG_SCHEMA = {
   enableLogging: {
-    description: "Enable logging when true",
     key: "logging",
     default: true,
     type: "boolean"
   },
   mqttTopicPrefix: {
-    description: "MQTT topic prefix (written by CLI, not used by script)",
     key: "mqtt-topic",
     default: "pool/pump",
     type: "string",
     cliOnly: true
   },
   preferredDeviceId: {
-    description: "Which device ID should run (actual Shelly device ID). Script compares this to its own ID",
     key: "preferred",
     default: null,
     type: "string",
     required: true
   },
   pro3DeviceId: {
-    description: "Pro3 device ID (for MQTT subscriptions - cross-device status tracking)",
     key: "pro3-id",
     default: null,
     type: "string",
     required: false
   },
   pro1DeviceId: {
-    description: "Pro1 device ID (for MQTT subscriptions - cross-device status tracking)",
     key: "pro1-id",
     default: null,
     type: "string",
     required: false
   },
   preferredSpeed: {
-    description: "Speed: 'eco', 'mid', 'high', 'max'. Maps to switches based on device capabilities",
     key: "speed",
     default: "eco",
     type: "string",
     required: false
   },
   ecoSpeed: {
-    description: "Pro3 switch ID for eco/low speed (0, 1, or 2)",
     key: "eco-speed",
     default: 2,
     type: "number",
     required: false
   },
   midSpeed: {
-    description: "Pro3 switch ID for mid speed (0, 1, or 2)",
     key: "mid-speed",
     default: 1,
     type: "number",
     required: false
   },
   highSpeed: {
-    description: "Pro3 switch ID for high speed (0, 1, or 2)",
     key: "high-speed",
     default: 0,
     type: "number",
     required: false
   },
   nightRunDurationMs: {
-    description: "Night run duration in ms (written by CLI, not used by script)",
     key: "night-duration",
     default: 3600000,
     type: "number",
     cliOnly: true
   },
   graceDelayMs: {
-    description: "Cross-device grace delay in ms (minimum 10000)",
     key: "grace-delay",
     default: 10000,
     type: "number",
     required: false
   },
   temperatureThreshold: {
-    description: "Temperature threshold (°C) for summer mode (day schedule)",
     key: "temp-threshold",
     default: 20,
     type: "number",
     required: false
   },
   poolVolume: {
-    description: "Pool volume in m³",
     key: "pool-volume",
     default: 46,
     type: "number"
   },
   turnover: {
-    description: "Daily turnover target (number of full pool volumes to filter per day)",
     key: "turnover",
     default: 5,
     type: "number"
   },
   maxFlowRate: {
-    description: "Pump max flow rate in m³/h at max RPM",
     key: "max-flow-rate",
     default: 31,
     type: "number"
   },
   maxRpm: {
-    description: "Pump rated max RPM",
     key: "max-rpm",
     default: 2900,
     type: "number"
   },
   ecoRpm: {
-    description: "Variator RPM setting for eco speed",
     key: "eco-rpm",
     default: 2000,
     type: "number"
   },
   midRpm: {
-    description: "Variator RPM setting for mid speed",
     key: "mid-rpm",
     default: 2600,
     type: "number"
   },
   highRpm: {
-    description: "Variator RPM setting for high speed",
     key: "high-rpm",
     default: 2900,
     type: "number"
   },
   maxTemp: {
-    description: "Temperature (°C) at which run time reaches one full turnover",
     key: "max-temp",
     default: 35,
     type: "number"
   },
   solarEnabled: {
-    description: "Enable solar-driven start/stop via the daemon's solar-available MQTT event",
     key: "solar-enabled",
     default: false,
     type: "boolean"
   },
   solarStartThresholdW: {
-    description: "Available solar power (W) required to trigger a solar start",
     key: "solar-start-w",
     default: 500,
     type: "number"
   },
   solarStopThresholdW: {
-    description: "Available solar power (W) below which a solar-driven run stops",
     key: "solar-stop-w",
     default: 200,
     type: "number"
   },
   solarStartDelayMs: {
-    description: "Solar must hold above start threshold this long (ms) before starting",
     key: "solar-start-delay",
     default: 300000,
     type: "number"
   },
   solarStopDelayMs: {
-    description: "Solar must hold below stop threshold this long (ms) before stopping",
     key: "solar-stop-delay",
     default: 600000,
     type: "number"
   },
   solarMinTurnover: {
-    description: "Soft-stop target (pool volumes/day); solar keeps running past this while solar remains available",
     key: "solar-min-turnover",
     default: 5,
     type: "number"
   },
   solarMaxTurnover: {
-    description: "Hard ceiling (pool volumes/day); pump always stops (and won't solar-start) once reached",
     key: "solar-max-turnover",
     default: 7,
     type: "number"
   },
   solarStaleMs: {
-    description: "Treat myhome/energy/solar/available as stale (fall back to schedule only) after this long (ms) without a message",
     key: "solar-stale-ms",
     default: 300000,
     type: "number"
@@ -262,143 +245,187 @@ function initConfig() {
 // Initialize CONFIG with defaults immediately so logging works
 initConfig();
 
+// --- Config loading state (peak-heap follow-up to #421) ------------------
+// loadConfig() used to be one function containing a nested loadNextKey()
+// closure, itself creating a BRAND NEW anonymous KVS.Get callback closure on
+// every single iteration (one per config key — ~22 sequential KVS round
+// trips on a real boot). Each of those closures captured key/schema/kvsKey
+// freshly, and — since Espruino's GC is not run between every statement —
+// garbage from earlier iterations can still be sitting on the heap when
+// later iterations allocate theirs, so peak heap during this phase scales
+// with the NUMBER of configured keys, not just the code around it. (This
+// matches the live finding that identical code peaks ~7.9KB higher with a
+// 24-key KVS config than a 5-key one — see issue #421 discussion.)
+//
+// The four module-level CONFIG_LOAD_* vars below plus the two named
+// functions after them replace that pattern: exactly one callback function
+// exists for the whole load (defined once, not once per key), and per-key
+// context travels through Shelly.call's own userdata parameter (a string —
+// the key name — not a new object) rather than a fresh closure capture.
+var CONFIG_LOAD_KEYS = null;
+var CONFIG_LOAD_INDEX = 0;
+var CONFIG_LOAD_MISSING = null;
+var CONFIG_LOAD_DONE = null;
+
 // Load configuration from KVS and validate required fields
 function loadConfig(callback) {
   log("Loading configuration from KVS...");
-  
-  var missingRequired = [];
-  var configKeys = [];
-  
+
+  CONFIG_LOAD_MISSING = [];
+  CONFIG_LOAD_KEYS = [];
+
   // Build array of config keys to load (skip cliOnly — written by CLI, not needed at runtime)
   for (var key in CONFIG_SCHEMA) {
     if (!CONFIG_SCHEMA[key].cliOnly) {
-      configKeys.push(key);
+      CONFIG_LOAD_KEYS.push(key);
     }
   }
-  
-  var keyIndex = 0;
-  
-  // Process one key at a time using task queue
-  function loadNextKey() {
-    if (keyIndex >= configKeys.length) {
-      // All keys loaded, validate
-      if (missingRequired.length > 0) {
-        log("ERROR: Missing required configuration:");
-        for (var i = 0; i < missingRequired.length; i++) {
-          log("  -", missingRequired[i]);
-        }
-        log("Script cannot start without required configuration.");
-        log("Please run: ctl pool setup <pro3-device> --pro1 <pro1-device>");
-        callback(false);
-        return;
-      }
 
-      // Clamp grace delay to minimum safe value
-      if (CONFIG.graceDelayMs < 10000) {
-        log("WARNING: grace-delay below minimum (10000ms), clamping");
-        CONFIG.graceDelayMs = 10000;
-      }
+  CONFIG_LOAD_INDEX = 0;
+  CONFIG_LOAD_DONE = callback;
+  loadNextConfigKey();
+}
 
-      // Enumerate available outputs and inputs
-      var availableOutputs = [];
-      for (var oi = 0; oi < 4; oi++) {
-        var swSt = Shelly.getComponentStatus("switch:" + oi);
-        if (swSt && ("output" in swSt)) {
-          availableOutputs.push(oi);
-        }
-      }
-      STATE.outputs = availableOutputs;
-
-      var availableInputs = [];
-      for (var ii = 0; ii < 4; ii++) {
-        var inSt = Shelly.getComponentStatus("input:" + ii);
-        if (inSt && ("state" in inSt)) {
-          availableInputs.push(ii);
-        }
-      }
-      STATE.inputs = availableInputs;
-
-      // Detect device type based on switch count
-      if (availableOutputs.length >= 3) {
-        STATE.deviceType = "pro3";
-        log("Detected device type: Pro3 (3 switches)");
-      } else if (availableOutputs.length === 1) {
-        STATE.deviceType = "pro1";
-        log("Detected device type: Pro1 (1 switch)");
-      } else {
-        STATE.deviceType = "unknown";
-        log("WARNING: Could not detect device type");
-      }
-      log("Switches:", availableOutputs, "Inputs:", availableInputs);
-
-      // Cache my device ID
-      var deviceInfo = Shelly.getDeviceInfo();
-      if (deviceInfo && deviceInfo.id) {
-        STATE.myDeviceId = deviceInfo.id;
-        log("My device ID:", STATE.myDeviceId);
-      } else {
-        log("ERROR: Could not get device ID");
-        callback(false);
-        return;
-      }
-
-      log("Configuration loaded successfully");
-      // Free schema object — only needed during KVS loading, not at runtime
-      CONFIG_SCHEMA = null;
-      callback(true);
-      return;
+// Called once CONFIG_LOAD_INDEX reaches the end of CONFIG_LOAD_KEYS:
+// validates required fields, detects device type/ID, then hands control
+// back to loadConfig's caller.
+function finishLoadConfig() {
+  if (CONFIG_LOAD_MISSING.length > 0) {
+    log("ERROR: Missing required configuration:");
+    for (var i = 0; i < CONFIG_LOAD_MISSING.length; i++) {
+      log("  -", CONFIG_LOAD_MISSING[i]);
     }
-    
-    var key = configKeys[keyIndex];
-    var schema = CONFIG_SCHEMA[key];
-    var kvsKey = CONFIG_KEY_PREFIX + schema.key;
-    keyIndex++;
-    
-    // Load from KVS asynchronously
-    Shelly.call("KVS.Get", {key: kvsKey}, function(result, err) {
-      if (err) {
-        log("WARNING: KVS.Get failed for", kvsKey, ":", err, "- using default");
-        CONFIG[key] = schema.default;
-        if (schema.required && CONFIG[key] === null) {
-          missingRequired.push(key + " (" + kvsKey + ") - KVS error: " + err);
-        }
-        queueTask(loadNextKey);
-        return;
-      }
-
-      if (result && ("value" in result) && result.value !== null && result.value !== "") {
-        var value = result.value;
-        
-        // Parse value based on type
-        if (schema.type === "boolean") {
-          CONFIG[key] = value === "true" || value === true;
-        } else if (schema.type === "number") {
-          var num = Number(value);
-          if (!isNaN(num)) {
-            CONFIG[key] = num;
-          } else {
-            log("WARNING: Invalid number for", key, ":", value);
-            CONFIG[key] = schema.default;
-          }
-        } else {
-          CONFIG[key] = value;
-        }
-      } else {
-        // Use default
-        CONFIG[key] = schema.default;
-        
-        // Check if required
-        if (schema.required && CONFIG[key] === null) {
-          missingRequired.push(key + " (" + kvsKey + ")");
-        }
-      }
-      
-      // Queue next key
-      queueTask(loadNextKey);
-    });
+    log("Script cannot start without required configuration.");
+    log("Please run: ctl pool setup <pro3-device> --pro1 <pro1-device>");
+    CONFIG_LOAD_DONE(false);
+    return;
   }
-  
-  loadNextKey();
+
+  // Clamp grace delay to minimum safe value
+  if (CONFIG.graceDelayMs < 10000) {
+    log("WARNING: grace-delay below minimum (10000ms), clamping");
+    CONFIG.graceDelayMs = 10000;
+  }
+
+  // Enumerate available outputs and inputs
+  var availableOutputs = [];
+  for (var oi = 0; oi < 4; oi++) {
+    var swSt = Shelly.getComponentStatus("switch:" + oi);
+    if (swSt && ("output" in swSt)) {
+      availableOutputs.push(oi);
+    }
+  }
+  STATE.outputs = availableOutputs;
+
+  var availableInputs = [];
+  for (var ii = 0; ii < 4; ii++) {
+    var inSt = Shelly.getComponentStatus("input:" + ii);
+    if (inSt && ("state" in inSt)) {
+      availableInputs.push(ii);
+    }
+  }
+  STATE.inputs = availableInputs;
+
+  // Detect device type based on switch count
+  if (availableOutputs.length >= 3) {
+    STATE.deviceType = "pro3";
+    log("Detected device type: Pro3 (3 switches)");
+  } else if (availableOutputs.length === 1) {
+    STATE.deviceType = "pro1";
+    log("Detected device type: Pro1 (1 switch)");
+  } else {
+    STATE.deviceType = "unknown";
+    log("WARNING: Could not detect device type");
+  }
+  log("Switches:", availableOutputs, "Inputs:", availableInputs);
+
+  // Cache my device ID
+  var deviceInfo = Shelly.getDeviceInfo();
+  if (deviceInfo && deviceInfo.id) {
+    STATE.myDeviceId = deviceInfo.id;
+    log("My device ID:", STATE.myDeviceId);
+  } else {
+    log("ERROR: Could not get device ID");
+    CONFIG_LOAD_DONE(false);
+    return;
+  }
+
+  log("Configuration loaded successfully");
+  // Free schema object — only needed during KVS loading, not at runtime
+  CONFIG_SCHEMA = null;
+  var doneCb = CONFIG_LOAD_DONE;
+  // Release load-scoped state now that the load is over — same intent as
+  // freeing CONFIG_SCHEMA above, one line down: none of it is needed again
+  // for the lifetime of the script.
+  CONFIG_LOAD_KEYS = null;
+  CONFIG_LOAD_MISSING = null;
+  CONFIG_LOAD_DONE = null;
+  doneCb(true);
+}
+
+// Requests the next key in CONFIG_LOAD_KEYS from KVS, or finishes the load
+// if none remain. The key name (a string already held by CONFIG_LOAD_KEYS,
+// not a new allocation) travels to onConfigKVSResult via Shelly.call's own
+// userdata parameter instead of a fresh per-iteration closure capture.
+function loadNextConfigKey() {
+  if (CONFIG_LOAD_INDEX >= CONFIG_LOAD_KEYS.length) {
+    finishLoadConfig();
+    return;
+  }
+
+  var key = CONFIG_LOAD_KEYS[CONFIG_LOAD_INDEX];
+  CONFIG_LOAD_INDEX++;
+  var schema = CONFIG_SCHEMA[key];
+  Shelly.call("KVS.Get", {key: CONFIG_KEY_PREFIX + schema.key}, onConfigKVSResult, key);
+}
+
+// Single shared KVS.Get completion handler for every config key (defined
+// once, unlike the per-iteration closure it replaces). Re-derives schema
+// from CONFIG_SCHEMA[key] rather than having it passed alongside — one
+// string of userdata is enough context to do that lookup.
+function onConfigKVSResult(result, err, errMsg, key) {
+  var schema = CONFIG_SCHEMA[key];
+  var kvsKey = CONFIG_KEY_PREFIX + schema.key;
+
+  if (err) {
+    log("WARNING: KVS.Get failed for", kvsKey, ":", err, "- using default");
+    CONFIG[key] = schema.default;
+    if (schema.required && CONFIG[key] === null) {
+      CONFIG_LOAD_MISSING.push(key + " (" + kvsKey + ") - KVS error: " + err);
+    }
+    queueTask(loadNextConfigKey);
+    return;
+  }
+
+  if (result && ("value" in result) && result.value !== null && result.value !== "") {
+    var value = result.value;
+
+    // Parse value based on type
+    if (schema.type === "boolean") {
+      CONFIG[key] = value === "true" || value === true;
+    } else if (schema.type === "number") {
+      var num = Number(value);
+      if (!isNaN(num)) {
+        CONFIG[key] = num;
+      } else {
+        log("WARNING: Invalid number for", key, ":", value);
+        CONFIG[key] = schema.default;
+      }
+    } else {
+      CONFIG[key] = value;
+    }
+  } else {
+    // Use default
+    CONFIG[key] = schema.default;
+
+    // Check if required
+    if (schema.required && CONFIG[key] === null) {
+      CONFIG_LOAD_MISSING.push(key + " (" + kvsKey + ")");
+    }
+  }
+
+  // Queue next key
+  queueTask(loadNextConfigKey);
 }
 
 
@@ -435,28 +462,79 @@ var STATE_KEYS = {
 // CALLS_IN_FLIGHT tracks every Shelly.call this script makes. It is wired up
 // once here by wrapping Shelly.call itself, rather than editing each of the
 // ~16 call sites in this file — every callback still receives exactly the
-// arguments it always did (trackCall forwards result/error_code/
-// error_message/userdata unchanged), so this is purely additive bookkeeping.
+// arguments it always did, so this is purely additive bookkeeping.
 var CALLS_IN_FLIGHT = 0;
 var N_SEEN = 0;       // lifetime count — proves tracking actually runs
 var MAX_CALLS_IN_FLIGHT = 4; // stay one below the real 5-call device ceiling
 
-// trackCall's returned closure is inlined directly into the Shelly.call
-// wrapper below (one function, not two) — same bookkeeping, one less named
-// function object retained on the heap for the lifetime of the script.
+// --- Peak-heap follow-up to #421 ---------------------------------------
+// The original fix wrapped every Shelly.call in a brand-new closure (one
+// function object allocated per call, purely to decrement CALLS_IN_FLIGHT
+// and forward to the caller's own callback) — continuous allocation churn
+// on a device already ~700 bytes from its heap ceiling (see issue #421's
+// hardware measurements). CALL_SLOTS below is a small fixed pool of plain
+// {cb, ud, used} records, allocated ONCE at script load. Each Shelly.call
+// mutates a free slot in place instead of allocating a new closure or a new
+// {cb, ud} object — since at most MAX_CALLS_IN_FLIGHT calls are ever
+// in flight by design (plus a small margin for calls fired outside the task
+// queue's own throttle), a fixed pool sized one above the real device
+// ceiling can never run out in practice; acquireSlot() still falls back to
+// allocating a fresh record rather than dropping a callback if it ever did.
+var CALL_SLOTS = [];
+// Sized to the real 5-call device ceiling + 1 spare, not just
+// MAX_CALLS_IN_FLIGHT: calls fired directly from event/timer handlers
+// (not funneled through queueTask) are not subject to that throttle.
+for (var CALL_SLOT_INIT_I = 0; CALL_SLOT_INIT_I < 6; CALL_SLOT_INIT_I++) {
+  CALL_SLOTS.push({cb: null, ud: null, used: false});
+}
+
+function acquireCallSlot(cb, ud) {
+  for (var i = 0; i < CALL_SLOTS.length; i++) {
+    if (!CALL_SLOTS[i].used) {
+      CALL_SLOTS[i].used = true;
+      CALL_SLOTS[i].cb = cb;
+      CALL_SLOTS[i].ud = ud;
+      return CALL_SLOTS[i];
+    }
+  }
+  // Pool exhausted (should not happen — see sizing note above): fall back
+  // to a fresh record rather than losing the callback.
+  return {cb: cb, ud: ud, used: true};
+}
+
+// Shared completion handler for calls that passed a callback. Decrements
+// unconditionally before invoking the caller's callback, so a slot is
+// always freed even if the callback itself throws (caught by
+// processTaskQueue's try/catch below, or top-level error handling).
+function sharedCallDone(result, error_code, error_message, slot) {
+  CALLS_IN_FLIGHT--;
+  var cb = slot ? slot.cb : null;
+  var ud = slot ? slot.ud : null;
+  if (slot) {
+    slot.used = false;
+    slot.cb = null;
+    slot.ud = null;
+  }
+  if (typeof cb === 'function') {
+    cb(result, error_code, error_message, ud);
+  }
+}
+
+// Shared completion handler for fire-and-forget calls (storeValue() and
+// friends) — nothing to forward, so no slot is needed at all: this path
+// allocates nothing per call.
+function decrementOnlyCallDone() {
+  CALLS_IN_FLIGHT--;
+}
+
 var RAW_CALL = Shelly.call;
 Shelly.call = function (method, params, callback, userdata) {
   CALLS_IN_FLIGHT++;
   N_SEEN++;
-  return RAW_CALL(method, params, function (result, error_code, error_message, userdata2) {
-    // Decrement unconditionally before invoking callback, so a slot is
-    // always freed even if callback itself throws (caught by
-    // processTaskQueue's try/catch below, or top-level error handling).
-    CALLS_IN_FLIGHT--;
-    if (typeof callback === 'function') {
-      callback(result, error_code, error_message, userdata2);
-    }
-  }, userdata);
+  if (typeof callback !== 'function') {
+    return RAW_CALL(method, params, decrementOnlyCallDone, null);
+  }
+  return RAW_CALL(method, params, sharedCallDone, acquireCallSlot(callback, userdata));
 };
 
 // --- Self-check: fail LOUDLY, never silently (#421) ---------------------

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -421,6 +421,43 @@ var STATE_KEYS = {
   activeOutput: "active-output"     // -1 (all off), 0, 1, 2 for pro3; 0 for pro1
 };
 
+// === IN-FLIGHT RPC TRACKING (#421 Bug A) ===
+// Real Gen2 firmware allows at most 5 concurrent Shelly.call RPCs per script
+// (see AGENTS.md "Per-script limits"); the 6th concurrent call raises an
+// uncaught "Too many calls in progress" exception that kills the ENTIRE
+// script, not just the offending call. processTaskQueue's 200ms tick (below)
+// only serialises *when* queued task functions run — it has no idea how many
+// of the underlying async RPCs those tasks fire are still in flight. That
+// gap is the root cause of two live crashes (persistRuntimeState's turnover
+// mirror, saveState's active-output mirror — both storeValue() fire-and-
+// forget writes) documented in issue #421.
+//
+// CALLS_IN_FLIGHT tracks every Shelly.call this script makes. It is wired up
+// once here by wrapping Shelly.call itself, rather than editing each of the
+// ~16 call sites in this file — every callback still receives exactly the
+// arguments it always did (trackCall forwards result/error_code/
+// error_message/userdata unchanged), so this is purely additive bookkeeping.
+var CALLS_IN_FLIGHT = 0;
+var MAX_CALLS_IN_FLIGHT = 4; // stay one below the real 5-call device ceiling
+
+function trackCall(onDone) {
+  CALLS_IN_FLIGHT++;
+  return function (result, error_code, error_message, userdata) {
+    // Decrement unconditionally before invoking onDone, so a slot is always
+    // freed even if onDone itself throws (caught by processTaskQueue's
+    // try/catch below, or by the script's top-level error handling).
+    CALLS_IN_FLIGHT--;
+    if (typeof onDone === 'function') {
+      onDone(result, error_code, error_message, userdata);
+    }
+  };
+}
+
+var RAW_SHELLY_CALL = Shelly.call;
+Shelly.call = function (method, params, callback, userdata) {
+  return RAW_SHELLY_CALL(method, params, trackCall(callback), userdata);
+};
+
 // === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
 var TASK_QUEUE = [];
 var TASK_INDEX = 0;
@@ -438,17 +475,37 @@ function processTaskQueue() {
     return;
   }
 
+  // Bug A root-cause fix (#421): don't dispatch another queued task while
+  // too many of this script's own Shelly.call RPCs are still in flight — a
+  // fixed 200ms tick is not a promise the device has actually kept up with.
+  // Skip this tick; TASK_INDEX is unchanged so the same task is retried on
+  // the next one, once a slot frees up.
+  if (CALLS_IN_FLIGHT >= MAX_CALLS_IN_FLIGHT) {
+    log('Task queue throttled, calls in flight:', CALLS_IN_FLIGHT);
+    return;
+  }
+
   // Execute next task; new tasks queued by the task itself extend TASK_QUEUE
   // and will be picked up on subsequent timer ticks.
   var task = TASK_QUEUE[TASK_INDEX];
   TASK_INDEX++;
-  task();
+
+  // Second, independent layer of defense (#421): one queued task throwing
+  // (whether from a call path the throttle above doesn't cover, or any
+  // other bug) must not be able to kill the entire script the way it did in
+  // the live incident this issue documents.
+  try {
+    task();
+  } catch (e) {
+    log('ERROR: queued task threw, continuing:', e);
+    if (e && false) {}
+  }
 }
 
 function queueTask(task) {
   // Simply append to queue
   TASK_QUEUE.push(task);
-  
+
   // Start timer only if not already running
   if (!TASK_TIMER) {
     TASK_TIMER = Timer.set(200, true, processTaskQueue);
@@ -2209,6 +2266,108 @@ function handleNightStop() {
   doStop('Night stop event');
 }
 
+// === RESTART CATCH-UP (#421 Bug B) ===
+// enforceOutputState() (below) only mirrors whatever physical state the
+// switch already has at boot — it never asks "should I actually be running
+// right now, given today's schedule window?". A restart (crash recovery,
+// script re-upload, device reboot) landing mid-window therefore silently
+// adopts a stale on/off state and only self-corrects whenever the next
+// schedule tick fires, which can be hours away. This is exactly what left a
+// live pump running hours past its scheduled evening-stop (see issue #421).
+// restartCatchUp() compares "now" against the currently active mode's
+// window — read straight from Schedule.List, the same source of truth
+// updateScheduleMode() writes to — and calls doStart()/doStop() immediately
+// if the physical state disagrees, instead of waiting for the next tick.
+
+// Parses the "M H" fields out of a Shelly cron timespec built by
+// makeTimespec() ("0 M H * * DAYS") or a fixed literal ("0 15 23 * * ...").
+// Returns minutes-since-midnight, or null for formats it can't resolve
+// (e.g. still-symbolic "@sunrise" specs on a schedule that has never had
+// updateScheduleMode() compute real times for it yet) — those windows are
+// left alone rather than guessed at.
+function parseTimespecHM(timespec) {
+  if (!timespec || timespec.indexOf('@') === 0) return null;
+  var parts = timespec.split(' ');
+  if (parts.length < 3) return null;
+  var m = Number(parts[1]);
+  var h = Number(parts[2]);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+function nowMinutesOfDay() {
+  var d = new Date();
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+// True if nowMin falls in [startMin, stopMin), handling windows that wrap
+// past midnight (e.g. the fixed winter night-run 23:15 -> 00:15).
+function isWithinWindow(nowMin, startMin, stopMin) {
+  if (startMin === null || stopMin === null) return false;
+  if (startMin <= stopMin) {
+    return nowMin >= startMin && nowMin < stopMin;
+  }
+  return nowMin >= startMin || nowMin < stopMin;
+}
+
+function restartCatchUp() {
+  if (!isMyTurnToRun()) {
+    return;
+  }
+
+  // Mode-aware on purpose: only one of these two job pairs is ever enabled
+  // at a time on a real device (updateScheduleMode() disables the other),
+  // so matching against the currently active mode avoids any ambiguity
+  // about which pair's timespec actually governs "now".
+  var mode = STATE.scheduleMode || 'winter';
+  var startCode = mode === 'summer' ? 'handleMorningStart()' : 'handleNightStart()';
+  var stopCode = mode === 'summer' ? 'handleEveningStop()' : 'handleNightStop()';
+
+  Shelly.call('Schedule.List', {}, function (result, err) {
+    if (err) {
+      log('Restart catch-up: Schedule.List failed, skipping:', err);
+      if (err && false) {}
+      return;
+    }
+    if (!result || !result.jobs) {
+      log('Restart catch-up: no schedules found, skipping');
+      return;
+    }
+
+    var startMin = null;
+    var stopMin = null;
+    for (var i = 0; i < result.jobs.length; i++) {
+      var job = result.jobs[i];
+      if (!job.enable || !job.calls || job.calls.length === 0) continue;
+      var code = job.calls[0].params && job.calls[0].params.code;
+      if (code === startCode) {
+        startMin = parseTimespecHM(job.timespec);
+      } else if (code === stopCode) {
+        stopMin = parseTimespecHM(job.timespec);
+      }
+    }
+
+    if (startMin === null || stopMin === null) {
+      log('Restart catch-up: could not resolve', mode, 'window, skipping');
+      return;
+    }
+
+    var nowMin = nowMinutesOfDay();
+    var shouldRun = isWithinWindow(nowMin, startMin, stopMin);
+    var isRunning = STATE.activeOutput !== -1;
+
+    log('Restart catch-up:', mode, 'now=', nowMin, 'window=[', startMin, ',', stopMin, ') shouldRun=', shouldRun, 'isRunning=', isRunning);
+
+    if (shouldRun && !isRunning) {
+      doStart(CONFIG.preferredSpeed, 'Restart catch-up: inside scheduled window');
+    } else if (!shouldRun && isRunning) {
+      doStop('Restart catch-up: outside scheduled window');
+    } else {
+      log('Restart catch-up: state already consistent with schedule');
+    }
+  });
+}
+
 // === INITIALIZATION ===
 function enforceOutputState() {
   log("Enforcing output state at startup...");
@@ -2339,6 +2498,10 @@ function continueInit() {
       log('✓ All initialization steps complete - script is now running');
       log('Current mode:', STATE.scheduleMode || 'winter');
       log('Should I run?', isMyTurnToRun());
+      // #421 Bug B: correct any stale physical state against the current
+      // schedule window immediately, before the (possibly hours-away) next
+      // schedule tick or today's forecast-driven mode re-check.
+      queueTask(restartCatchUp);
       queueTask(handleDailyCheck);
       return;
     }

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,6 +89,48 @@ func poolPumpSchedules() []map[string]interface{} {
 			}},
 		},
 	}
+}
+
+// activeNightWindowSchedules returns poolPumpSchedules() with the night-run
+// window (handleNightStart/handleNightStop) widened to bracket time.Now()
+// instead of the fixed 23:15/00:15 literals. Tests that leave the pump
+// already "on" in ComponentStatus at boot (simulating a legitimate
+// in-progress run carried across a restart) need this: pool-pump.js's #421
+// Bug B restart catch-up compares "now" against the currently active mode's
+// schedule window and calls doStop() if they disagree. scheduleMode defaults
+// to "winter" when Storage doesn't carry a saved mode (as in these
+// fixtures), so catch-up looks at the night-start/night-stop jobs — and the
+// fixed 23:15-00:15 band essentially never contains the real time these
+// tests run at, which would otherwise make catch-up immediately stop the
+// pump these tests are trying to exercise.
+func activeNightWindowSchedules() []map[string]interface{} {
+	schedules := poolPumpSchedules()
+	now := time.Now()
+	start := now.Add(-30 * time.Minute)
+	stop := now.Add(3 * time.Hour)
+	startSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", start.Minute(), start.Hour())
+	stopSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", stop.Minute(), stop.Hour())
+	for _, job := range schedules {
+		calls, ok := job["calls"].([]interface{})
+		if !ok || len(calls) == 0 {
+			continue
+		}
+		call, ok := calls[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		params, ok := call["params"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch params["code"] {
+		case "handleNightStart()":
+			job["timespec"] = startSpec
+		case "handleNightStop()":
+			job["timespec"] = stopSpec
+		}
+	}
+	return schedules
 }
 
 func pro3ComponentStatus() map[string]interface{} {
@@ -232,7 +275,7 @@ func TestPoolPump_WaterSupplyRestoresSpeed(t *testing.T) {
 		KVS:             controllerKVS(),
 		Storage:         make(map[string]interface{}),
 		ComponentStatus: cs,
-		Schedules:       poolPumpSchedules(),
+		Schedules:       activeNightWindowSchedules(),
 		EventInjector:   injector,
 	}
 
@@ -583,7 +626,7 @@ func TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover(t *testing.T) {
 		KVS:             controllerKVS(),
 		Storage:         make(map[string]interface{}),
 		ComponentStatus: cs,
-		Schedules:       poolPumpSchedules(),
+		Schedules:       activeNightWindowSchedules(),
 		EventInjector:   injector,
 	}
 
@@ -675,7 +718,7 @@ func TestPoolPump_RuntimeAccounting_ContinuesAfterReboot(t *testing.T) {
 			"runtime-date": dateString(time.Now()),
 		},
 		ComponentStatus: cs,
-		Schedules:       poolPumpSchedules(),
+		Schedules:       activeNightWindowSchedules(),
 		EventInjector:   injector,
 	}
 
@@ -1094,5 +1137,243 @@ func TestPoolPump_SolarStaleTsFallsBackImmediately(t *testing.T) {
 
 	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "-1" {
 		t.Fatalf("stale ts: expected pump to stay off (stale detected immediately on receipt), got active-output=%v", v)
+	}
+}
+
+// === #421 Bug A: "Too many calls in progress" concurrent-call ceiling ===
+//
+// Reproduces the live crash from issue #421 by recreating its actual trigger:
+// activateOutput()'s runtime-accounting hooks (stopRuntimeAccounting ->
+// persistRuntimeState, and setOutput's saveState() callback) queue
+// storeValue() fire-and-forget KVS writes via queueTask() — the same two
+// call sites the live crash dumps named (persistRuntimeState's turnover
+// mirror, saveState's active-output mirror). processTaskQueue's 200ms tick
+// only serializes *when* those queued task functions run — it has no idea
+// how many of the underlying async Shelly.call RPCs are still in flight.
+//
+// This drives four rapid, alternating water-supply toggle events at a pump
+// that's already running. Because each toggle's own Switch.Set call is
+// deferred (DeviceState.CallDelay simulates a real RPC's async round-trip),
+// STATE.activeOutput stays stale across the whole burst, so every "water
+// supply ON" toggle sees a spurious wasRunning->false transition and queues
+// two more persistRuntimeState writes each time — on top of the four
+// directly-dispatched Switch.Set calls themselves. That combination
+// reliably pushes concurrent in-flight Shelly.call RPCs past the real
+// device's 5-call ceiling, recreating "Too many calls in progress" (see the
+// two crash dumps quoted in issue #421).
+func TestPoolPump_ConcurrentCallCeiling_WaterSupplyBurstDoesNotCrash(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	// Generous: boot alone (26 sequential config keys, each round-tripping
+	// through CallDelay) takes on the order of 15-20s with this delay, plus
+	// a 10s settle buffer (see below) and the burst/drain phase.
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		90*time.Second,
+	)
+	defer cancel()
+
+	injector := make(chan []byte, 8)
+
+	deviceState := &script.DeviceState{
+		KVS:             pro1KVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: pro1ComponentStatus(),
+		Schedules:       pro1Schedules(),
+		EventInjector:   injector,
+		Mode:            script.DeviceTestMode,
+		// Long enough that four rapid-fire Switch.Set dispatches (injected
+		// within microseconds of each other) all stay "in flight"
+		// simultaneously across several 200ms task-queue ticks — recreating
+		// the real overlap between the task queue's fixed cadence and an
+		// RPC's actual completion time. Short enough that, once the fix
+		// throttles processTaskQueue's own dispatch against real in-flight
+		// count, the whole burst still drains within this test's deadline.
+		CallDelay: 500 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	initDone := waitFor(60*time.Second, 200*time.Millisecond, func() bool {
+		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		return exists
+	})
+	if !initDone {
+		cancel()
+		<-done
+		t.Fatalf("init did not complete within timeout")
+	}
+
+	// schedule-mode appears early (right after STATE.initializing flips to
+	// false) — well before the 4 sequential initSteps (Sys.SetConfig,
+	// applyComponentNames, verifySchedules, ...), restartCatchUp(), and
+	// handleDailyCheck()'s forecast fetch finish draining, each of which
+	// dispatches its own CallDelay-deferred Shelly.call. Give that leftover
+	// init activity time to fully settle so the burst below is the only
+	// concurrent-call activity in play — otherwise it can trip the ceiling
+	// (or fail to, post-fix) for reasons unrelated to what this test targets.
+	time.Sleep(10 * time.Second)
+
+	// Turn the pump on first (button press bypasses activateOutput() per
+	// existing test comments, so it doesn't itself contribute to the
+	// concurrent-call count) and wait for it to actually land, so the burst
+	// below starts from a known, settled "running" state.
+	injector <- shellyButtonEvent()
+	if !waitFor(3*time.Second, 50*time.Millisecond, func() bool {
+		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		return ok && v == "0"
+	}) {
+		t.Fatalf("pump did not turn on before the concurrent-call burst")
+	}
+
+	// Fire the burst: four alternating water-supply transitions with no
+	// delay in between (see the doc comment above).
+	injector <- shellyInputEvent(0, true)
+	injector <- shellyInputEvent(0, false)
+	injector <- shellyInputEvent(0, true)
+	injector <- shellyInputEvent(0, false)
+
+	deadline := time.After(20 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var runErr error
+settleLoop:
+	for {
+		select {
+		case runErr = <-done:
+			break settleLoop
+		case <-deadline:
+			break settleLoop
+		case <-ticker.C:
+			// No specific end state to poll for (the deliberately-raced
+			// toggles make the final active-output unpredictable) — just
+			// give queued/deferred work time to drain without crashing.
+		}
+	}
+
+	cancel()
+	if runErr == nil {
+		runErr = <-done
+	}
+
+	if runErr != nil && strings.Contains(runErr.Error(), "Too many calls in progress") {
+		t.Fatalf("script crashed on the concurrent-call ceiling (issue #421 Bug A): %v", runErr)
+	}
+}
+
+// === #421 Bug B: restart catch-up against the active schedule window ===
+//
+// enforceOutputState() only mirrors whatever physical switch state it finds
+// at boot — it never asks "should I actually be running right now, given
+// today's schedule window?". This simulates a restart landing well outside
+// the active summer-mode window (morning-start/evening-stop, computed here
+// relative to time.Now() so the test is deterministic regardless of when it
+// runs) with the pump physically left "on", and asserts the fixed
+// restartCatchUp() path calls doStop() and the switch ends up off — without
+// waiting for any schedule tick (there is no cron emulation in this
+// harness).
+func TestPoolPump_RestartCatchUp_StopsOutsideScheduleWindow(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	now := time.Now()
+	winStart := now.Add(3 * time.Hour)
+	winStop := now.Add(4 * time.Hour)
+	startSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", winStart.Minute(), winStart.Hour())
+	stopSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", winStop.Minute(), winStop.Hour())
+
+	schedules := []map[string]interface{}{
+		{
+			"id": 1, "enable": true,
+			"timespec": "@sunrise * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleDailyCheck()"},
+			}},
+		},
+		{
+			"id": 2, "enable": true,
+			"timespec": startSpec, // 3h from now — "now" is outside this window
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleMorningStart()"},
+			}},
+		},
+		{
+			"id": 3, "enable": true,
+			"timespec": stopSpec,
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleEveningStop()"},
+			}},
+		},
+		{
+			"id": 4, "enable": false, // disabled: summer mode, night schedules off
+			"timespec": "0 15 23 * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleNightStart()"},
+			}},
+		},
+		{
+			"id": 5, "enable": false,
+			"timespec": "0 15 0 * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleNightStop()"},
+			}},
+		},
+	}
+
+	cs := pro1ComponentStatus()
+	cs["switch:0"] = map[string]interface{}{"id": 0, "output": true} // physically on at "restart"
+
+	deviceState := &script.DeviceState{
+		KVS:             pro1KVS(),
+		Storage:         map[string]interface{}{"schedule-mode": "summer"},
+		ComponentStatus: cs,
+		Schedules:       schedules,
+	}
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		15*time.Second,
+	)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	stopped := waitFor(10*time.Second, 100*time.Millisecond, func() bool {
+		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		return ok && v == "-1"
+	})
+	cancel()
+	<-done
+
+	if !stopped {
+		t.Fatalf("restart outside scheduled window: expected catch-up to stop the pump (active-output=-1), got %v",
+			deviceState.KVS["script/pool-pump/active-output"])
+	}
+
+	entry, ok := deviceState.ComponentStatus["switch:0"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("switch:0 component status missing or malformed: %v", deviceState.ComponentStatus["switch:0"])
+	}
+	if on, _ := entry["output"].(bool); on {
+		t.Errorf("restart outside scheduled window: switch:0 still physically on after catch-up")
 	}
 }

--- a/pkg/shelly/script/device_state.go
+++ b/pkg/shelly/script/device_state.go
@@ -5,14 +5,59 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 )
+
+// ExecutionMode controls how strictly the goja-based emulator enforces
+// Shelly Gen2 per-script resource limits (see AGENTS.md "Per-script
+// limits"). This is a minimal slice of issue #250 — only the concurrent
+// Shelly.call ceiling is modeled here; timer/event-handler/status-handler/
+// MQTT-subscription count limits are #250's remaining scope, not this one's.
+type ExecutionMode int
+
+const (
+	// DeviceTestMode is the zero value / default: the emulator mirrors the
+	// real device's concurrent-call ceiling, panicking with a message
+	// matching the real device's "Too many calls in progress" error once
+	// MaxConcurrentCalls calls are already in flight. Use for all unit
+	// tests exercising scripts against simulated device behavior.
+	DeviceTestMode ExecutionMode = iota
+	// DeviceExtensionMode disables the ceiling entirely, for daemon-side
+	// script execution (myhome/scripthost) that intentionally aggregates
+	// state across multiple devices and must not be constrained by any
+	// single device's per-script limits.
+	DeviceExtensionMode
+)
+
+// MaxConcurrentCalls mirrors the real Shelly Gen2 per-script ceiling on
+// in-flight Shelly.call RPCs (see AGENTS.md "Per-script limits"). Exceeding
+// it on real hardware raises an uncaught "Too many calls in progress"
+// exception that kills the entire script (see issue #421).
+const MaxConcurrentCalls = 5
 
 // DeviceState represents the persistent state of a Shelly device for testing
 type DeviceState struct {
 	KVS     map[string]interface{} `json:"kvs"`
 	Storage map[string]interface{} `json:"storage"`
+
+	// Mode selects resource-limit enforcement (see ExecutionMode). The zero
+	// value is DeviceTestMode, so existing callers that don't set this field
+	// keep getting strict enforcement by default.
+	Mode ExecutionMode `json:"-"`
+
+	// CallDelay, when non-zero and Mode is DeviceTestMode, artificially
+	// delays the *release* of a Shelly.call's in-flight slot (not the
+	// call's dispatch or its callback — those stay synchronous, preserving
+	// every script's existing callback-ordering assumptions). This lets a
+	// test create genuinely overlapping in-flight calls — e.g. several
+	// calls dispatched a fixed tick apart, each taking longer than that
+	// tick to "complete" from the device's perspective — to exercise the
+	// concurrent-call ceiling (see issue #421). Zero (default) preserves
+	// the emulator's original synchronous-release behavior. Ignored in
+	// DeviceExtensionMode.
+	CallDelay time.Duration `json:"-"`
 
 	// Schedules tracks jobs created via Schedule.Create during script execution.
 	// Each entry is the raw params map passed to Schedule.Create, plus an "id" field.

--- a/pkg/shelly/script/event_handler.go
+++ b/pkg/shelly/script/event_handler.go
@@ -107,12 +107,17 @@ func (eh *eventsHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byt
 
 	log.Info("Processing event", "event", eventData)
 
-	// Call all registered event handlers
+	// Call all registered event handlers. On real Shelly firmware an
+	// uncaught exception in any callback kills the entire script — mirror
+	// that here (see the equivalent fix in RunWithDeviceState's event loop,
+	// issue #421) by stopping and propagating the first error instead of
+	// logging and continuing to the next handler.
 	for i, handler := range eh.handlers {
 		eh.log.Info("Calling event handler", "handler", i, "event", eventData)
 		_, err := handler.callback(goja.Undefined(), eventObj, handler.userdata)
 		if err != nil {
 			log.Error(err, "Event handler failed", "handler", i, "event", eventData)
+			return err
 		}
 	}
 

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -110,7 +110,17 @@ func RunWithDeviceState(ctx context.Context, name string, buf []byte, minify boo
 			msg := value.Bytes()
 			handlerCountBefore := len(handlers)
 			if err := handlers[handlerIdx].Handle(ctx, vm, msg); err != nil {
-				log.Error(err, "Handler failed", "handler", handlerIdx)
+				// On real Shelly firmware, an uncaught exception in *any*
+				// script callback (timer tick, event handler, MQTT message)
+				// kills the entire script — not just that one callback.
+				// Mirror that here: a handler error is a full script crash,
+				// not a log-and-continue. Without this, Bug A's crash (see
+				// issue #421), which happens inside a Timer-driven
+				// processTaskQueue tick rather than the initial synchronous
+				// script evaluation, would be silently swallowed and the
+				// emulator could never observe it.
+				log.Error(err, "Handler failed - script crashed", "handler", handlerIdx)
+				return err
 			}
 			// Check if new handlers were added during Handle()
 			if len(handlers) != handlerCountBefore {
@@ -165,6 +175,16 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	timers := make(map[int]*timerHandler)
 	nextTimerHandle := 1
 
+	// callsInFlight tracks concurrent Shelly.call RPCs for this VM, enforced
+	// only in DeviceTestMode (see issue #421 / #250). Only ever read and
+	// mutated from the single goroutine that drives script execution: the
+	// initial synchronous vm.RunScript() call, or a later handler Handle()
+	// call from RunWithDeviceState's event loop — never concurrently, so no
+	// synchronization is needed even though its release (see CallDelay) may
+	// be scheduled from a timer-like goroutine that only ever *sends on a
+	// channel*, never touches this variable directly.
+	callsInFlight := 0
+
 	vm := goja.New()
 
 	// Shelly event handler system
@@ -189,7 +209,52 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 		log.Info("Shelly.call()", "method", method, "params", params.Export())
 
 		if fn, ok := methods[method]; ok {
+			if deviceState.Mode == DeviceTestMode {
+				if callsInFlight >= MaxConcurrentCalls {
+					// Mirrors the real Gen2 firmware's uncaught exception
+					// when a script exceeds its concurrent-call budget (see
+					// AGENTS.md "Per-script limits", issue #421). Using
+					// vm.NewGoError (an *Object) rather than a plain Go
+					// panic keeps this catchable by a script-level
+					// try/catch, exactly like the real device's exception —
+					// necessary for testing pool-pump.js's own try/catch
+					// defense layer.
+					panic(vm.NewGoError(fmt.Errorf("Too many calls in progress")))
+				}
+				callsInFlight++
+			}
+
+			dispatch := func() {
+				_, err := fn(vm, method, params, callback, userdata)
+				if deviceState.Mode == DeviceTestMode {
+					callsInFlight--
+				}
+				if err != nil {
+					log.Error(err, "Shelly.call() failed (deferred)", "method", method)
+				}
+			}
+
+			if deviceState.Mode == DeviceTestMode && deviceState.CallDelay > 0 {
+				// Defer the entire dispatch — method execution AND its
+				// callback — by CallDelay, rather than just this call's
+				// internal in-flight accounting. A script's own real
+				// in-flight tracking (built from its callbacks, like the
+				// #421 fix) can only throttle against overlap it can
+				// actually observe; deferring just the accounting would be
+				// invisible to it. Shelly.call() always returns undefined
+				// on real hardware, so there's no synchronous result to
+				// preserve here (the one caller in this codebase that reads
+				// a return value, loadValue() in pool-pump.js, is unused
+				// dead code).
+				deferDispatch(handlers, deviceState.CallDelay, dispatch)
+				return goja.Undefined()
+			}
+
 			result, err := fn(vm, method, params, callback, userdata)
+			if deviceState.Mode == DeviceTestMode {
+				callsInFlight--
+			}
+
 			if err != nil {
 				log.Error(err, "Shelly.call() failed", "method", method)
 				return vm.ToValue(err)
@@ -757,6 +822,45 @@ type testEventForwarder struct {
 func (f *testEventForwarder) Wait() <-chan []byte { return f.ch }
 func (f *testEventForwarder) Handle(ctx context.Context, vm *goja.Runtime, msg []byte) error {
 	return f.eh.Handle(ctx, vm, msg)
+}
+
+// deferredCallHandler is a one-shot handler (same shape as a one-shot Timer,
+// see timerHandler below) that fires `dispatch` after `delay` elapses. It
+// exists solely to let DeviceState.CallDelay simulate a real RPC's async
+// round-trip: the method call and its callback both happen only once the
+// delay elapses, rather than synchronously (see issue #421). It never
+// errors itself — any error from `dispatch` (i.e. from the wrapped
+// Shelly.call) is handled by `dispatch` before it returns.
+type deferredCallHandler struct {
+	delay    time.Duration
+	dispatch func()
+	ch       chan []byte
+}
+
+func (h *deferredCallHandler) Wait() <-chan []byte {
+	if h.ch != nil {
+		return h.ch
+	}
+	h.ch = make(chan []byte)
+	go func() {
+		time.Sleep(h.delay)
+		h.ch <- []byte{}
+		close(h.ch)
+	}()
+	return h.ch
+}
+
+func (h *deferredCallHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byte) error {
+	h.dispatch()
+	return nil
+}
+
+// deferDispatch registers a deferredCallHandler so `dispatch` fires once
+// `delay` has elapsed, driven by RunWithDeviceState's normal event loop (see
+// reflect.Select there) rather than a raw goroutine touching VM state
+// directly.
+func deferDispatch(handlers *[]handler, delay time.Duration, dispatch func()) {
+	*handlers = append(*handlers, &deferredCallHandler{delay: delay, dispatch: dispatch})
 }
 
 type methodFunc func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error)


### PR DESCRIPTION
Fixes #421. **Do not merge yet — see "Blocked on real hardware" below.**

## What this fixes

**Bug A — `Too many calls in progress` killed the entire script.** `processTaskQueue` dispatched one
queued task per 200ms tick, which serialises only *when task functions run* — it had no idea how
many `Shelly.call` RPCs those tasks left in flight, and `storeValue()` is fire-and-forget. Real Gen2
firmware caps concurrent RPCs per script at 5; the 6th raises an uncaught exception that kills the
whole script, stopping all schedule-driven pump control. That is how a live pump was found running
hours past its scheduled evening stop.

Fix: track in-flight calls and have `processTaskQueue` skip a tick while `MAX_CALLS_IN_FLIGHT` (4,
one below the device ceiling) are outstanding, leaving `TASK_INDEX` unchanged so the task retries.
Plus a `try/catch` around `task()` as an independent second layer — no single queued task should be
able to kill schedule-driven pump control again, whatever the cause.

**Bug B — no catch-up against the schedule window on restart.** `enforceOutputState()` only mirrored
the physical switch at boot; it never asked whether *now* is inside today's window, so a restart
mid-window silently adopted stale state until the next tick, possibly hours later. Adds
`restartCatchUp()`, which reads the active mode's start/stop jobs from `Schedule.List` (the same
source `updateScheduleMode` writes) and calls `doStart()`/`doStop()` when reality disagrees. Handles
windows wrapping past midnight; skips unresolvable/symbolic timespecs rather than guessing.

**Emulator:** adds a per-VM concurrent-call counter and artificial completion delay, enforced only in
`DeviceTestMode`. This is the minimal slice of #250 needed to reproduce the crash in tests; the rest
of #250's scope is deliberately left to that issue.

**Fail-loudly self-check.** The throttle works by reassigning `Shelly.call` to a wrapper. If that
ever stops being permitted, the counter stays 0, the throttle goes inert, and the crash returns —
*while every emulator test still passes*, because goja allows a reassignment a device might refuse.
Failing open and silently is the dangerous case, so it is asserted, not assumed. Two failure modes
are covered (assignment rejected; assignment took but nothing tracked), both printing a diagnostic
that names the cause, the consequence, an explicit "read issue #421 first", and the alternative fix
direction — so whoever meets this log next does not re-derive the root cause. Both also emit a
`pool.call_tracking_broken` notice event. A healthy boot logs a positive confirmation, so silence is
never ambiguous. Uses `print()` rather than `log()` because `log()` is gated on
`CONFIG.enableLogging` and would hide the message in production. Lines are kept short because the
device truncates UDP debug lines at ~128 chars.

## Verified on real hardware (Shelly Plus 1, fw 1.7.5)

- Wrapper installs on mJS (`patched=true`).
- The 12-concurrent-`Script.Eval` burst that crashed the pre-fix script on its first attempt now
  survives. Throttle engaged 3x at 4 in flight; the `try/catch` never fired — the root cause is
  prevented, not merely caught.
- Queued KVS writes still land (`runtime-sec`, `turnover-today`, `active-output`) — survival is not
  bought by dropping work.
- Restart catch-up emitted `pool.pump_stop {"reason":"Restart catch-up: outside scheduled window"}`
  and physically opened the relay.
- Both self-check failure modes produce the full untruncated diagnostic and the notice event.

`make test`: 47 packages ok, 0 failures.

## Memory work (why the last commit exists)

The first working version could not run on real hardware at all — `out_of_memory` on the production
Pro1 and on a Plus 1 configured to match it, stranding the pump ON. Measurements (total JS heap
23030 bytes, shared across all scripts, `watchdog.js` resident, 24 real KVS keys set):

| version | minified | result |
|---|---|---|
| `main` @ `ae4c5da` | 36155 | runs, `mem_peak 22330`, `mem_free 10276` |
| first fix | 40002 | `out_of_memory` |
| after static size trim | 38483 | `out_of_memory` |
| **after call-slot pool** | — | runs, **`mem_peak 21280`**, `mem_free 8148` |

`main` alone already peaks at 22330 of 23030 — ~700 bytes of headroom. So this was never a
code-size problem: trimming 1519 minified bytes changed nothing. It was **peak allocation** — the
wrapper allocated a fresh closure on every `Shelly.call` (39 during init alone). Replacing that with
a fixed pool of records claimed in place and passed via `userdata` to one shared completion handler
brought peak ~1050 bytes *below* `main`'s.

## Blocked on real hardware — do not merge yet

The final build runs on the Plus 1 but **still fails with `out_of_memory` on the production Pro1
(`filtration-hiver`)**. The devices report the same total heap but run **different firmware
generations — Pro1 on 2.0.0, Plus 1 on 1.7.5** — so the Plus 1 is not a valid proxy for this
particular constraint, despite matched scripts and matched KVS config.

Remaining options, in the maintainer's hands:
1. Free heap on the Pro1 (e.g. stop/remove `watchdog.js`, 3554 bytes) — a production behaviour change.
2. Reduce `main`'s own footprint so the whole thing fits with margin.
3. Split this PR: land Bug A (the crash fix, cheap) and defer Bug B (`restartCatchUp`, ~1.1 KB).

The production device is currently on v0.11.9's `pool-pump.js`, which is stable there
(`mem_peak 17136`, ~6 KB headroom) and completed a full unattended day cycle (10:18 start,
17:42 stop) during this work.

## Relationship to #401 / #406

#406 (removing the legacy `SolarAutomation` daemon code) is gated on #402/#403/#405 being verified
against the real pump. That gate is **not met** while this cannot run on the Pro1.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): bound in-flight RPCs and catch up on restart (#421) ([5ea7f73](https://github.com/asnowfix/home-automation/commit/5ea7f730a90a58797e22750e695939979f070a31))
- fix(pool-pump): fail loudly if the Shelly.call wrapper is not live (#421) ([75e161f](https://github.com/asnowfix/home-automation/commit/75e161f914b25a977ce3d760ba2af746a719bb4a))
- fix(pool-pump): shrink #421 fix's minified footprint for the Pro1 heap ([af8c9fc](https://github.com/asnowfix/home-automation/commit/af8c9fceb62ffffdc9eebee66d712146ee928ff1))
- fix(pool-pump): reuse call slots instead of a closure per RPC (#421) ([0ee8eac](https://github.com/asnowfix/home-automation/commit/0ee8eac4e980b82d98686bf587e96ed7cc36945d))
<!-- END-AUTO-GENERATED-COMMITS -->