### PR TITLE
feat(minifier): esbuild engine with opt-in top-level mangling and symbol map

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -621,6 +621,71 @@ pool:
 | `pool.solar.min_volume_turnover` | `MYHOME_POOL_SOLAR_MIN_VOLUME_TURNOVER` | `--pool-solar-min-volume-turnover` | `5` | Soft-stop target: pool volumes filtered per day; pump keeps running past this while solar is still above the start threshold |
 | `pool.solar.max_volume_turnover` | `MYHOME_POOL_SOLAR_MAX_VOLUME_TURNOVER` | `--pool-solar-max-volume-turnover` | `7` | Hard ceiling: pool volumes filtered per day; pump always stops (and won't be solar-started) once reached |
 
+## Scripts (JS minifier)
+
+The daemon's automatic device setup path (triggered whenever it discovers an
+unconfigured Shelly device on the network) uploads `watchdog.js` with
+minification enabled and no human in the loop. These options select which
+minifier it uses. **Both default to today's exact, long-proven behavior** —
+`tdewolff`, no top-level identifier mangling — and must be changed
+explicitly; see the "Default OFF" rationale below.
+
+### Example
+
+```yaml
+scripts:
+  minifier_engine: "tdewolff"   # or "esbuild"
+  mangle_top_level: false        # esbuild only
+```
+
+### Options
+
+| Key | Env var | Flag | Default | Description |
+|-----|---------|------|---------|-------------|
+| `scripts.minifier_engine` | `MYHOME_SCRIPTS_MINIFIER_ENGINE` | `--script-minifier-engine` | `tdewolff` | JS minifier for the daemon's automatic watchdog.js upload: `tdewolff` (proven-safe, mangles local identifiers only) or `esbuild` (experimental; ES5-targeted, can also mangle top-level identifiers) |
+| `scripts.mangle_top_level` | `MYHOME_SCRIPTS_MANGLE_TOP_LEVEL` | `--script-mangle-top-level` | `false` | Also mangle top-level (module-scope) identifiers; only takes effect with `minifier_engine: esbuild`. Reduces output size further (measured ~19% smaller on pool-pump.js) but wraps the script in an IIFE, which makes internal top-level names (e.g. `STATE`, `CONFIG`) unreachable from a live `Script.Eval` session unless separately declared as debug-exports in code (see `internal/shelly/scripts/minify_config.go`) |
+
+### Why default OFF
+
+Both the `esbuild` engine and `mangle_top_level` are new (see the minifier
+work tracked from issue-derived exploration around pool-pump.js's JS-heap
+pressure). The daemon's auto-setup path
+(`myhome/devices/impl/manager.go` → `internal/myhome/shelly/setup.SetupDevice`)
+runs unattended the moment a new, unconfigured device shows up on the
+network — a minifier bug there would silently push a broken script to real
+hardware. Both options must be flipped on deliberately, by a human editing
+config or passing a flag, never by a version upgrade alone. `myhome ctl
+shelly setup` also accepts the same two flags for one-off manual setups.
+
+A related, per-script safety mechanism lives in code, not config: which
+top-level names must survive `mangle_top_level` as real globals (because a
+Shelly `Schedule` job calls them by name via `script.eval`) is a per-script
+list in `internal/shelly/scripts/minify_config.go`
+(`scriptMinifyOverrides`), not a global setting — get it wrong for a given
+script and that script's scheduled automation silently stops firing.
+
+### CLI: minify and demangle
+
+```bash
+# Minify an embedded script locally (no device involved) and report size:
+myhome ctl shelly script minify pool-pump.js --engine esbuild --mangle-top-level
+
+# Same, also writing the minified code and a symbol map:
+myhome ctl shelly script minify pool-pump.js --engine esbuild --mangle-top-level \
+  --out /tmp/pool-pump.min.js --symbol-map /tmp/pool-pump.symbols.json
+
+# Translate a Shelly crash message's mangled names back to source names:
+myhome ctl shelly script demangle /tmp/pool-pump.symbols.json \
+  'in function "t" called from t(n.count)'
+```
+
+The symbol map is a flat `mangled -> original` table for top-level symbols
+only (see the doc comment on `pkg/shelly/script.SymbolMap`) — it exists
+because Shelly crash traces give function names and code snippets but never
+a line/column, so an ordinary Source Map v3 (also generated, alongside the
+symbol map, when `--mangle-top-level` is set) cannot resolve them on its
+own.
+
 ## Notice & Email (SMTP)
 
 The notice service (see `docs/notice-events-plan.md`) curates a `notice` severity for events worth a human's attention — the daily pool/garden plans, solar pump on/off, and motion at night or while the home is unoccupied — and emails a daily digest. Unlike the events/occupancy/temperature services, it is **not** auto-enabled with the device manager: it depends on both the events and occupancy services already running, so an operator opts in explicitly with `notice.enabled: true` or `--enable-notice-service`.

--- a/internal/myhome/shelly/script/ops.go
+++ b/internal/myhome/shelly/script/ops.go
@@ -36,6 +36,34 @@ func UploadNamedScript(ctx context.Context, log logr.Logger, via types.Channel, 
 // UploadWithVersion uploads a script and tracks its version in KVS
 // This is MyHome-specific business logic that combines script upload with version tracking
 func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, name string, code []byte, minify bool, force bool) (uint32, error) {
+	return uploadWithVersion(ctx, log, via, device, name, code, force, func() (uint32, error) {
+		return script.Upload(ctx, via, device, name, code, minify)
+	})
+}
+
+// UploadWithVersionAndOptions is like UploadWithVersion but takes an
+// explicit script.MinifyOptions instead of a plain bool, so a caller can
+// select the minifier engine and opt into top-level mangling for a specific
+// script. Always minifies -- there is no "raw upload" mode here.
+//
+// This exists specifically so the daemon's automatic per-device setup path
+// (SetupDevice -> here, for watchdog.js) can be switched to the new
+// esbuild engine via a config option, without touching the signature or
+// behavior of UploadWithVersion/Upload, which every other caller
+// (CLI commands, garden/heater/pool setup) keeps using unchanged. See
+// CLAUDE.md's "Default OFF" requirement: pass
+// script.MinifyOptions{Engine: script.EngineTdewolff} (or the zero value)
+// here to reproduce today's exact behavior.
+func UploadWithVersionAndOptions(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, name string, code []byte, opts script.MinifyOptions, force bool) (uint32, error) {
+	return uploadWithVersion(ctx, log, via, device, name, code, force, func() (uint32, error) {
+		return script.UploadWithOptions(ctx, via, device, name, code, opts)
+	})
+}
+
+// uploadWithVersion holds the version-check/KVS-bookkeeping/start logic
+// shared by UploadWithVersion and UploadWithVersionAndOptions; doUpload
+// performs the actual (already-configured) upload call.
+func uploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, name string, code []byte, force bool, doUpload func() (uint32, error)) (uint32, error) {
 	// Calculate version hash
 	h := sha1.New()
 	h.Write(code)
@@ -66,7 +94,7 @@ func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, 
 		}
 
 		// Upload the script using the generic pkg/shelly/script package
-		id, err = script.Upload(ctx, via, device, name, code, minify)
+		id, err = doUpload()
 		if err != nil {
 			return 0, err
 		}

--- a/internal/myhome/shelly/setup/setup.go
+++ b/internal/myhome/shelly/setup/setup.go
@@ -14,6 +14,7 @@ import (
 
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
 	mhscript "github.com/asnowfix/home-automation/internal/myhome/shelly/script"
+	embeddedscripts "github.com/asnowfix/home-automation/internal/shelly/scripts"
 	"github.com/asnowfix/home-automation/pkg/devices"
 	shellyapi "github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/input"
@@ -37,6 +38,17 @@ type Config struct {
 	MqttPort int
 	// Resolver is used for DNS lookups
 	Resolver mynet.Resolver
+	// ScriptMinifierEngine selects the JS minifier used when uploading
+	// watchdog.js during automatic setup. Defaults to pkgscript.EngineTdewolff
+	// (today's proven-safe behavior) via DefaultConfig -- see CLAUDE.md's
+	// "Default OFF" requirement: this must never silently change without a
+	// human opting in via config/flag, because SetupDevice runs
+	// unattended whenever the daemon discovers a new device.
+	ScriptMinifierEngine pkgscript.Engine
+	// ScriptMangleTopLevel additionally enables esbuild's top-level
+	// identifier mangling (ignored when ScriptMinifierEngine is not
+	// EngineEsbuild). Opt-in, default false.
+	ScriptMangleTopLevel bool
 }
 
 // WifiConfig holds WiFi configuration options for device setup
@@ -51,8 +63,10 @@ type WifiConfig struct {
 // DefaultConfig returns a Config with default values
 func DefaultConfig() Config {
 	return Config{
-		MqttBroker: "mqtt.local",
-		MqttPort:   1883,
+		MqttBroker:           "mqtt.local",
+		MqttPort:             1883,
+		ScriptMinifierEngine: pkgscript.EngineTdewolff,
+		ScriptMangleTopLevel: false,
 	}
 }
 
@@ -298,7 +312,8 @@ func SetupDevice(ctx context.Context, log logr.Logger, sd *shellyapi.Device, tar
 			log.Error(err, "Failed to read watchdog script", "device", deviceId)
 			return fmt.Errorf("failed to read watchdog script: %w", err)
 		}
-		id, err := mhscript.UploadWithVersion(ctx, log, via, sd, "watchdog.js", buf, true, false)
+		minifyOpts := embeddedscripts.MinifyOptionsFor("watchdog.js", cfg.ScriptMinifierEngine, cfg.ScriptMangleTopLevel, false)
+		id, err := mhscript.UploadWithVersionAndOptions(ctx, log, via, sd, "watchdog.js", buf, minifyOpts, false)
 		if err != nil {
 			log.Error(err, "Failed to upload watchdog script", "device", deviceId)
 			return fmt.Errorf("failed to upload watchdog script: %w", err)

--- a/internal/shelly/scripts/minify_config.go
+++ b/internal/shelly/scripts/minify_config.go
@@ -1,0 +1,97 @@
+package scripts
+
+import "github.com/asnowfix/home-automation/pkg/shelly/script"
+
+// scriptMinifyOverrides maps an embedded script's basename to the top-level
+// symbol names that must remain reachable as real globals if that script is
+// minified with esbuild's top-level mangling enabled (opt-in; see
+// pkg/shelly/script.MinifyOptions.MangleTopLevel). This registry is the
+// concrete answer to "make the preserve-list configurable per script, not
+// hardcoded to pool-pump": add an entry here, not in pkg/shelly/script
+// (which must stay generic -- see the Three-Tier Layer Rule in CLAUDE.md).
+//
+// Two categories per entry:
+//
+//   - PreserveGlobals: names invoked BY NAME from outside the script's own
+//     JS execution -- concretely, a Shelly Schedule job whose "code" field
+//     is a bare call like "handleMorningStart()", evaluated later via
+//     script.eval. If MangleTopLevel renames these away without
+//     re-exporting them, the schedule silently stops working (the eval
+//     throws "not defined", which nothing here catches -- it fails on
+//     the device, not at build time). Get this list right.
+//   - DebugExports: additional names kept reachable purely so a developer
+//     can inspect them live via Script.Eval while debugging on real
+//     hardware (e.g. STATE, CONFIG). This is a deliberate trade-off,
+//     documented on MinifyOptions.DebugExports: real debuggability gained,
+//     in exchange for a few extra bytes and a small global-namespace
+//     collision risk with other scripts on the same device. Left empty
+//     by default; a developer opts in per investigation, not permanently.
+//
+// A script with no entry here gets the zero value (empty PreserveGlobals
+// and DebugExports) from MinifyOptionsFor, which is a SAFE default -- it
+// just means nothing is protected. Any script that gains a
+// Schedule.Create-by-name call (grep for `code:` in the .js files under
+// this package to check) must get an entry here before its build path is
+// ever switched to esbuild with MangleTopLevel.
+var scriptMinifyOverrides = map[string]script.MinifyOptions{
+	// pool-pump.js: five Schedule jobs (daily-check, morning-start,
+	// evening-stop, night-start, night-stop) each eval one of these by
+	// name. NOTE: the four-name list quoted in earlier investigation notes
+	// (issue #421 handover) omitted handleDailyCheck -- verified against
+	// the current source (grep for `code: '` in pool-pump.js) and included
+	// here. pool-pump.js is owned by PR #426 as of this writing and is
+	// deliberately NOT switched to esbuild by this change; this entry
+	// exists so the registry is correct and ready whenever that switch is
+	// made.
+	"pool-pump.js": {
+		PreserveGlobals: []string{
+			"handleDailyCheck",
+			"handleMorningStart",
+			"handleEveningStop",
+			"handleNightStart",
+			"handleNightStop",
+		},
+		// Names most useful for live Script.Eval debugging during the
+		// #421 investigation. Off by default (DebugExports is only
+		// consulted when a caller explicitly asks MinifyOptionsFor to
+		// merge it in -- see includeDebugExports below); listed here so
+		// the option exists without editing this file again mid-incident.
+		DebugExports: []string{"STATE", "CONFIG", "TASK_QUEUE"},
+	},
+	// garden.js: two Schedule jobs (handlePlan, handleWateringStart).
+	"garden.js": {
+		PreserveGlobals: []string{
+			"handlePlan",
+			"handleWateringStart",
+		},
+	},
+	// watchdog.js, prometheus-metrics.js, and every other embedded script
+	// currently have no Schedule.Create-by-name calls (verified by
+	// grepping for `code:` across internal/shelly/scripts/*.js), so no
+	// entry is needed -- an empty PreserveGlobals list is correct, not an
+	// oversight.
+}
+
+// MinifyOptionsFor returns the MinifyOptions to use for top-level mangling
+// of the given embedded script (looked up by basename, e.g. "pool-pump.js"),
+// merging the caller-supplied engine/MangleTopLevel/includeDebugExports
+// choice with this script's registered preserve/debug lists.
+//
+// includeDebugExports controls whether the registered DebugExports are
+// actually applied -- keep it false for routine/automatic minification
+// (the daemon's auto-setup path) and set it true only when a developer is
+// deliberately trading a few bytes for live-debuggability on a specific
+// investigation. This mirrors the "opt-in, default OFF" requirement that
+// also governs MangleTopLevel itself.
+func MinifyOptionsFor(scriptName string, engine script.Engine, mangleTopLevel bool, includeDebugExports bool) script.MinifyOptions {
+	base := scriptMinifyOverrides[scriptName] // zero value if absent: no preserve/debug names
+	opts := script.MinifyOptions{
+		Engine:          engine,
+		MangleTopLevel:  mangleTopLevel,
+		PreserveGlobals: append([]string(nil), base.PreserveGlobals...),
+	}
+	if includeDebugExports {
+		opts.DebugExports = append([]string(nil), base.DebugExports...)
+	}
+	return opts
+}

--- a/internal/shelly/scripts/scripts_esbuild_test.go
+++ b/internal/shelly/scripts/scripts_esbuild_test.go
@@ -1,0 +1,186 @@
+package scripts
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+	"github.com/asnowfix/home-automation/pkg/shelly/script"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+// esbuildES5DownlevelUnsupported is esbuild's fixed error phrasing when
+// asked to target ES5 for syntax it cannot downlevel to ES5 at all (notably
+// let/const/classes -- as opposed to syntax it simply won't ever emit, like
+// arrow functions, which it CAN downlevel). This is a real, current
+// limitation of esbuild itself, not a bug in this package's wrapping code:
+// a handful of this repo's existing scripts already use let/const directly
+// in source (and apparently run fine on real Shelly hardware -- Espruino's
+// "limited ES6" support evidently covers them), which the tdewolff path
+// left untouched because it doesn't transpile syntax either. Until those
+// scripts are rewritten to `var`-only (a separate, larger cleanup, out of
+// scope here) or esbuild adds ES5 let/const downleveling, they simply
+// cannot go through the esbuild path -- MinifyWithOptions fails loudly
+// with this error rather than risking silently-wrong output, which is the
+// safe failure mode. Scripts that hit this are logged and skipped rather
+// than failing the suite.
+const esbuildES5DownlevelUnsupported = "is not supported yet"
+
+// TestSmokeAllScriptsEsbuild extends TestSmokeAllScripts (tdewolff path) to
+// the new esbuild engine, for every embedded script, in two modes:
+//
+//  1. esbuild, no top-level mangling (local-identifier mangling only, same
+//     scope as today's tdewolff path).
+//  2. esbuild, top-level mangling ON, using this script's registered
+//     PreserveGlobals (see MinifyOptionsFor) -- verifies the preserved
+//     names are still present in the output as literal tokens, i.e. still
+//     reachable by Shelly Schedule jobs that eval them by name.
+//
+// Every mode is checked for ES5-only syntax and run through the goja
+// emulator harness, exactly like the tdewolff smoke test.
+func TestSmokeAllScriptsEsbuild(t *testing.T) {
+	minifyOnly := map[string]string{
+		"universal-blu-to-mqtt.js": "uses BLE.Scanner (hardware-only API)",
+	}
+	perScriptState := map[string]*script.DeviceState{}
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	entries, err := fs.ReadDir(GetFS(), ".")
+	if err != nil {
+		t.Fatalf("failed to read embedded script FS: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".js") {
+			continue
+		}
+		name := entry.Name()
+
+		t.Run(name, func(t *testing.T) {
+			rawBuf, err := fs.ReadFile(GetFS(), name)
+			if err != nil {
+				t.Fatalf("read embedded script: %v", err)
+			}
+
+			modes := []struct {
+				label string
+				opts  script.MinifyOptions
+			}{
+				{"no top-level mangling", MinifyOptionsFor(name, script.EngineEsbuild, false, false)},
+				{"top-level mangling", MinifyOptionsFor(name, script.EngineEsbuild, true, false)},
+			}
+
+			for _, mode := range modes {
+				t.Run(mode.label, func(t *testing.T) {
+					res, err := script.MinifyWithOptions(name, rawBuf, mode.opts)
+					if err != nil {
+						if strings.Contains(err.Error(), esbuildES5DownlevelUnsupported) {
+							t.Skipf("script uses syntax esbuild cannot downlevel to ES5 (e.g. let/const) -- skipping, see esbuildES5DownlevelUnsupported doc comment: %v", err)
+						}
+						t.Fatalf("esbuild minify (%s) failed: %v", mode.label, err)
+					}
+					if found := script.FindES6Syntax(res.Code); len(found) > 0 {
+						t.Errorf("esbuild output contains ES6-only marker(s) %v", found)
+					}
+
+					// Every registered PreserveGlobals name must remain a
+					// literal token in the output -- the whole point of
+					// the preserve-list.
+					for _, preserved := range mode.opts.PreserveGlobals {
+						if !strings.Contains(string(res.Code), preserved) {
+							t.Errorf("preserved global %q not found in esbuild output (%s)", preserved, mode.label)
+						}
+					}
+
+					if reason, ok := minifyOnly[name]; ok {
+						t.Logf("minify-only (skipping goja run): %s", reason)
+						return
+					}
+
+					ctx, cancel := context.WithTimeout(
+						logr.NewContext(context.Background(), testr.New(t)),
+						smokeTimeout,
+					)
+					defer cancel()
+
+					deviceState, ok := perScriptState[name]
+					if !ok {
+						deviceState = &script.DeviceState{
+							KVS:             make(map[string]interface{}),
+							Storage:         make(map[string]interface{}),
+							ComponentStatus: genericComponentStatus(),
+						}
+					}
+
+					runErr := script.RunWithDeviceState(ctx, name, res.Code, false, deviceState)
+					if runErr != nil &&
+						!errors.Is(runErr, context.Canceled) &&
+						!errors.Is(runErr, context.DeadlineExceeded) {
+						t.Fatalf("script failed to initialise under esbuild (%s): %v", mode.label, runErr)
+					}
+				})
+			}
+		})
+	}
+}
+
+// TestSmokeAllScriptsEsbuild_SymbolMapCoversPreservedNames verifies, for
+// every script with a registered preserve/debug-export list, that the
+// symbol map produced alongside top-level-mangled output actually contains
+// entries -- i.e. VLQ-decoding the source map against these real,
+// much-larger-than-the-synthetic-test-fixture scripts (pool-pump.js is
+// ~75KB) works and yields a non-trivial mapping, and that every
+// preserved/debug-exported ORIGINAL name has at least one internal mangled
+// call site recorded.
+//
+// Note: a preserved/debug-exported name being reachable as a literal
+// top-level global (via the outer re-export assignment) does NOT mean it
+// has no mangled form -- quite the opposite. Every reference to it INSIDE
+// the wrapped closure (e.g. "STATE" read/written ~160 times throughout
+// pool-pump.js) still resolves to the local declaration and gets mangled
+// like any other local reference; only the one, extra, outer re-export
+// statement keeps the literal name callable/inspectable from outside. So
+// this test asserts each preserved/debug name DOES appear as an original
+// name in the symbol map (the internal savings are still being captured),
+// not that it's absent.
+func TestSmokeAllScriptsEsbuild_SymbolMapCoversPreservedNames(t *testing.T) {
+	for name, overrides := range scriptMinifyOverrides {
+		name, overrides := name, overrides
+		t.Run(name, func(t *testing.T) {
+			rawBuf, err := fs.ReadFile(GetFS(), name)
+			if err != nil {
+				t.Fatalf("read embedded script: %v", err)
+			}
+
+			opts := MinifyOptionsFor(name, script.EngineEsbuild, true, true) // include debug exports too
+			res, err := script.MinifyWithOptions(name, rawBuf, opts)
+			if err != nil {
+				t.Fatalf("esbuild minify failed: %v", err)
+			}
+			if res.Symbols == nil || len(res.Symbols.Symbols) == 0 {
+				t.Fatal("expected a non-empty symbol map")
+			}
+
+			originals := make(map[string]bool, len(res.Symbols.Symbols))
+			for _, o := range res.Symbols.Symbols {
+				originals[o] = true
+			}
+
+			for _, name := range append(append([]string{}, overrides.PreserveGlobals...), overrides.DebugExports...) {
+				if !originals[name] {
+					t.Errorf("expected preserved/debug-exported name %q to still have an internal mangled call site recorded in the symbol map", name)
+				}
+			}
+
+			t.Logf("%s: %d top-level symbols mapped", name, len(res.Symbols.Symbols))
+		})
+	}
+}

--- a/myhome-example.yaml
+++ b/myhome-example.yaml
@@ -232,6 +232,25 @@ sfr:
   username: ""
   password: ""
 
+# JS minifier used by the daemon's automatic device setup path (uploads
+# watchdog.js to newly-discovered devices with no human in the loop).
+# Both options default to today's exact, long-proven behavior and must be
+# changed deliberately -- see docs/configuration.md "Scripts (JS minifier)"
+# for why this stays off by default.
+scripts:
+  # "tdewolff" (default, proven-safe: mangles local identifiers only) or
+  # "esbuild" (experimental: ES5-targeted, can also mangle top-level
+  # identifiers -- see mangle_top_level below).
+  # Default: tdewolff
+  # minifier_engine: tdewolff
+
+  # Also mangle top-level (module-scope) identifiers; only takes effect
+  # with minifier_engine: esbuild. Smaller output, but internal top-level
+  # names (e.g. STATE, CONFIG) become unreachable from a live Script.Eval
+  # session unless explicitly listed as debug-exports in code.
+  # Default: false
+  # mangle_top_level: false
+
 # Notice service: curates a "notice" event severity (daily pool/garden plans,
 # solar pump on/off, motion at night or while absent) and emails a daily
 # digest. Unlike events/occupancy/temperature, this is NOT auto-enabled with

--- a/myhome/ctl/options/options.go
+++ b/myhome/ctl/options/options.go
@@ -112,6 +112,8 @@ var Flags struct {
 	SMTPPassword                string        // SMTP auth password (e.g. a Gmail App Password); from .env, never a flag
 	SMTPFrom                    string        // envelope/header From address; empty disables email entirely
 	SMTPTo                      string        // recipient address, or comma-separated list of addresses
+	ScriptMinifierEngine        string        // the value taken by --script-minifier-engine: "tdewolff" (default) or "esbuild"
+	ScriptMangleTopLevel        bool          // the value taken by --script-mangle-top-level; only meaningful with the esbuild engine
 }
 
 var Via types.Channel

--- a/myhome/ctl/shelly/script/demangle.go
+++ b/myhome/ctl/shelly/script/demangle.go
@@ -1,0 +1,36 @@
+package script
+
+import (
+	"fmt"
+	"strings"
+
+	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	Cmd.AddCommand(demangleCtl)
+}
+
+var demangleCtl = &cobra.Command{
+	Use:   "demangle SYMBOL_MAP_FILE MESSAGE...",
+	Short: "Translate a Shelly crash message's mangled identifiers back to their original names",
+	Long: `Reads a symbol map JSON file (written by "myhome ctl shelly script minify --symbol-map")
+and substitutes every mangled top-level identifier found in MESSAGE with its original name.
+MESSAGE may be given as several arguments (joined with spaces) so a crash message can be
+pasted without quoting every special character.
+
+All substitution logic lives in pkg/shelly/script.SymbolMap.Demangle -- this command is a
+thin, offline wrapper around it; it never touches a device.`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		m, err := pkgscript.ReadSymbolMap(args[0])
+		if err != nil {
+			return err
+		}
+		msg := strings.Join(args[1:], " ")
+		fmt.Println(m.Demangle(msg))
+		return nil
+	},
+}

--- a/myhome/ctl/shelly/script/minify.go
+++ b/myhome/ctl/shelly/script/minify.go
@@ -1,0 +1,113 @@
+package script
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	embeddedscripts "github.com/asnowfix/home-automation/internal/shelly/scripts"
+	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
+
+	"github.com/spf13/cobra"
+)
+
+// minify/demangle are local, offline tools: they read a script (embedded or
+// from a local file), minify it, and optionally write out the minified code
+// and/or a symbol map -- no MQTT, no device, no network. This matters
+// because this feature is explicitly opt-in/exploratory (see
+// docs/configuration.md "Scripts (JS minifier)" and CLAUDE.md's "Default
+// OFF" requirement); a developer evaluating the esbuild engine should be
+// able to do so entirely offline before ever touching daemon config or a
+// real device. All business logic (engine selection, wrapping, symbol map
+// derivation) lives in pkg/shelly/script and internal/shelly/scripts --
+// per the Three-Tier Layer Rule in CLAUDE.md, this file is CLI plumbing
+// only.
+
+var (
+	minifyEngine                string
+	minifyMangleTopLevel        bool
+	minifyPreserveGlobals       []string
+	minifyDebugExports          []string
+	minifyOutPath               string
+	minifySymbolMapPath         string
+	minifyDisableSyntaxLowering bool
+)
+
+func init() {
+	Cmd.AddCommand(minifyCtl)
+	minifyCtl.Flags().StringVar(&minifyEngine, "engine", string(pkgscript.EngineTdewolff), "Minifier engine: tdewolff (default) or esbuild")
+	minifyCtl.Flags().BoolVar(&minifyMangleTopLevel, "mangle-top-level", false, "Also mangle top-level identifiers (esbuild engine only)")
+	minifyCtl.Flags().StringSliceVar(&minifyPreserveGlobals, "preserve", nil, "Extra top-level names to keep reachable as globals, on top of this script's registered preserve-list (see internal/shelly/scripts/minify_config.go)")
+	minifyCtl.Flags().StringSliceVar(&minifyDebugExports, "debug-export", nil, "Top-level names to keep reachable for live Script.Eval debugging, on top of this script's registered debug-export list")
+	minifyCtl.Flags().StringVar(&minifyOutPath, "out", "", "Write the minified code to this file")
+	minifyCtl.Flags().StringVar(&minifySymbolMapPath, "symbol-map", "", "Write the top-level symbol map (JSON) to this file (requires --engine esbuild --mangle-top-level)")
+	minifyCtl.Flags().BoolVar(&minifyDisableSyntaxLowering, "disable-syntax-lowering", false, "esbuild engine only: keep sequential statements separate instead of collapsing them into comma-expressions -- see issue #266 (comma-expression-in-return crashed a real device with \"Too much recursion\"); costs a little size, NOT verified on hardware")
+}
+
+var minifyCtl = &cobra.Command{
+	Use:   "minify SCRIPT",
+	Short: "Minify a script locally (no device involved) and report its size",
+	Long: `Minify SCRIPT -- either the basename of an embedded script (e.g. pool-pump.js) or a
+path to a local .js file -- and print its minified size. This command never touches a device
+or the network; it is a local, offline way to evaluate minifier engines and options before
+changing daemon config.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return doMinifyCommand(args[0])
+	},
+}
+
+// loadScriptSource resolves nameOrPath first against the embedded scripts
+// filesystem (so "pool-pump.js" just works), falling back to a local file
+// on disk. Returns the basename to use for registry lookups and error
+// messages, and the raw source bytes.
+func loadScriptSource(nameOrPath string) (name string, src []byte, err error) {
+	if data, ferr := fs.ReadFile(embeddedscripts.GetFS(), nameOrPath); ferr == nil {
+		return nameOrPath, data, nil
+	}
+	data, ferr := os.ReadFile(nameOrPath)
+	if ferr != nil {
+		return "", nil, fmt.Errorf("could not read %q as an embedded script or a local file: %w", nameOrPath, ferr)
+	}
+	return filepath.Base(nameOrPath), data, nil
+}
+
+func doMinifyCommand(nameOrPath string) error {
+	name, src, err := loadScriptSource(nameOrPath)
+	if err != nil {
+		return err
+	}
+
+	engine := pkgscript.Engine(minifyEngine)
+	opts := embeddedscripts.MinifyOptionsFor(name, engine, minifyMangleTopLevel, len(minifyDebugExports) > 0)
+	opts.PreserveGlobals = append(opts.PreserveGlobals, minifyPreserveGlobals...)
+	opts.DebugExports = append(opts.DebugExports, minifyDebugExports...)
+	opts.DisableSyntaxLowering = minifyDisableSyntaxLowering
+
+	res, err := pkgscript.MinifyWithOptions(name, src, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s: %d bytes -> %d bytes (engine=%s mangle_top_level=%v)\n", name, len(src), len(res.Code), engine, minifyMangleTopLevel)
+
+	if minifyOutPath != "" {
+		if err := os.WriteFile(minifyOutPath, res.Code, 0o644); err != nil {
+			return fmt.Errorf("write minified output: %w", err)
+		}
+		fmt.Printf("wrote minified code to %s\n", minifyOutPath)
+	}
+
+	if minifySymbolMapPath != "" {
+		if res.Symbols == nil {
+			return fmt.Errorf("no symbol map produced -- pass --engine esbuild --mangle-top-level to generate one")
+		}
+		if err := pkgscript.WriteSymbolMap(minifySymbolMapPath, res.Symbols); err != nil {
+			return err
+		}
+		fmt.Printf("wrote symbol map (%d symbols) to %s\n", len(res.Symbols.Symbols), minifySymbolMapPath)
+	}
+
+	return nil
+}

--- a/myhome/ctl/shelly/setup/main.go
+++ b/myhome/ctl/shelly/setup/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/asnowfix/home-automation/hlog"
 	shellysetup "github.com/asnowfix/home-automation/internal/myhome/shelly/setup"
 	"github.com/asnowfix/home-automation/internal/myhome"
+	shellyscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/myhome/ctl/options"
 	mhmqtt "github.com/asnowfix/home-automation/myhome/mqtt"
 	mynet "github.com/asnowfix/home-automation/internal/myhome/net"
@@ -42,6 +43,8 @@ func init() {
 	Cmd.Flags().StringVar(&sta1Passwd, "sta1-passwd", "", "STA1 Password")
 	Cmd.Flags().StringVar(&apPasswd, "ap-passwd", "", "AP Password")
 	Cmd.Flags().StringVar(&deviceNameOverride, "name", "", "Set device name (overrides auto-derivation)")
+	Cmd.Flags().StringVar(&options.Flags.ScriptMinifierEngine, "script-minifier-engine", "tdewolff", "JS minifier engine for the watchdog.js upload: \"tdewolff\" (default, proven-safe) or \"esbuild\" (experimental)")
+	Cmd.Flags().BoolVar(&options.Flags.ScriptMangleTopLevel, "script-mangle-top-level", false, "Also mangle top-level JS identifiers (esbuild engine only); opt-in, see docs/configuration.md")
 }
 
 // isTimeoutError checks if an error is a timeout error
@@ -71,8 +74,10 @@ func setupDevicesByName(ctx context.Context, pattern string) error {
 // unless overridden by command-line flag.
 func getSetupConfig(ctx context.Context) (shellysetup.Config, error) {
 	cfg := shellysetup.Config{
-		MqttPort: 1883,
-		Resolver: mynet.MyResolver(hlog.Logger),
+		MqttPort:             1883,
+		Resolver:             mynet.MyResolver(hlog.Logger),
+		ScriptMinifierEngine: shellyscript.Engine(options.Flags.ScriptMinifierEngine),
+		ScriptMangleTopLevel: options.Flags.ScriptMangleTopLevel,
 	}
 
 	// Use parent's --mqtt-broker flag if specified, otherwise use current process MQTT broker

--- a/myhome/daemon/run.go
+++ b/myhome/daemon/run.go
@@ -92,6 +92,8 @@ func init() {
 	runCmd.PersistentFlags().IntVar(&options.Flags.NoticeDigestHour, "notice-digest-hour", 8, "Local hour (0-23) at which the daily notice digest email is sent")
 	runCmd.PersistentFlags().StringVar(&options.Flags.SMTPHost, "smtp-host", "smtp.gmail.com", "SMTP host for the notice digest email")
 	runCmd.PersistentFlags().IntVar(&options.Flags.SMTPPort, "smtp-port", 587, "SMTP port for the notice digest email (STARTTLS submission)")
+	runCmd.PersistentFlags().StringVar(&options.Flags.ScriptMinifierEngine, "script-minifier-engine", "tdewolff", "JS minifier engine for the daemon's automatic device setup uploads: \"tdewolff\" (default, proven-safe) or \"esbuild\" (experimental)")
+	runCmd.PersistentFlags().BoolVar(&options.Flags.ScriptMangleTopLevel, "script-mangle-top-level", false, "Also mangle top-level JS identifiers (esbuild engine only); opt-in, reduces size further but sacrifices some Script.Eval debuggability -- see docs/configuration.md")
 	runCmd.MarkFlagsMutuallyExclusive("enable-gen1-proxy", "disable-gen1-proxy")
 	runCmd.MarkFlagsMutuallyExclusive("enable-occupancy-service", "disable-occupancy-service")
 	runCmd.MarkFlagsMutuallyExclusive("enable-temperature-service", "disable-temperature-service")
@@ -325,6 +327,18 @@ var runCmd = &cobra.Command{
 		}
 		if v.IsSet("pool.solar.max_volume_turnover") && !cmd.Flags().Changed("pool-solar-max-volume-turnover") {
 			options.Flags.PoolSolarMaxVolumeTurnover = v.GetFloat64("pool.solar.max_volume_turnover")
+		}
+
+		// Handle script minifier config from viper / flags. Defaults
+		// ("tdewolff", MangleTopLevel=false) reproduce today's exact
+		// behavior -- a human must explicitly opt into the esbuild engine
+		// and/or top-level mangling, per CLAUDE.md's "Default OFF"
+		// requirement for this feature.
+		if v.IsSet("scripts.minifier_engine") && !cmd.Flags().Changed("script-minifier-engine") {
+			options.Flags.ScriptMinifierEngine = v.GetString("scripts.minifier_engine")
+		}
+		if v.IsSet("scripts.mangle_top_level") && !cmd.Flags().Changed("script-mangle-top-level") {
+			options.Flags.ScriptMangleTopLevel = v.GetBool("scripts.mangle_top_level")
 		}
 
 		// Store Viper instance in global options for daemon to use

--- a/myhome/devices/impl/manager.go
+++ b/myhome/devices/impl/manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/asnowfix/home-automation/pkg/devices"
 	"github.com/asnowfix/home-automation/pkg/shelly"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
+	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"github.com/go-logr/logr"
 )
@@ -392,9 +393,18 @@ func (dm *DeviceManager) Start(ctx context.Context) error {
 		return err
 	}
 
-	// Configure auto-setup for new devices (used by device updater loop)
+	// Configure auto-setup for new devices (used by device updater loop).
+	// ScriptMinifierEngine/ScriptMangleTopLevel default to
+	// options.Flags' own defaults ("tdewolff", false) -- i.e. today's
+	// exact behavior -- unless a human explicitly sets
+	// --script-minifier-engine / --script-mangle-top-level or the
+	// equivalent scripts.* config keys. See CLAUDE.md's "Default OFF"
+	// requirement: this auto-setup path uploads watchdog.js to newly
+	// discovered devices with no human in the loop.
 	dm.setupConfig = shellysetup.Config{
-		Resolver: dm.resolver,
+		Resolver:             dm.resolver,
+		ScriptMinifierEngine: pkgscript.Engine(options.Flags.ScriptMinifierEngine),
+		ScriptMangleTopLevel: options.Flags.ScriptMangleTopLevel,
 	}
 	// Use the current process MQTT broker for auto-setup. DeviceServer()
 	// resolves a loopback address (e.g. the embedded broker's "localhost:1883")

--- a/pkg/shelly/script/es5check.go
+++ b/pkg/shelly/script/es5check.go
@@ -1,0 +1,37 @@
+package script
+
+import "strings"
+
+// es6Markers are syntax fragments that must never appear in code targeted
+// at ES5 -- Shelly's Espruino JS engine does not support them, and
+// esbuild's minifier can emit some of them (arrow functions, shorthand
+// properties, template literals) from otherwise-ES5 input unless
+// Target: api.ES5 is set explicitly (see minifyEsbuild). let/const are
+// included because, while a handful of this repo's existing scripts
+// already use them directly in source (and esbuild's ES5 target currently
+// refuses to downlevel let/const at all -- see MinifyWithOptions doc on
+// that limitation), freshly-generated minifier OUTPUT introducing a *new*
+// let/const that wasn't in the source would be a minifier bug worth
+// catching.
+var es6Markers = []string{"=>", "let ", "const ", "`"}
+
+// FindES6Syntax scans code (with string and comment CONTENTS masked out
+// first, so a log message like log("a", "=>", "b") or a comment mentioning
+// "let" doesn't produce a false positive) for ES6-only syntax markers and
+// returns the distinct markers found, in es6Markers order. An empty result
+// means the code is clear of the markers this function knows to look for.
+//
+// This is a heuristic, not a parser: it cannot catch every ES6 construct
+// (e.g. object-literal shorthand methods have no single distinctive
+// token), but it catches the constructs most likely to actually break
+// Shelly's Espruino engine and that a minifier could plausibly introduce.
+func FindES6Syntax(code []byte) []string {
+	masked := string(maskStringsAndComments(code))
+	var found []string
+	for _, marker := range es6Markers {
+		if strings.Contains(masked, marker) {
+			found = append(found, marker)
+		}
+	}
+	return found
+}

--- a/pkg/shelly/script/go.mod
+++ b/pkg/shelly/script/go.mod
@@ -10,8 +10,10 @@ require (
 
 require (
 	github.com/dlclark/regexp2 v1.11.4 // indirect
+	github.com/evanw/esbuild v0.28.1 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
 	github.com/tdewolff/parse/v2 v2.8.3 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 )

--- a/pkg/shelly/script/go.sum
+++ b/pkg/shelly/script/go.sum
@@ -3,6 +3,8 @@ github.com/dlclark/regexp2 v1.11.4 h1:rPYF9/LECdNymJufQKmri9gV604RvvABwgOA8un7yA
 github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dop251/goja v0.0.0-20251103141225-af2ceb9156d7 h1:jxmXU5V9tXxJnydU5v/m9SG8TRUa/Z7IXODBpMs/P+U=
 github.com/dop251/goja v0.0.0-20251103141225-af2ceb9156d7/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
+github.com/evanw/esbuild v0.28.1 h1:ds+yuRyUaZGx++GR56CrCeuXh8PVhVM4xq8v7PNELFc=
+github.com/evanw/esbuild v0.28.1/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
@@ -15,5 +17,9 @@ github.com/tdewolff/parse/v2 v2.8.3 h1:5VbvtJ83cfb289A1HzRA9sf02iT8YyUwN84ezjkdY
 github.com/tdewolff/parse/v2 v2.8.3/go.mod h1:Hwlni2tiVNKyzR1o6nUs4FOF07URA+JLBLd6dlIXYqo=
 github.com/tdewolff/test v1.0.11 h1:FdLbwQVHxqG16SlkGveC0JVyrJN62COWTRyUFzfbtBE=
 github.com/tdewolff/test v1.0.11/go.mod h1:XPuWBzvdUzhCuxWO1ojpXsyzsA5bFoS3tO/Q3kFuTG8=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
+golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/pkg/shelly/script/main.go
+++ b/pkg/shelly/script/main.go
@@ -340,16 +340,41 @@ func Upload(ctx context.Context, via types.Channel, device types.Device, name st
 	return id, nil
 }
 
+// UploadWithOptions is like Upload but takes an explicit MinifyOptions
+// instead of a plain bool, so callers can select the minifier engine and
+// (opt-in) top-level mangling -- see MinifyOptions. Always minifies (there
+// is no "raw upload" mode here; use Upload with minify=false for that).
+func UploadWithOptions(ctx context.Context, via types.Channel, device types.Device, name string, code []byte, opts MinifyOptions) (uint32, error) {
+	var err error
+
+	if len(code) == 0 {
+		code, err = fs.ReadFile(scripts, name)
+		if err != nil {
+			log.Error(err, "Unknown script", "name", name, "device", device.Name())
+			return 0, err
+		}
+	}
+
+	return doUploadWithOptions(ctx, via, device, name, code, true, opts)
+}
+
 func doUpload(ctx context.Context, via types.Channel, device types.Device, name string, buf []byte, minify bool) (uint32, error) {
+	// MinifyOptions{} is the zero value: EngineTdewolff, no top-level
+	// mangling -- exactly today's behavior, so this preserves it precisely
+	// for every existing bool-based caller of Upload/doUpload.
+	return doUploadWithOptions(ctx, via, device, name, buf, minify, MinifyOptions{})
+}
+
+func doUploadWithOptions(ctx context.Context, via types.Channel, device types.Device, name string, buf []byte, minify bool, opts MinifyOptions) (uint32, error) {
 	// Minify before splitting and uploading (only if requested)
 	if minify {
 		origLen := len(buf)
-		if minified, err := minifyJS(buf); err != nil {
+		if res, err := MinifyWithOptions(name, buf, opts); err != nil {
 			log.Error(err, "Minify failed", "name", name)
 			return 0, err
 		} else {
-			buf = minified
-			log.Info("Minified script", "name", name, "from", origLen, "to", len(buf))
+			buf = res.Code
+			log.Info("Minified script", "name", name, "engine", opts.Engine, "mangle_top_level", opts.MangleTopLevel, "from", origLen, "to", len(buf))
 			// Downgrade ES6 template literals without interpolations to plain strings
 			before := len(buf)
 			buf = downgradeTemplates(buf)

--- a/pkg/shelly/script/minify_esbuild.go
+++ b/pkg/shelly/script/minify_esbuild.go
@@ -330,7 +330,43 @@ func buildSymbolMap(name string, engine Engine, topLevelNames []string, code []b
 	return &SymbolMap{Script: name, Engine: engine, Symbols: symbols}, nil
 }
 
+// utf16ColumnToByteOffset converts a Source Map v3 generated column into a
+// byte offset within line.
+//
+// Source Map v3 columns are counted in UTF-16 code units, not bytes. Go
+// strings are indexed by bytes, so the two only coincide while the generated
+// output is pure ASCII. esbuild's default Charset is ASCII (it escapes
+// non-ASCII as \uXXXX), which made them coincide by accident — until that
+// default had to be changed to CharsetUTF8, because Espruino rejects \uXXXX
+// literals outright (see the Charset setting above). With raw UTF-8 in the
+// output, every multi-byte character shifts byte offsets relative to columns,
+// and indexing a line by a column yields the wrong position — decoding, for
+// example, "handleMorningStart" as "andleMorningStart".
+//
+// Returns -1 if col lies beyond the end of the line.
+func utf16ColumnToByteOffset(line string, col int) int {
+	if col <= 0 {
+		return col // 0 -> 0; negative is rejected by the caller
+	}
+	units := 0
+	for i, r := range line {
+		if units >= col {
+			return i
+		}
+		if r > 0xFFFF {
+			units += 2 // encoded as a surrogate pair in UTF-16
+		} else {
+			units++
+		}
+	}
+	if units >= col {
+		return len(line)
+	}
+	return -1
+}
+
 func identifierAt(line string, col int) string {
+	col = utf16ColumnToByteOffset(line, col)
 	if col < 0 || col >= len(line) || !isIdentPart(line[col]) {
 		return ""
 	}

--- a/pkg/shelly/script/minify_esbuild.go
+++ b/pkg/shelly/script/minify_esbuild.go
@@ -130,6 +130,7 @@ func minifyEsbuild(name string, src []byte, opts MinifyOptions) (*MinifyResult, 
 	if !opts.MangleTopLevel {
 		result := api.Transform(string(src), api.TransformOptions{
 			Target:            api.ES5,
+			Charset:           api.CharsetUTF8,
 			MinifyWhitespace:  true,
 			MinifyIdentifiers: true,
 			MinifySyntax:      !opts.DisableSyntaxLowering,
@@ -171,6 +172,7 @@ func minifyEsbuild(name string, src []byte, opts MinifyOptions) (*MinifyResult, 
 
 	result := api.Transform(wrapped, api.TransformOptions{
 		Target:            api.ES5,
+		Charset:           api.CharsetUTF8,
 		MinifyWhitespace:  true,
 		MinifyIdentifiers: true,
 		MinifySyntax:      !opts.DisableSyntaxLowering,

--- a/pkg/shelly/script/minify_esbuild.go
+++ b/pkg/shelly/script/minify_esbuild.go
@@ -1,0 +1,348 @@
+package script
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/evanw/esbuild/pkg/api"
+)
+
+// Engine selects which JS minifier implementation MinifyWithOptions uses.
+type Engine string
+
+const (
+	// EngineTdewolff is today's minifier (github.com/tdewolff/minify). It
+	// mangles LOCAL identifiers only; top-level names survive untouched.
+	// This is the default everywhere -- see CLAUDE.md "Resilience" and the
+	// "Default OFF" requirement for the esbuild path.
+	EngineTdewolff Engine = "tdewolff"
+
+	// EngineEsbuild is the new esbuild-based minifier
+	// (github.com/evanw/esbuild/pkg/api). It supports optional top-level
+	// identifier mangling (see MinifyOptions.MangleTopLevel). Must always be
+	// invoked with an ES5 target -- Shelly's Espruino JS engine does not
+	// support ES6 syntax, and esbuild's minifier can otherwise emit it
+	// (arrow functions, template literals, shorthand properties) even from
+	// ES5-only input.
+	EngineEsbuild Engine = "esbuild"
+)
+
+// MinifyOptions configures MinifyWithOptions. The zero value reproduces
+// today's behavior exactly: EngineTdewolff, no top-level mangling. Every new
+// capability added here is opt-in for that reason.
+type MinifyOptions struct {
+	// Engine selects the minifier implementation. Zero value (empty string)
+	// is treated as EngineTdewolff.
+	Engine Engine
+
+	// MangleTopLevel, when true and Engine is EngineEsbuild, wraps the
+	// script in an IIFE so esbuild's identifier mangler also renames
+	// top-level (module-scope) symbols -- normally esbuild treats top-level
+	// names in a plain script as globals and leaves them untouched. Ignored
+	// for EngineTdewolff (which never mangles top-level identifiers).
+	MangleTopLevel bool
+
+	// PreserveGlobals lists top-level identifiers that MUST remain
+	// reachable, by their original name, as real globals after wrapping.
+	// Concretely: Shelly Schedule jobs invoke handlers BY NAME via
+	// `script.eval` (e.g. {"code": "handleMorningStart()"}); if that name
+	// disappears into the IIFE's closure, the schedule breaks. This list is
+	// per-script -- see internal/shelly/scripts.MinifyOptionsFor for the
+	// registry of which scripts need which names preserved. Every entry
+	// must name an actual top-level declaration in the source, or
+	// MinifyWithOptions returns an error (fail fast on config typos rather
+	// than silently uploading a broken script).
+	PreserveGlobals []string
+
+	// DebugExports lists additional top-level identifiers to keep reachable
+	// as globals purely so a developer can inspect them live via
+	// Script.Eval while debugging on real hardware (e.g. "STATE",
+	// "CONFIG"). This is a deliberate, documented trade-off: every name
+	// here is a live debuggability win but also a few extra bytes and a
+	// (very small) global-namespace collision risk with other scripts on
+	// the same device. Off by default; opt in per incident.
+	DebugExports []string
+
+	// DisableSyntaxLowering turns off esbuild's MinifySyntax pass (Engine
+	// EngineEsbuild only). This exists specifically because of
+	// https://github.com/asnowfix/home-automation/issues/266: with
+	// MinifySyntax ON (the default here, matching esbuild's normal
+	// "aggressive minification" behavior), esbuild collapses sequential
+	// `x += f(...)` statements into a single comma-expression inside a
+	// `return`, EXACTLY like tdewolff does today -- confirmed by direct
+	// comparison against prometheus-metrics.js's `_buildSwitchMetrics`,
+	// which is the function issue #266 identified as crashing real
+	// hardware with "Too much recursion" (Espruino's C expression
+	// evaluator is recursive; a long comma chain overflows its stack).
+	// Setting this to true keeps each statement separate (semicolon, not
+	// comma), which a structural comparison shows avoids that pattern
+	// (verified via static analysis of the emitted code only -- NOT
+	// verified on real hardware; do not treat this as a fix for #266
+	// until it's been run on a device). Costs a small amount of size
+	// (~180 bytes larger on prometheus-metrics.js in testing) relative to
+	// leaving MinifySyntax on, but was still smaller than tdewolff's
+	// current output. Off by default so today's byte-savings numbers
+	// don't silently regress.
+	DisableSyntaxLowering bool
+}
+
+// MinifyResult is the output of MinifyWithOptions.
+type MinifyResult struct {
+	// Code is the minified script, ready to upload.
+	Code []byte
+
+	// SourceMap is the Source Map v3 JSON esbuild produced, or nil when the
+	// engine/options combination didn't generate one (EngineTdewolff, or
+	// EngineEsbuild without MangleTopLevel -- there is nothing to map when
+	// no top-level renaming happened).
+	SourceMap []byte
+
+	// Symbols is the flat mangled->original table for top-level symbols,
+	// derived from SourceMap. nil under the same conditions as SourceMap.
+	// See SymbolMap for why this exists alongside (not instead of) the
+	// source map: Shelly crash traces carry function names and code
+	// snippets but no line/column, so a source map alone cannot resolve
+	// them -- this flat table can.
+	Symbols *SymbolMap
+}
+
+// MinifyWithOptions minifies src according to opts. name is used only for
+// error messages and to label the resulting SymbolMap; pass the script's
+// filename (e.g. "pool-pump.js").
+func MinifyWithOptions(name string, src []byte, opts MinifyOptions) (*MinifyResult, error) {
+	switch opts.Engine {
+	case "", EngineTdewolff:
+		out, err := minifyJS(src)
+		if err != nil {
+			return nil, err
+		}
+		return &MinifyResult{Code: out}, nil
+	case EngineEsbuild:
+		return minifyEsbuild(name, src, opts)
+	default:
+		return nil, fmt.Errorf("minify %s: unknown minifier engine %q", name, opts.Engine)
+	}
+}
+
+func minifyEsbuild(name string, src []byte, opts MinifyOptions) (*MinifyResult, error) {
+	if !opts.MangleTopLevel {
+		result := api.Transform(string(src), api.TransformOptions{
+			Target:            api.ES5,
+			MinifyWhitespace:  true,
+			MinifyIdentifiers: true,
+			MinifySyntax:      !opts.DisableSyntaxLowering,
+		})
+		if err := esbuildErr(name, result.Errors); err != nil {
+			return nil, err
+		}
+		return &MinifyResult{Code: result.Code}, nil
+	}
+
+	topLevel := topLevelDeclarations(src)
+	known := make(map[string]bool, len(topLevel))
+	for _, n := range topLevel {
+		known[n] = true
+	}
+
+	exportNames := make([]string, 0, len(opts.PreserveGlobals)+len(opts.DebugExports))
+	seenExport := make(map[string]bool, cap(exportNames))
+	addExports := func(list []string, kind string) error {
+		for _, n := range list {
+			if !known[n] {
+				return fmt.Errorf("minify %s: %s %q is not a top-level declaration in the script", name, kind, n)
+			}
+			if !seenExport[n] {
+				seenExport[n] = true
+				exportNames = append(exportNames, n)
+			}
+		}
+		return nil
+	}
+	if err := addExports(opts.PreserveGlobals, "preserve-global"); err != nil {
+		return nil, err
+	}
+	if err := addExports(opts.DebugExports, "debug-export"); err != nil {
+		return nil, err
+	}
+
+	wrapped := wrapIIFE(src, exportNames)
+
+	result := api.Transform(wrapped, api.TransformOptions{
+		Target:            api.ES5,
+		MinifyWhitespace:  true,
+		MinifyIdentifiers: true,
+		MinifySyntax:      !opts.DisableSyntaxLowering,
+		Sourcemap:         api.SourceMapExternal,
+		SourcesContent:    api.SourcesContentInclude,
+	})
+	if err := esbuildErr(name, result.Errors); err != nil {
+		return nil, err
+	}
+
+	symbols, err := buildSymbolMap(name, opts.Engine, topLevel, result.Code, result.Map)
+	if err != nil {
+		return nil, fmt.Errorf("minify %s: build symbol map: %w", name, err)
+	}
+
+	return &MinifyResult{
+		Code:      result.Code,
+		SourceMap: result.Map,
+		Symbols:   symbols,
+	}, nil
+}
+
+func esbuildErr(name string, msgs []api.Message) error {
+	if len(msgs) == 0 {
+		return nil
+	}
+	parts := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		parts = append(parts, m.Text)
+	}
+	return fmt.Errorf("esbuild minify %s: %s", name, strings.Join(parts, "; "))
+}
+
+// exportsVar is the name of the synthetic top-level variable that holds the
+// wrapped IIFE's return value. It is deliberately verbose/unlikely to
+// collide with anything in the wrapped script or with other scripts running
+// on the same device (top-level names are never mangled -- see
+// wrapIIFE for why).
+const exportsVar = "__myhome_minify_exports__"
+
+// wrapIIFE wraps src in an IIFE so esbuild's identifier mangler treats the
+// script's top-level declarations as an ordinary (renameable) function
+// scope instead of the page/module's global scope, then re-exports
+// exportNames as real top-level globals under their ORIGINAL names.
+//
+// This works because of how esbuild's non-bundled Transform treats
+// identifier scope: top-level (true script-level) declarations are never
+// renamed (other code could reference them by name), but declarations
+// nested inside a function body are an ordinary scope and are freely
+// renamed. By moving the whole script inside a closure, its own top-level
+// symbols become "nested" and thus mangle-eligible; the explicit re-export
+// assignments below are themselves at the SCRIPT's true top level, so their
+// left-hand identifiers are, in turn, never renamed -- giving external code
+// (Shelly Schedule jobs evaluating "handleMorningStart()", or a developer
+// using Script.Eval) a stable, literal name to call into the mangled
+// internals through.
+//
+// The re-export must go through the returned object rather than a bare
+// `name = name;` statement: inside the closure, `name` resolves to the
+// local (about-to-be-renamed) declaration on BOTH sides of that assignment,
+// so it would just reassign the local binding to itself and export nothing.
+func wrapIIFE(src []byte, exportNames []string) string {
+	var b strings.Builder
+	b.WriteString("var ")
+	b.WriteString(exportsVar)
+	b.WriteString("=(function(){\n")
+	b.Write(src)
+	b.WriteString("\nreturn {")
+	for i, n := range exportNames {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(strconv.Quote(n))
+		b.WriteString(":")
+		b.WriteString(n)
+	}
+	b.WriteString("};\n})();\n")
+	for _, n := range exportNames {
+		b.WriteString(n)
+		b.WriteString("=")
+		b.WriteString(exportsVar)
+		b.WriteString(".")
+		b.WriteString(n)
+		b.WriteString(";\n")
+	}
+	return b.String()
+}
+
+// sourceMapV3 is the subset of the Source Map v3 JSON format
+// (https://sourcemaps.info/spec.html) that buildSymbolMap needs.
+type sourceMapV3 struct {
+	Version int      `json:"version"`
+	Sources []string `json:"sources"`
+	Names   []string `json:"names"`
+	Mappings string  `json:"mappings"`
+}
+
+// buildSymbolMap derives the flat top-level mangled->original table by
+// decoding the source map's VLQ "mappings" and, for every mapping that
+// carries a "names" entry matching a KNOWN top-level declaration, reading
+// the actual mangled identifier text out of the generated code at that
+// position. Restricting to knownTopLevel is what makes the result
+// unambiguous: esbuild gives top-level (module-scope) symbols a single flat
+// scope, so each one gets a unique mangled name across the whole file --
+// but nested (function-local) symbols can and do reuse short mangled names
+// across different scopes, so including them here would make the table
+// lossy/wrong. See docs on MinifyOptions.DebugExports for the related,
+// narrower re-export mechanism.
+func buildSymbolMap(name string, engine Engine, topLevelNames []string, code []byte, rawMap []byte) (*SymbolMap, error) {
+	var sm sourceMapV3
+	if err := json.Unmarshal(rawMap, &sm); err != nil {
+		return nil, fmt.Errorf("parse source map: %w", err)
+	}
+
+	known := make(map[string]bool, len(topLevelNames))
+	for _, n := range topLevelNames {
+		known[n] = true
+	}
+
+	lines := strings.Split(string(code), "\n")
+
+	segs, err := decodeMappings(sm.Mappings)
+	if err != nil {
+		return nil, fmt.Errorf("decode mappings: %w", err)
+	}
+
+	symbols := make(map[string]string)
+	for _, seg := range segs {
+		if seg.nameIdx < 0 || seg.nameIdx >= len(sm.Names) {
+			continue
+		}
+		orig := sm.Names[seg.nameIdx]
+		if !known[orig] {
+			continue
+		}
+		if seg.genLine < 0 || seg.genLine >= len(lines) {
+			continue
+		}
+		line := lines[seg.genLine]
+		mangled := identifierAt(line, seg.genCol)
+		if mangled == "" {
+			continue
+		}
+		if existing, ok := symbols[mangled]; ok && existing != orig {
+			// A mangled token mapped to two different "top-level" original
+			// names should not happen (top-level symbols get a unique
+			// mangled name each) -- if it does, don't guess; drop the
+			// ambiguous entry rather than risk a wrong demangle.
+			delete(symbols, mangled)
+			continue
+		}
+		symbols[mangled] = orig
+	}
+
+	return &SymbolMap{Script: name, Engine: engine, Symbols: symbols}, nil
+}
+
+func identifierAt(line string, col int) string {
+	if col < 0 || col >= len(line) || !isIdentPart(line[col]) {
+		return ""
+	}
+	end := col
+	for end < len(line) && isIdentPart(line[end]) {
+		end++
+	}
+	return line[col:end]
+}
+
+func isIdentStart(b byte) bool {
+	return b == '_' || b == '$' || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isIdentPart(b byte) bool {
+	return isIdentStart(b) || (b >= '0' && b <= '9')
+}

--- a/pkg/shelly/script/minify_esbuild_goja_test.go
+++ b/pkg/shelly/script/minify_esbuild_goja_test.go
@@ -1,0 +1,62 @@
+package script
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/testr"
+)
+
+// TestEsbuildOutput_RunsInGojaHarness verifies the goja emulator harness
+// (Run/RunWithDeviceState) accepts and executes a script minified by the
+// new esbuild path -- both without and with top-level mangling -- just as
+// it already does for tdewolff output (see
+// internal/shelly/scripts.TestSmokeAllScripts). Reaching the timeout is the
+// healthy outcome: it means the script initialised without a JS-level
+// exception and was left running/waiting.
+func TestEsbuildOutput_RunsInGojaHarness(t *testing.T) {
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	cases := []struct {
+		name string
+		opts MinifyOptions
+	}{
+		{"no top-level mangling", MinifyOptions{Engine: EngineEsbuild}},
+		{"top-level mangling", MinifyOptions{
+			Engine:          EngineEsbuild,
+			MangleTopLevel:  true,
+			PreserveGlobals: []string{"handleMorningStart", "handleEveningStop"},
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), tc.opts)
+			if err != nil {
+				t.Fatalf("MinifyWithOptions: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(
+				logr.NewContext(context.Background(), testr.New(t)),
+				2*time.Second,
+			)
+			defer cancel()
+
+			deviceState := &DeviceState{
+				KVS:     make(map[string]interface{}),
+				Storage: make(map[string]interface{}),
+			}
+			runErr := RunWithDeviceState(ctx, "test.js", res.Code, false, deviceState)
+			if runErr != nil && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, context.DeadlineExceeded) {
+				t.Fatalf("script failed to run under goja: %v\ncode:\n%s", runErr, res.Code)
+			}
+		})
+	}
+}

--- a/pkg/shelly/script/minify_esbuild_test.go
+++ b/pkg/shelly/script/minify_esbuild_test.go
@@ -1,0 +1,256 @@
+package script
+
+import (
+	"strings"
+	"testing"
+)
+
+const esbuildTestScript = `
+var CONFIG = {};
+var STATE = { count: 0 };
+
+function log(msg) {
+  print(msg);
+}
+
+function handleMorningStart() {
+  STATE.count = STATE.count + 1;
+  log("morning start, count=" + STATE.count);
+}
+
+function handleEveningStop() {
+  STATE.count = 0;
+  log("evening stop");
+}
+
+function internalHelper() {
+  return STATE.count * 2;
+}
+
+handleMorningStart();
+`
+
+func assertES5(t *testing.T, code []byte) {
+	t.Helper()
+	if found := FindES6Syntax(code); len(found) > 0 {
+		t.Errorf("minified output contains ES6-only marker(s) %v:\n%s", found, code)
+	}
+}
+
+// commaCollapseTestScript mirrors the shape of prometheus-metrics.js's
+// _buildSwitchMetrics (see internal/shelly/scripts/prometheus-metrics.js),
+// the function identified in issue #266 as crashing a real Shelly device
+// with "Too much recursion": a run of sequential `result += f(...)`
+// statements. tdewolff's minifier collapses these into a single
+// comma-expression inside the `return`, and (confirmed by direct
+// comparison during this change) esbuild's MinifySyntax pass does exactly
+// the same thing by default -- MinifyOptions.DisableSyntaxLowering exists
+// to opt out of that specific behavior.
+const commaCollapseTestScript = `
+function buildMetrics(sw) {
+  var result = "";
+  result += metric("a", sw);
+  result += metric("b", sw);
+  result += metric("c", sw);
+  result += metric("d", sw);
+  result += metric("e", sw);
+  result += metric("f", sw);
+  return result;
+}
+function metric(name, sw) {
+  return name + ":" + sw;
+}
+`
+
+// TestMinifyWithOptions_EsbuildCollapsesSequentialStatementsByDefault
+// documents that esbuild's default behavior (MinifySyntax on, same as
+// MinifyWithOptions' EngineEsbuild default) reproduces the exact
+// comma-expression-in-return pattern from issue #266 -- i.e. esbuild does
+// NOT sidestep that bug by default. See DisableSyntaxLowering for the
+// opt-out (unverified on real hardware).
+func TestMinifyWithOptions_EsbuildCollapsesSequentialStatementsByDefault(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(commaCollapseTestScript), MinifyOptions{
+		Engine: EngineEsbuild,
+	})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	code := string(res.Code)
+	// The six `result += metric(...)` statements collapse into one
+	// comma-expression: "return a+=...,a+=...,...,a" -- i.e. the `return`
+	// keyword is followed by an expression containing at least 5 top-level
+	// commas before the closing `}` of the function, with NO `;` in
+	// between (statements got joined, not just whitespace-compacted).
+	if !strings.Contains(code, "return") {
+		t.Fatalf("expected output to contain a return statement, got:\n%s", code)
+	}
+	returnIdx := strings.Index(code, "return")
+	closeBraceIdx := strings.Index(code[returnIdx:], "}")
+	if closeBraceIdx < 0 {
+		t.Fatalf("could not find end of the return statement in:\n%s", code)
+	}
+	returnStmt := code[returnIdx : returnIdx+closeBraceIdx]
+	if strings.Contains(returnStmt, ";") {
+		t.Fatalf("expected statements to be collapsed into the return (no ';' inside it) by default, got: %q", returnStmt)
+	}
+	if commas := strings.Count(returnStmt, ","); commas < 5 {
+		t.Fatalf("expected at least 5 top-level commas in the collapsed return statement, got %d: %q", commas, returnStmt)
+	}
+}
+
+// TestMinifyWithOptions_DisableSyntaxLoweringKeepsStatementsSeparate is the
+// counterpart to the test above: with DisableSyntaxLowering set, the same
+// six statements must stay separate (terminated by ';', not folded into a
+// comma-expression) -- avoiding the structural pattern issue #266
+// identified, though this is a static-analysis result only, not a
+// hardware-verified fix.
+func TestMinifyWithOptions_DisableSyntaxLoweringKeepsStatementsSeparate(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(commaCollapseTestScript), MinifyOptions{
+		Engine:                EngineEsbuild,
+		DisableSyntaxLowering: true,
+	})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	assertES5(t, res.Code)
+	code := string(res.Code)
+	returnIdx := strings.Index(code, "return")
+	if returnIdx < 0 {
+		t.Fatalf("expected output to contain a return statement, got:\n%s", code)
+	}
+	// With syntax lowering disabled, the statement immediately preceding
+	// "return" must be semicolon-terminated (statements kept separate),
+	// not comma-joined into the return expression.
+	before := strings.TrimRight(code[:returnIdx], " \t\n")
+	if !strings.HasSuffix(before, ";") && !strings.HasSuffix(before, "{") {
+		t.Fatalf("expected the statement before 'return' to end with ';' (kept separate), got tail: %q", before[max(0, len(before)-20):])
+	}
+}
+
+func TestMinifyWithOptions_TdewolffDefault(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), MinifyOptions{})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	if len(res.Code) == 0 {
+		t.Fatal("expected non-empty minified code")
+	}
+	if res.Symbols != nil {
+		t.Fatalf("tdewolff engine should never produce a symbol map, got %v", res.Symbols)
+	}
+	// tdewolff never mangles top-level names -- they must all survive verbatim.
+	for _, name := range []string{"CONFIG", "STATE", "handleMorningStart", "handleEveningStop"} {
+		if !strings.Contains(string(res.Code), name) {
+			t.Errorf("expected top-level name %q to survive tdewolff minification, output:\n%s", name, res.Code)
+		}
+	}
+}
+
+func TestMinifyWithOptions_EsbuildNoTopLevelMangling(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), MinifyOptions{
+		Engine: EngineEsbuild,
+	})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	assertES5(t, res.Code)
+	if res.Symbols != nil {
+		t.Fatalf("esbuild without MangleTopLevel should not produce a symbol map, got %v", res.Symbols)
+	}
+	for _, name := range []string{"CONFIG", "STATE", "handleMorningStart", "handleEveningStop"} {
+		if !strings.Contains(string(res.Code), name) {
+			t.Errorf("expected top-level name %q to survive un-mangled esbuild minification, output:\n%s", name, res.Code)
+		}
+	}
+}
+
+func TestMinifyWithOptions_EsbuildTopLevelMangling(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), MinifyOptions{
+		Engine:          EngineEsbuild,
+		MangleTopLevel:  true,
+		PreserveGlobals: []string{"handleMorningStart", "handleEveningStop"},
+	})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	assertES5(t, res.Code)
+
+	code := string(res.Code)
+
+	// Preserved names must remain reachable as literal top-level tokens.
+	for _, name := range []string{"handleMorningStart", "handleEveningStop"} {
+		if !strings.Contains(code, name) {
+			t.Errorf("expected preserved global %q to remain reachable, output:\n%s", name, code)
+		}
+	}
+
+	// internalHelper was never preserved or debug-exported, and is
+	// referenced nowhere outside the closure -- it should have been
+	// renamed away (i.e. its literal name should no longer appear).
+	if strings.Contains(code, "internalHelper") {
+		t.Errorf("expected non-preserved top-level name %q to be mangled away, output:\n%s", "internalHelper", code)
+	}
+
+	if res.SourceMap == nil {
+		t.Fatal("expected a source map when MangleTopLevel is set")
+	}
+	if res.Symbols == nil || len(res.Symbols.Symbols) == 0 {
+		t.Fatal("expected a non-empty symbol map when MangleTopLevel is set")
+	}
+
+	// internalHelper must appear as an ORIGINAL name somewhere in the
+	// symbol map (i.e. we can recover it even though it's not preserved).
+	found := false
+	for _, orig := range res.Symbols.Symbols {
+		if orig == "internalHelper" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected symbol map to contain an entry for internalHelper, got %v", res.Symbols.Symbols)
+	}
+}
+
+func TestMinifyWithOptions_UnknownPreserveGlobalErrors(t *testing.T) {
+	_, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), MinifyOptions{
+		Engine:          EngineEsbuild,
+		MangleTopLevel:  true,
+		PreserveGlobals: []string{"doesNotExist"},
+	})
+	if err == nil {
+		t.Fatal("expected an error for a PreserveGlobals name that isn't a top-level declaration")
+	}
+}
+
+func TestMinifyWithOptions_DebugExports(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), MinifyOptions{
+		Engine:         EngineEsbuild,
+		MangleTopLevel: true,
+		DebugExports:   []string{"STATE", "CONFIG"},
+	})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	code := string(res.Code)
+	for _, name := range []string{"STATE", "CONFIG"} {
+		if !strings.Contains(code, name) {
+			t.Errorf("expected debug-exported name %q to remain reachable, output:\n%s", name, code)
+		}
+	}
+}
+
+// TestMinifyOptions_ZeroValueIsTdewolff documents the "Default OFF"
+// safety property the whole minifier-selection design leans on: a
+// MinifyOptions{} zero value (e.g. an uninitialized struct field, or a
+// config option nobody set) must minify exactly like today's tdewolff
+// path, not silently pick esbuild or top-level mangling.
+func TestMinifyOptions_ZeroValueIsTdewolff(t *testing.T) {
+	res, err := MinifyWithOptions("test.js", []byte(esbuildTestScript), MinifyOptions{})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	if res.Symbols != nil || res.SourceMap != nil {
+		t.Fatalf("zero-value MinifyOptions must never produce a symbol map or source map, got Symbols=%v SourceMap=%v", res.Symbols, res.SourceMap)
+	}
+}

--- a/pkg/shelly/script/minify_esbuild_test.go
+++ b/pkg/shelly/script/minify_esbuild_test.go
@@ -1,8 +1,10 @@
 package script
 
 import (
+	"regexp"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 const esbuildTestScript = `
@@ -252,5 +254,53 @@ func TestMinifyOptions_ZeroValueIsTdewolff(t *testing.T) {
 	}
 	if res.Symbols != nil || res.SourceMap != nil {
 		t.Fatalf("zero-value MinifyOptions must never produce a symbol map or source map, got Symbols=%v SourceMap=%v", res.Symbols, res.SourceMap)
+	}
+}
+
+// TestMinifyWithOptions_EsbuildEmitsRawUTF8NotEscapes is a regression test for a
+// bug found only on real hardware: esbuild defaults to ASCII output and escapes
+// non-ASCII characters as \uXXXX, but Espruino rejects those outright with
+//
+//	Uncaught SyntaxError: \uXXXX literals are disallowed
+//
+// pool-pump.js contains a "✓" (U+2713) and several em dashes (U+2014) in log
+// strings, so the whole script failed to parse on a Shelly Plus 1 — while goja
+// and the rest of the test suite stayed green, because goja accepts \uXXXX
+// happily. Fixed by setting Charset: api.CharsetUTF8 on both api.Transform call
+// sites. This affects esbuild output with AND without top-level mangling, so
+// both paths are asserted here.
+func TestMinifyWithOptions_EsbuildEmitsRawUTF8NotEscapes(t *testing.T) {
+	src := []byte(`
+var CONFIG_SCHEMA = { tick: { description: "x", key: "tick", default: 1, type: "number" } };
+function handleTick() { print("✓ done — really"); }
+handleTick();
+`)
+
+	escape := regexp.MustCompile(`\\u[0-9a-fA-F]{4}`)
+
+	for _, tc := range []struct {
+		name   string
+		mangle bool
+	}{
+		{"no mangling", false},
+		{"top-level mangling", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := MinifyOptions{Engine: EngineEsbuild, MangleTopLevel: tc.mangle}
+			if tc.mangle {
+				opts.PreserveGlobals = []string{"handleTick"}
+			}
+			res, err := MinifyWithOptions("charset-test.js", src, opts)
+			if err != nil {
+				t.Fatalf("MinifyWithOptions: %v", err)
+			}
+			if got := escape.FindAllString(string(res.Code), -1); len(got) > 0 {
+				t.Errorf("esbuild emitted %d \\uXXXX escape(s) %v; Espruino rejects these "+
+					"(\"\\uXXXX literals are disallowed\") and the script will not parse on device", len(got), got)
+			}
+			if !utf8.Valid(res.Code) {
+				t.Error("minified output is not valid UTF-8")
+			}
+		})
 	}
 }

--- a/pkg/shelly/script/minify_esbuild_test.go
+++ b/pkg/shelly/script/minify_esbuild_test.go
@@ -304,3 +304,61 @@ handleTick();
 		})
 	}
 }
+
+// TestUtf16ColumnToByteOffset is a regression test for a symbol-map decoding
+// bug exposed by the Charset: api.CharsetUTF8 fix.
+//
+// Source Map v3 columns count UTF-16 code units; Go strings index bytes. The
+// two coincide only while the generated output is pure ASCII, which esbuild's
+// default ASCII charset made true by accident. Once raw UTF-8 is emitted (as
+// it must be, since Espruino rejects \uXXXX literals) every multi-byte
+// character shifts byte offsets relative to columns, and indexing a line by a
+// column silently slices identifiers at the wrong place — "handleMorningStart"
+// decoded as "andleMorningStart". That corrupted the symbol map with bogus
+// entries (98 real symbols were reported as 184) and would have produced wrong
+// demangling of crash traces.
+func TestUtf16ColumnToByteOffset(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		line string
+		col  int
+		want int
+	}{
+		{"pure ascii is identity", "var abc=1;", 4, 4},
+		{"zero column", "✓var abc=1;", 0, 0},
+		// "✓" is 3 bytes but ONE UTF-16 unit, so column 1 is byte 3.
+		{"after a 3-byte rune", "✓var abc=1;", 1, 3},
+		{"identifier after a 3-byte rune", "✓var abc=1;", 5, 7},
+		// "—" (U+2014) is also 3 bytes / 1 unit; two of them shift by 4.
+		{"after two 3-byte runes", "—x—var abc=1;", 3, 7},
+		{"column at end of line", "abc", 3, 3},
+		{"column past end of line", "abc", 9, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := utf16ColumnToByteOffset(tc.line, tc.col); got != tc.want {
+				t.Errorf("utf16ColumnToByteOffset(%q, %d) = %d, want %d", tc.line, tc.col, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIdentifierAt_AfterMultiByteRune asserts the decoder recovers a whole
+// identifier when a multi-byte character precedes it on the same line — the
+// exact shape of the "andleMorningStart" truncation.
+func TestIdentifierAt_AfterMultiByteRune(t *testing.T) {
+	line := `print("✓ ok");function handleMorningStart(){}`
+	col := 0
+	for i, r := range line {
+		if i > 0 && line[i:] != "" && len(line[i:]) >= len("handleMorningStart") && line[i:i+len("handleMorningStart")] == "handleMorningStart" {
+			break
+		}
+		if r > 0xFFFF {
+			col += 2
+		} else {
+			col++
+		}
+	}
+	if got := identifierAt(line, col); got != "handleMorningStart" {
+		t.Errorf("identifierAt = %q, want %q (byte-vs-UTF-16 column confusion)", got, "handleMorningStart")
+	}
+}

--- a/pkg/shelly/script/symbolmap.go
+++ b/pkg/shelly/script/symbolmap.go
@@ -1,0 +1,257 @@
+package script
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// SymbolMap is a flat mangled -> original name table for a script's
+// top-level symbols, persisted alongside the minified script.
+//
+// It exists BECAUSE a Source Map v3 alone does not solve the actual
+// problem: Shelly crash traces give function names and code snippets with
+// no line/column information at all, e.g.
+//
+//	in function "storeValue" called from storeValue("turnover-today",computeTurnoverToday(t))
+//
+// Source maps resolve generated (line, column) -> original (line, column);
+// we don't have a (line, column) to look up, only bare identifier text. So
+// SymbolMap instead gives a direct string substitution table: every
+// top-level identifier that MangleTopLevel could have renamed, mapped back
+// to its original name. Demangle uses it to turn a crash message with
+// mangled names back into one a human can read.
+//
+// Limitations (see Demangle):
+//   - Only TOP-LEVEL symbols are covered. Local/nested identifiers are
+//     deliberately excluded because their mangled names are reused across
+//     different scopes (not unique), so a flat table for them would be
+//     wrong, not just incomplete.
+//   - It is a textual, word-boundary substitution over the whole message,
+//     not a real parser -- a mangled name that happens to appear inside a
+//     JSON string value in the crash message (e.g. a KVS key literally
+//     equal to a mangled identifier) would also get rewritten. Accepted
+//     trade-off for a diagnostic tool.
+type SymbolMap struct {
+	// Script is the originating script's filename, e.g. "pool-pump.js".
+	Script string `json:"script"`
+	// Engine that produced this map (always EngineEsbuild today).
+	Engine Engine `json:"engine"`
+	// Symbols maps mangled identifier -> original identifier.
+	Symbols map[string]string `json:"symbols"`
+}
+
+// WriteSymbolMap persists m as indented JSON at path, creating parent
+// directories as needed.
+func WriteSymbolMap(path string, m *SymbolMap) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create symbol map directory: %w", err)
+	}
+	buf, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal symbol map: %w", err)
+	}
+	buf = append(buf, '\n')
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return fmt.Errorf("write symbol map %s: %w", path, err)
+	}
+	return nil
+}
+
+// ReadSymbolMap loads a SymbolMap previously written by WriteSymbolMap.
+func ReadSymbolMap(path string) (*SymbolMap, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read symbol map %s: %w", path, err)
+	}
+	var m SymbolMap
+	if err := json.Unmarshal(buf, &m); err != nil {
+		return nil, fmt.Errorf("parse symbol map %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// Demangle rewrites every whole-identifier occurrence of a mangled name in
+// msg with its original name, using m's table. Longer mangled names are
+// substituted first so that (in the rare case one mangled name is a prefix
+// of another -- it isn't for esbuild's single-char-then-two-char scheme,
+// but this is defensive) a shorter name doesn't shadow a longer match
+// first. Matching requires an identifier boundary on both sides (so "a"
+// only matches a standalone "a" token, never the "a" inside "abc" or
+// "_a1"). A nil receiver or an empty table is a safe no-op that returns msg
+// unchanged.
+func (m *SymbolMap) Demangle(msg string) string {
+	if m == nil || len(m.Symbols) == 0 {
+		return msg
+	}
+
+	keys := make([]string, 0, len(m.Symbols))
+	for k := range m.Symbols {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return len(keys[i]) > len(keys[j]) })
+
+	out := make([]byte, 0, len(msg))
+	i := 0
+	for i < len(msg) {
+		if isIdentStart(msg[i]) && (i == 0 || !isIdentPart(msg[i-1])) {
+			matched := false
+			for _, k := range keys {
+				if len(k) == 0 || i+len(k) > len(msg) {
+					continue
+				}
+				if msg[i:i+len(k)] != k {
+					continue
+				}
+				end := i + len(k)
+				if end < len(msg) && isIdentPart(msg[end]) {
+					continue // not a whole-identifier match
+				}
+				out = append(out, m.Symbols[k]...)
+				i = end
+				matched = true
+				break
+			}
+			if matched {
+				continue
+			}
+		}
+		out = append(out, msg[i])
+		i++
+	}
+	return string(out)
+}
+
+// mapping is one decoded segment of a Source Map v3 "mappings" field,
+// keeping only what buildSymbolMap needs: the generated position and
+// (optionally) an index into the map's "names" array.
+type mapping struct {
+	genLine int
+	genCol  int
+	nameIdx int // -1 if this segment carries no name
+}
+
+// vlqBase64Alphabet is the standard Base64 alphabet used by the Source Map
+// v3 "Base64 VLQ" encoding (https://sourcemaps.info/spec.html and the
+// original vlq.js this format was borrowed from). It is NOT the same thing
+// as ordinary base64 encoding of bytes -- each character encodes a 5-bit
+// group of a variable-length, zig-zag-signed integer, with the 6th bit as a
+// continuation flag.
+const vlqBase64Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+var vlqDecodeTable = func() [256]int8 {
+	var t [256]int8
+	for i := range t {
+		t[i] = -1
+	}
+	for i, c := range vlqBase64Alphabet {
+		t[byte(c)] = int8(i)
+	}
+	return t
+}()
+
+// decodeMappings decodes a Source Map v3 "mappings" field into a flat list
+// of segments. Only the generated line/column and name index are tracked
+// (source index/line/column deltas are consumed to keep the decoder state
+// machine correct, per spec, but discarded -- buildSymbolMap doesn't need
+// them: it already knows which ORIGINAL names it cares about from
+// topLevelDeclarations, not from the source map's own line/column
+// information).
+func decodeMappings(mappings string) ([]mapping, error) {
+	var segs []mapping
+
+	genLine, genCol := 0, 0
+	srcIdx, srcLine, srcCol, nameIdx := 0, 0, 0, 0
+
+	i := 0
+	n := len(mappings)
+
+	readVLQ := func() (int, error) {
+		val := 0
+		shift := uint(0)
+		for {
+			if i >= n {
+				return 0, fmt.Errorf("truncated VLQ at offset %d", i)
+			}
+			c := mappings[i]
+			i++
+			d := vlqDecodeTable[c]
+			if d < 0 {
+				return 0, fmt.Errorf("invalid base64-vlq byte %q at offset %d", c, i-1)
+			}
+			cont := d & 0x20
+			digit := int(d & 0x1f)
+			val += digit << shift
+			shift += 5
+			if cont == 0 {
+				break
+			}
+		}
+		if val&1 != 0 {
+			return -(val >> 1), nil
+		}
+		return val >> 1, nil
+	}
+
+	for i < n {
+		switch mappings[i] {
+		case ';':
+			genLine++
+			genCol = 0
+			i++
+			continue
+		case ',':
+			i++
+			continue
+		}
+
+		dCol, err := readVLQ()
+		if err != nil {
+			return nil, err
+		}
+		genCol += dCol
+
+		seg := mapping{genLine: genLine, genCol: genCol, nameIdx: -1}
+
+		if i >= n || mappings[i] == ',' || mappings[i] == ';' {
+			// Generated-code-only segment (no source mapping). Valid but
+			// irrelevant to us since it can't carry a name.
+			segs = append(segs, seg)
+			continue
+		}
+
+		dSrc, err := readVLQ()
+		if err != nil {
+			return nil, err
+		}
+		srcIdx += dSrc
+
+		dSrcLine, err := readVLQ()
+		if err != nil {
+			return nil, err
+		}
+		srcLine += dSrcLine
+
+		dSrcCol, err := readVLQ()
+		if err != nil {
+			return nil, err
+		}
+		srcCol += dSrcCol
+		_ = srcIdx // consumed for decoder-state correctness only
+
+		if i < n && mappings[i] != ',' && mappings[i] != ';' {
+			dName, err := readVLQ()
+			if err != nil {
+				return nil, err
+			}
+			nameIdx += dName
+			seg.nameIdx = nameIdx
+		}
+
+		segs = append(segs, seg)
+	}
+
+	return segs, nil
+}

--- a/pkg/shelly/script/symbolmap_test.go
+++ b/pkg/shelly/script/symbolmap_test.go
@@ -1,0 +1,148 @@
+package script
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSymbolMap_MangleDemangleRoundTrip mangles a synthetic script with
+// top-level mangling enabled, builds a synthetic Shelly-style crash message
+// using the MANGLED names (the way a real device would report it), and
+// verifies Demangle recovers the original names -- including a message
+// shaped like a real Shelly error, which gives no line/column, only
+// function names and a code snippet (see the SymbolMap doc comment for why
+// that's the whole reason this table exists).
+func TestSymbolMap_MangleDemangleRoundTrip(t *testing.T) {
+	res, err := MinifyWithOptions("pool-pump.js", []byte(esbuildTestScript), MinifyOptions{
+		Engine:          EngineEsbuild,
+		MangleTopLevel:  true,
+		PreserveGlobals: []string{"handleMorningStart", "handleEveningStop"},
+	})
+	if err != nil {
+		t.Fatalf("MinifyWithOptions: %v", err)
+	}
+	if res.Symbols == nil {
+		t.Fatal("expected a symbol map")
+	}
+
+	// Find the mangled name for "internalHelper" and "STATE" via the map's
+	// reverse direction (original -> mangled), the way a developer working
+	// backward from the source would.
+	mangledOf := func(orig string) string {
+		for m, o := range res.Symbols.Symbols {
+			if o == orig {
+				return m
+			}
+		}
+		t.Fatalf("no mangled name found for original %q in %v", orig, res.Symbols.Symbols)
+		return ""
+	}
+	mangledHelper := mangledOf("internalHelper")
+	mangledState := mangledOf("STATE")
+
+	// Shape a synthetic crash message the way Shelly actually reports
+	// errors: function name + a code snippet, no line/column at all. See
+	// https://github.com/asnowfix/home-automation/issues/266 for a real
+	// example of this exact shape.
+	crash := `Uncaught Error: Too much recursion
+ in function "` + mangledHelper + `" called from ` + mangledHelper + `(` + mangledState + `.count)`
+
+	demangled := res.Symbols.Demangle(crash)
+
+	if !strings.Contains(demangled, "internalHelper") {
+		t.Errorf("expected demangled message to contain original name %q, got: %s", "internalHelper", demangled)
+	}
+	if !strings.Contains(demangled, "STATE") {
+		t.Errorf("expected demangled message to contain original name %q, got: %s", "STATE", demangled)
+	}
+	if strings.Contains(demangled, mangledHelper+"(") {
+		// Loose check: the mangled call-site token shouldn't survive.
+		t.Errorf("expected mangled name %q to be replaced, got: %s", mangledHelper, demangled)
+	}
+}
+
+func TestSymbolMap_DemangleRequiresWholeIdentifierMatch(t *testing.T) {
+	m := &SymbolMap{
+		Script: "test.js",
+		Engine: EngineEsbuild,
+		Symbols: map[string]string{
+			"a": "STATE",
+		},
+	}
+	// "a" must NOT match inside "abc", "a1", or "_a1" -- but a standalone
+	// "a" token, wherever it appears (including as a lone function
+	// argument), is a legitimate whole-identifier match.
+	in := `catch(a){} abc a1 _a1 (a) a.b a,b`
+	out := m.Demangle(in)
+	want := `catch(STATE){} abc a1 _a1 (STATE) STATE.b STATE,b`
+	if out != want {
+		t.Fatalf("Demangle() = %q, want %q", out, want)
+	}
+}
+
+func TestSymbolMap_DemangleNilSafe(t *testing.T) {
+	var m *SymbolMap
+	if got := m.Demangle("hello a b c"); got != "hello a b c" {
+		t.Fatalf("nil SymbolMap.Demangle should be a no-op, got %q", got)
+	}
+
+	empty := &SymbolMap{}
+	if got := empty.Demangle("hello a b c"); got != "hello a b c" {
+		t.Fatalf("empty SymbolMap.Demangle should be a no-op, got %q", got)
+	}
+}
+
+func TestSymbolMap_WriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "pool-pump.symbols.json")
+
+	m := &SymbolMap{
+		Script: "pool-pump.js",
+		Engine: EngineEsbuild,
+		Symbols: map[string]string{
+			"t": "handleMorningStart",
+			"a": "handleEveningStop",
+			"n": "STATE",
+		},
+	}
+
+	if err := WriteSymbolMap(path, m); err != nil {
+		t.Fatalf("WriteSymbolMap: %v", err)
+	}
+
+	got, err := ReadSymbolMap(path)
+	if err != nil {
+		t.Fatalf("ReadSymbolMap: %v", err)
+	}
+	if got.Script != m.Script || got.Engine != m.Engine || len(got.Symbols) != len(m.Symbols) {
+		t.Fatalf("round-tripped SymbolMap = %+v, want %+v", got, m)
+	}
+	for k, v := range m.Symbols {
+		if got.Symbols[k] != v {
+			t.Errorf("Symbols[%q] = %q, want %q", k, got.Symbols[k], v)
+		}
+	}
+}
+
+func TestDecodeMappings_Basic(t *testing.T) {
+	// "AAAA" decodes to a single all-zero segment (genCol=0, srcIdx=0,
+	// srcLine=0, srcCol=0), the standard smoke-test mapping used across
+	// most source-map decoder implementations.
+	segs, err := decodeMappings("AAAA")
+	if err != nil {
+		t.Fatalf("decodeMappings: %v", err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("expected 1 segment, got %d: %+v", len(segs), segs)
+	}
+	if segs[0].genLine != 0 || segs[0].genCol != 0 || segs[0].nameIdx != -1 {
+		t.Fatalf("unexpected segment: %+v", segs[0])
+	}
+}
+
+func TestDecodeMappings_InvalidByte(t *testing.T) {
+	if _, err := decodeMappings("!!!!"); err == nil {
+		t.Fatal("expected an error for invalid base64-vlq input")
+	}
+}

--- a/pkg/shelly/script/toplevel.go
+++ b/pkg/shelly/script/toplevel.go
@@ -1,0 +1,240 @@
+package script
+
+// topLevelDeclarations returns the names of every identifier declared with
+// `function NAME(...)` or `var NAME [= ...]` at the outermost brace depth of
+// src (i.e. not nested inside any function body, block, or object/array
+// literal). This is the "renameable top-level symbol" set referenced by
+// MinifyOptions.PreserveGlobals/DebugExports and by buildSymbolMap.
+//
+// The scan is a small hand-written state machine rather than a regexp:
+// object/array literals like `var CONFIG = {a:1, b:2};` open and close
+// braces WITHIN a single top-level statement, so a naive per-line or
+// per-brace-toggle regexp would misclassify their contents. Tracking one
+// depth counter across the whole file, incremented for every `{ ( [` and
+// decremented for every `} ) ]` (with strings and comments masked out
+// first), correctly returns to 0 by the end of such a statement -- so
+// "depth == 0" at a `function`/`var` keyword reliably means "this is a
+// genuine top-level declaration", including through nested function
+// expressions used as object properties.
+func topLevelDeclarations(src []byte) []string {
+	masked := maskStringsAndComments(src)
+	n := len(masked)
+
+	var names []string
+	seen := make(map[string]bool)
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+
+	wordAt := func(i int) (string, int) {
+		j := i
+		for j < n && isIdentPart(masked[j]) {
+			j++
+		}
+		return string(masked[i:j]), j
+	}
+	precededByIdentChar := func(i int) bool {
+		return i > 0 && isIdentPart(masked[i-1])
+	}
+	skipSpace := func(i int) int {
+		for i < n && isSpaceByte(masked[i]) {
+			i++
+		}
+		return i
+	}
+
+	depth := 0
+	i := 0
+	for i < n {
+		c := masked[i]
+		switch c {
+		case '{', '(', '[':
+			depth++
+			i++
+		case '}', ')', ']':
+			if depth > 0 {
+				depth--
+			}
+			i++
+		default:
+			if !isIdentStart(c) || precededByIdentChar(i) {
+				i++
+				continue
+			}
+			word, next := wordAt(i)
+			if depth != 0 {
+				i = next
+				continue
+			}
+			switch word {
+			case "function":
+				k := skipSpace(next)
+				if k < n && isIdentStart(masked[k]) {
+					name, k2 := wordAt(k)
+					add(name)
+					i = k2
+					continue
+				}
+				i = next
+			case "var":
+				i = scanVarDeclarators(masked, next, add)
+			default:
+				i = next
+			}
+		}
+	}
+	return names
+}
+
+// scanVarDeclarators parses a top-level `var a [= expr], b [= expr], ...;`
+// statement starting right after the `var` keyword at position i, calling
+// add for each declared identifier, and returns the position just past the
+// statement's terminating `;` (or end of input / unmatched brace if the
+// source is malformed -- best-effort, this is a diagnostic tool, not a full
+// parser).
+func scanVarDeclarators(masked []byte, i int, add func(string)) int {
+	n := len(masked)
+	for {
+		for i < n && isSpaceByte(masked[i]) {
+			i++
+		}
+		if i >= n || !isIdentStart(masked[i]) {
+			break
+		}
+		j := i
+		for j < n && isIdentPart(masked[j]) {
+			j++
+		}
+		add(string(masked[i:j]))
+		i = j
+		for i < n && isSpaceByte(masked[i]) {
+			i++
+		}
+		// Skip any initializer, tracking bracket depth locally so a nested
+		// object/array literal's commas don't get mistaken for declarator
+		// separators.
+		local := 0
+		for i < n {
+			ch := masked[i]
+			switch ch {
+			case '{', '(', '[':
+				local++
+				i++
+				continue
+			case '}', ')', ']':
+				if local > 0 {
+					local--
+				}
+				i++
+				continue
+			}
+			if local == 0 && (ch == ',' || ch == ';') {
+				break
+			}
+			i++
+		}
+		if i < n && masked[i] == ',' {
+			i++
+			continue
+		}
+		if i < n && masked[i] == ';' {
+			i++
+		}
+		break
+	}
+	return i
+}
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// maskStringsAndComments returns a copy of src with the CONTENTS of every
+// string literal and comment replaced by spaces (delimiters kept as-is
+// where harmless, dropped where not). Bracket characters that appear inside
+// a string or comment are erased so brace-depth tracking elsewhere never
+// misreads them; everything else (whitespace, statement structure) keeps
+// its original byte offsets so line/column-free callers can still reason
+// about position within the file.
+func maskStringsAndComments(src []byte) []byte {
+	out := make([]byte, len(src))
+	copy(out, src)
+
+	inStr := false
+	strQuote := byte(0)
+	esc := false
+	inLineComment := false
+	inBlockComment := false
+
+	for i := 0; i < len(out); i++ {
+		b := out[i]
+
+		if inStr {
+			if esc {
+				esc = false
+			} else if b == '\\' {
+				esc = true
+			} else if b == strQuote {
+				inStr = false
+			}
+			if b != '\n' {
+				out[i] = ' '
+			}
+			continue
+		}
+		if inLineComment {
+			if b == '\n' {
+				inLineComment = false
+			} else {
+				out[i] = ' '
+			}
+			continue
+		}
+		if inBlockComment {
+			if b == '*' && i+1 < len(out) && out[i+1] == '/' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i++
+				inBlockComment = false
+			} else if b != '\n' {
+				out[i] = ' '
+			}
+			continue
+		}
+
+		if b == '/' && i+1 < len(out) {
+			if out[i+1] == '/' {
+				inLineComment = true
+				out[i] = ' '
+				out[i+1] = ' '
+				i++
+				continue
+			}
+			if out[i+1] == '*' {
+				inBlockComment = true
+				out[i] = ' '
+				out[i+1] = ' '
+				i++
+				continue
+			}
+		}
+
+		if b == '\'' || b == '"' || b == '`' {
+			inStr = true
+			strQuote = b
+			// Keep the opening delimiter as a space too so a lone quote
+			// byte can't be misread as anything meaningful; only its
+			// position (not content) matters to callers.
+			out[i] = ' '
+			continue
+		}
+
+		// default: leave byte as-is
+	}
+
+	return out
+}

--- a/pkg/shelly/script/toplevel_test.go
+++ b/pkg/shelly/script/toplevel_test.go
@@ -1,0 +1,56 @@
+package script
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTopLevelDeclarations(t *testing.T) {
+	src := []byte(`
+// a leading comment with { braces } and "quotes"
+var CONFIG = {};
+var STATE = { count: 0, calc: function() {
+  var innerLocal = 1; // must NOT be reported: nested inside a function expression
+  function innerHelper() {} // also nested
+  return innerLocal;
+} };
+var a = 1, b = "two, three {four}", c = { x: [1,2,3] };
+
+function topFn(x) {
+  var localVar = x; // nested, must NOT be reported
+  if (x) {
+    var alsoNested = 2; // nested (inside if-block), must NOT be reported
+  }
+  return localVar;
+}
+
+function anotherFn() {}
+
+/* a block comment with a fake declaration
+var fakeVar = 1;
+function fakeFn() {}
+*/
+
+var trailingAfterComment = "ok";
+`)
+
+	got := topLevelDeclarations(src)
+	want := []string{
+		"CONFIG", "STATE", "a", "b", "c",
+		"topFn", "anotherFn", "trailingAfterComment",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("topLevelDeclarations() = %v, want %v", got, want)
+	}
+}
+
+func TestTopLevelDeclarations_StringWithBraces(t *testing.T) {
+	src := []byte(`var msg = "in function {foo} called from bar(1,2)";
+function realFn() {}
+`)
+	got := topLevelDeclarations(src)
+	want := []string{"msg", "realFn"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("topLevelDeclarations() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Adds `github.com/evanw/esbuild/pkg/api` as a second, **selectable** JS minifier alongside tdewolff,
with optional top-level identifier mangling and a symbol map for decoding crash traces.

**Draft on purpose**: nothing is enabled by default, and the mangling path has not been verified on
real hardware. This repo auto-merges PRs when CI goes green, so it stays draft until someone
deliberately device-tests it.

## Why

The Shelly JS heap is one pool shared across all scripts on a device (~23 KB). `pool-pump.js` on the
production Pro1 runs at `mem_peak 21350` — roughly 1680 bytes of headroom — and has failed to start
with `out_of_memory` more than once (#421 / #426). tdewolff mangles local identifiers only; top-level
names survive untouched, and on `pool-pump.js` they account for ~121 symbols over ~899 occurrences.

## Measured results

| script | raw | tdewolff | esbuild (no mangle) | esbuild + top-level mangle |
|---|---|---|---|---|
| pool-pump.js (main) | 76614 | 36155 | 36162 | **31010** |
| pool-pump.js (#426 branch) | 90065 | 37739 | 37601 | **31318** |
| watchdog.js | 8186 | 3338 | 3315 | **3193** |
| garden.js | 44363 | 23971 | 23743 | **19493** |
| prometheus-metrics.js | 11338 | 6075 | 6063 | 6032 |

For reference v0.11.9's `pool-pump.js` — which runs comfortably on the Pro1 at `mem_peak 17136` — is
30409 bytes. Mangling brings the current script back into that range (−14%), and the heavier #426
version from an OOM-crashing 37739 down to 31318 (−17%).

## How top-level mangling works

esbuild will not rename top-level names in a plain script — they are globals. The script is wrapped
in an IIFE whose return value re-exports the preserved names at true top level:

```js
var __myhome_minify_exports__=(function(){ /* script */ return {handleMorningStart:tt,...}; })();
handleMorningStart=__myhome_minify_exports__.handleMorningStart, ...
```

This is required for correctness: device `Schedule` jobs invoke `handleMorningStart()`,
`handleEveningStop()`, `handleNightStart()`, `handleNightStop()` and `handleDailyCheck()` **by name**
via `script.eval`. Mangling them would silently stop every schedule firing. The preserve-list is
per-script and configurable (`internal/shelly/scripts/minify_config.go`), not hardcoded.

## Symbol map and `demangle`

Shelly crash traces carry function names and code snippets but **no line/column**, e.g.
`in function "storeValue" called from storeValue("turnover-today",...)`. A Source Map v3 alone
cannot resolve that. So the Source Map's `names` array is post-processed into a flat
mangled -> original table for top-level symbols (unambiguous — they share one flat scope), and
`myhome ctl shelly script demangle` rewrites a crash message with it.

Verified end-to-end: `in function "P"` -> `in function "storeValue"`.

## Safety

- **Default OFF everywhere.** `scripts.minifier_engine` defaults to `tdewolff` and
  `scripts.mangle_top_level` to `false`, reproducing today's behaviour exactly. This matters because
  the minifier runs *inside the daemon* — `manager.go` -> `shellysetup.SetupDevice()` uploads
  `watchdog.js` automatically to every discovered device, with no human in the loop.
- `Target: api.ES5` is mandatory; esbuild would otherwise emit ES6 into an Espruino engine.
- `ComputeScriptVersion` hashes the raw embedded source, so changing engines cannot churn version
  hashes or trigger mass re-uploads. Verified.
- esbuild is cgo-free: `GOOS=linux GOARCH=arm64 go build` produces a statically linked aarch64
  binary. Cost: **+4.86 MB** (38.97 MB -> 43.83 MB), relevant to #367.

## Known limitations

- **9 of 19 embedded scripts use `let`/`const`** and esbuild's ES5 target cannot downlevel them — it
  errors loudly rather than emitting wrong code (safe failure, but those scripts cannot use this
  path today).
- With mangling on, any top-level name not preserved or debug-exported becomes unreachable via live
  `Script.Eval` — the exact capability the #421 investigation relied on. `DebugExports` mitigates
  this but is opt-in per name.
- The daemon's automatic upload path does **not** persist a symbol map; enabling mangling for real
  uploads means separately running `script minify --symbol-map` to retain crash decoding.
- `Demangle` is word-boundary textual substitution, not a parser.

## Bonus finding on #266

esbuild's default `MinifySyntax` **reproduces** tdewolff's crash-inducing comma-expression-in-return
pattern — it does not sidestep #266. A new `DisableSyntaxLowering` option keeps statements
semicolon-separated and structurally avoids the pattern for ~180 bytes. **Static analysis only, not
hardware-verified.** If it holds up on a device, PR #267 would likely be superseded or much
simplified.

## Test plan

- [x] `make generate && make build`
- [x] `make test` — 47 packages ok, 0 failures (reviewer-verified independently)
- [x] `GOOS=linux GOARCH=arm64 go build -o /tmp/x ./myhome` — statically linked aarch64
- [x] Preserved globals survive mangling (all five present in output)
- [x] Symbol map round-trip on a real #421 crash string
- [ ] **Device-test at least `pool-pump.js` and `watchdog.js` before enabling in production**
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- feat(minifier): add esbuild engine with opt-in top-level mangling ([945a42f](https://github.com/asnowfix/home-automation/commit/945a42f159407d9f8253df48989f4f1031b79a70))
- fix(minifier): emit raw UTF-8 from esbuild, not \uXXXX escapes ([5f9afea](https://github.com/asnowfix/home-automation/commit/5f9afea421d7063cc825f2727c7f669171405dcf))
- fix(minifier): decode source-map columns as UTF-16 units, not bytes ([f0c0118](https://github.com/asnowfix/home-automation/commit/f0c0118b02296bea6e6a7d075efac477ebfdd15f))
<!-- END-AUTO-GENERATED-COMMITS -->