### PR TITLE
docs: record Shelly device heap budget, measurement method, and #429 agent handover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,6 +435,36 @@ Use a **different port per device** so concurrent captures do not interleave int
 Note that `log()` in these scripts is gated on `CONFIG.enableLogging` — a diagnostic that must
 always be visible has to use `print()` directly.
 
+#### DANGER: a bad `Script.Eval` KILLS the running script
+
+`Script.Eval` runs in the script's own context, and an uncaught exception there terminates the
+**whole script** — the same failure class as #421. Evaluating an expression that names a symbol the
+installed version does not define is enough:
+
+```
+Uncaught ReferenceError: "SOLAR" is not defined
+ at line 1 col 11
+"W="+SOLAR.availableW+"|since="+SOLAR.aboveStartSince
+```
+
+That happened on the **production pool pump**: a diagnostic written for the solar-capable build was
+evaluated against v0.11.9 (which has no solar code at all) and killed the script. Because every
+device Schedule job uses `script.eval`, a dead script silently turns all of them into no-ops — the
+pump then never starts or stops on schedule.
+
+Rules:
+
+- **Guard every probe.** Prefer `typeof X !== "undefined" ? ... : "n/a"` over a bare reference, or
+  wrap the expression in `try/catch` (never an empty catch — reference `e`).
+- **Match the probe to the installed version.** Confirm which script is actually on the device
+  first; `mem_used`/`mem_peak`/`mem_free` from `Script.GetStatus` are a reliable fingerprint, and
+  `Script.GetCode` can be grepped for a version-specific identifier.
+- **Beware stale/queued diagnostics.** A probe scheduled before a script swap can fire after it, in
+  which case it is evaluated against the *new* script. Cancel pending background checks before
+  changing what is running on a device.
+- After any `Script.Eval` against a production device, re-check `Script.GetStatus` — an eval that
+  killed the script leaves it `running: false` and the pump uncontrolled.
+
 ### Script Lifecycle Logging
 
 Always add startup and stop logging to Shelly scripts:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -619,6 +619,38 @@ myhome ctl shelly call -B tcp://<broker>:1883 -T 60s <device> Script.GetStatus '
 **Rule of thumb**: aim for `mem_free` ≥ ~5 KB steady-state. A script that boots with 1–2 KB free is
 one allocation away from `out_of_memory` and will die unpredictably later.
 
+#### Measuring one script's footprint (differential method)
+
+Because the heap is shared, no API reports a single script's cost directly. Measure it by
+difference: read `mem_free`, stop the script, read `mem_free` again. Any script id returns the same
+device-wide numbers, so you can keep polling id 1 even while stopping id 2.
+
+```bash
+B="myhome ctl shelly call -B tcp://<broker>:1883 -T 60s <device>"
+$B Script.GetStatus '{"id":1}'        # baseline mem_free
+$B Script.Stop       '{"id":2}'
+$B Script.GetStatus  '{"id":1}'       # delta = script 2's footprint
+$B Script.Stop       '{"id":1}'
+$B Script.GetStatus  '{"id":1}'       # delta = script 1's footprint
+# ...then Script.Start both again to leave the device as you found it
+```
+
+Measured on a Shelly Plus 1 (fw 1.7.5) this way:
+
+| state | `mem_free` | implied footprint |
+|---|---|---|
+| `watchdog.js` + `myhome-link.js` running | 21350 | — |
+| `myhome-link.js` stopped | 23044 | `myhome-link.js` ≈ **1694 B** |
+| `watchdog.js` also stopped | 25200 | `watchdog.js` ≈ **2156 B** |
+
+Two caveats:
+
+- **`mem_used + mem_free` is not a constant.** It reads ~23030 while a script is running but
+  `mem_free` reaches ~25200 with all scripts stopped, so the running VM itself consumes roughly
+  2 KB. Treat "total heap" as approximate and always compare like-for-like states.
+- Always **restart what you stopped**. On a production device the resident scripts are load-bearing
+  (`watchdog.js` handles MQTT-failure reboots and firmware updates).
+
 ### Testing memory on a spare device — how to avoid a falsely-easy test
 
 A spare device is only a valid proxy if it is loaded **exactly** like production. Getting this wrong

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -906,6 +906,27 @@ When a script contains errors:
 
 **CRITICAL**: Every new feature MUST include incremental unit test cases.
 
+#### Sub-agents: do NOT background `make test` — commit first (see issue #432)
+
+`make test` is slow here (`internal/shelly/scripts` alone ~183s, full run several minutes), which
+tempts agents into `run_in_background: true`. **Do not do this if you are a sub-agent.** Observed 4
+times out of 8 agent runs: the agent backgrounds the test, ends its turn to wait for the completion
+notification, and never resumes — so its work is left **uncommitted** and its final report,
+measurements and caveats are lost, even though the tests passed.
+
+Rules for sub-agents:
+
+1. **Commit your work BEFORE running the full test suite.** Then a stall costs you the report, never
+   the code.
+2. **Run `make test` in the foreground** with a generous timeout. Use `go test ./path/...` on a
+   single package for fast iteration and save the full `make test` for the end.
+3. Do not end your turn waiting on a background task.
+
+If you are the **coordinating** agent and a sub-agent reports "waiting for the background test run",
+treat it as finished: review its worktree (`git -C <worktree> status` / `diff`), run the
+verification yourself, and commit on its behalf. Do not re-launch it — the work is usually already
+complete and correct.
+
 #### Testing Requirements
 
 1. **Write tests before or alongside implementation**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,41 @@ Severity is assigned by `internal/myhome/shelly/gen2/listener.go:severityFor()`.
 
 ---
 
+### Capturing live device debug output
+
+`myhome ctl shelly script debug <device> true` sends the script's `print()` output to a UDP
+listener. Three constraints, each of which has silently destroyed a capture:
+
+- **Debug lines truncate at ~128 characters.** A long `print()` is cut off mid-sentence, so the
+  actionable part of a diagnostic is exactly what gets lost. **Write on-device diagnostics as
+  several short lines (<80 chars each), never one long one.**
+- **Do not use netcat.** `nc -u -l -k <port>` silently stops recording after the first burst on
+  macOS 15.7.7, `-k` notwithstanding (verified with round-trip test datagrams). Use a small
+  dependency-free Python listener and prove it with a few test packets before trusting a long run:
+  ```python
+  import socket, sys
+  s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+  s.bind(("0.0.0.0", int(sys.argv[1])))
+  with open(sys.argv[2], "ab", buffering=0) as f:
+      while True:
+          f.write(s.recvfrom(65535)[0])
+  ```
+- **Logs are NUL-separated**, not newline-separated. Read them with `tr '\0' '\n' < file`.
+
+If the dev machine has a VPN whose default route beats the LAN, `net.MainInterface()` picks the
+wrong callback address and the device sends debug packets nowhere. Fix it by setting the address
+explicitly, and note this needs no reboot (`restart_required: false`):
+
+```bash
+myhome ctl shelly call -B tcp://<broker>:1883 -T 60s <device> \
+  Sys.SetConfig '{"config":{"debug":{"udp":{"addr":"<lan-ip>:<port>"}}}}'
+```
+
+Use a **different port per device** so concurrent captures do not interleave into one file.
+
+Note that `log()` in these scripts is gated on `CONFIG.enableLogging` — a diagnostic that must
+always be visible has to use `print()` directly.
+
 ### Script Lifecycle Logging
 
 Always add startup and stop logging to Shelly scripts:
@@ -544,6 +579,63 @@ The number of scripts that can run simultaneously on a single device depends on 
 | Shelly 1 Mini G3 (`shelly1minig3`) | 3 |
 
 Other models are not yet catalogued here — add entries as you hit them. Attempting to enable a script beyond the limit returns: `"Reached the maximum N of enabled scripts"` (error code -108).
+
+### JS Heap Budget — the binding constraint on large scripts
+
+**The JS heap is ONE shared pool across every script on the device.** It is not per-script. Read it
+from any script's status; the numbers are device-wide:
+
+```bash
+myhome ctl shelly call -B tcp://<broker>:1883 -T 60s <device> Script.GetStatus '{"id":N}'
+# -> {"running":true,"mem_used":16632,"mem_peak":21350,"mem_free":6398}
+```
+
+`mem_used + mem_free` is the **total heap** — measured **23030 bytes** on both a Shelly Pro1
+(fw 2.0.0) and a Shelly Plus 1 (fw 1.7.5). A script that cannot start reports
+`{"running":false,"errors":["out_of_memory"]}`.
+
+**`mem_peak` decides survival — not `mem_used`, and not the source file size.** Measured for
+`pool-pump.js` on a Pro1 with `watchdog.js` resident alongside it:
+
+| version | minified | mem_peak | mem_free | result |
+|---|---|---|---|---|
+| v0.11.9 | 30409 | 17136 | 12068 | comfortable |
+| main (`ae4c5da`) | 36155 | 22330 | 10276 | runs, ~700 B peak headroom |
+| + #421 fix, first cut | 40002 | — | — | **out_of_memory** |
+| + static size trim (−1519 B) | 38483 | — | — | **out_of_memory** |
+| + fixed call-slot pool | ~38500 | 21350 | 6398 | runs |
+
+**Two lessons, both learned the hard way:**
+
+1. **Peak/transient allocation dominates static size.** Trimming 1519 minified bytes changed
+   nothing. Removing a *single per-call allocation* moved peak by ~1050 bytes and turned OOM into a
+   working script. Before optimising size, hunt per-call/per-tick allocation: a closure created per
+   RPC, an object literal built per call, string concatenation in a hot path.
+2. **Prefer a fixed pool to per-call allocation.** `pool-pump.js` tracks in-flight RPCs with
+   `CALL_SLOTS`: a small array of `{cb, ud, used}` records allocated **once** at load, claimed in
+   place, and passed through `Shelly.call`'s `userdata` to ONE shared completion handler. The
+   earlier version allocated a fresh closure on every `Shelly.call` (39 during init alone).
+
+**Rule of thumb**: aim for `mem_free` ≥ ~5 KB steady-state. A script that boots with 1–2 KB free is
+one allocation away from `out_of_memory` and will die unpredictably later.
+
+### Testing memory on a spare device — how to avoid a falsely-easy test
+
+A spare device is only a valid proxy if it is loaded **exactly** like production. Getting this wrong
+produced a green result on a spare device followed immediately by an OOM on the real one:
+
+1. **Match the resident scripts.** Stopping other scripts to "make room" invalidates the test — the
+   heap is shared. Production had `watchdog.js` resident; the spare had it stopped.
+2. **Match the KVS configuration — this is the big one.** With 5 `script/pool-pump/*` keys the
+   script used `mem_used 13748`; with production's 24 keys the identical code OOM'd. **~7.9 KB of
+   footprint was config-driven runtime state, not code.** Copy the real config across first:
+   ```bash
+   myhome ctl shelly call -B tcp://<broker>:1883 -T 60s <prod-device> KVS.GetMany '{"match":"script/<name>/*"}'
+   # then KVS.Set each key on the spare, overriding any device-id key to the spare's own id
+   ```
+3. **Record both firmware versions** (`Shelly.GetDeviceInfo` → `ver`). They may differ across the
+   fleet (Pro1 2.0.0 vs Plus 1 1.7.5). Firmware did NOT explain an OOM difference in practice —
+   record it, but don't reach for it as an explanation before checking scripts and KVS.
 
 ### KVS Key Naming Convention
 
@@ -1121,6 +1213,27 @@ func doUpload(ctx context.Context, log logr.Logger, via types.Channel, device de
 - `--no-minify`: Do not minify script before upload (recommended for Shelly)
 - `--force`: Force re-upload even if version hash matches
 - `--verbose`: Enable verbose logging
+
+#### Gotchas that cost real debugging time
+
+- **`SCRIPT` is a bare name resolved from the binary's embedded FS (`//go:embed *.js`), NOT a
+  filesystem path.** Passing a path fails with `Failed to read script <path>: file does not exist`
+  — that is `io/fs` wording, and the tell that it never touched the disk. Consequence: **the version
+  uploaded is whatever `internal/shelly/scripts/<name>.js` contained when that binary was built.**
+  To upload a different version, check that file out and rebuild (e.g. build from a tag's worktree).
+- **A reported upload failure is often a successful upload.** The chunked transfer completes, then a
+  post-upload RPC (`KVS.Get` version read, `Script.Start`) times out and the command exits non-zero
+  with `all 1 device(s) failed`. Seen on every attempt against a Pro1 at `-T 60s`, `90s` and `120s`.
+  **Always verify with `Script.GetStatus` before believing a failure** — see issue #428. Trusting a
+  false failure once produced a wrong conclusion about real hardware.
+- **`error_msg` is stale until the new script actually runs.** After uploading a new version, the
+  device still reports the *previous* crash. Cross-check the message against what the installed
+  source actually contains (`Script.GetCode` and grep for a version-specific identifier) before
+  believing it. A crash trace naming a function the installed version does not contain is stale.
+- **The device is briefly unresponsive to MQTT RPC right after `Script.Start`.** `Script.GetStatus`
+  has timed out at 14s and even 45s immediately after a start, then answered normally a minute
+  later. Use `-T 60s` and re-poll; do not conclude the device is wedged. The default `-T 14s` is too
+  short for the Pro1 generally.
 
 #### Examples
 

--- a/docs/429-watchdog-agent-handover.md
+++ b/docs/429-watchdog-agent-handover.md
@@ -1,0 +1,179 @@
+# Agent launch & control package — issue #429 (watchdog.js heap footprint)
+
+This file is a **ready-to-run launch package**. A coordinating agent (or human) with no memory of
+the session that produced it can start the implementation agent, supervise it, and decide whether to
+accept its work, using only what is written here plus issue #429.
+
+Nothing in here needs to be re-derived. Where a number is quoted it was measured on real hardware on
+2026-08-04/05; re-verify before relying on it, but do not start from scratch.
+
+---
+
+## 1. What you are launching
+
+One implementation agent to reduce `internal/shelly/scripts/watchdog.js`'s runtime heap footprint,
+per **issue #429**. Read `gh issue view 429` first — it is self-contained and authoritative. This
+file only covers *how to run and control the agent*.
+
+**Model**: `sonnet`. **Isolation**: its own git worktree. **Run in background**: yes.
+
+**Base branch**: `docs/shelly-device-constraints`, NOT `main`. That branch carries the `AGENTS.md`
+sections the agent depends on ("JS Heap Budget", "Measuring one script's footprint", "Testing memory
+on a spare device"). If it has already merged to `main`, base on `main` instead and say so.
+
+---
+
+## 2. Preconditions to check before launching
+
+| Check | How | Expected |
+|---|---|---|
+| Issue exists | `gh issue view 429` | open, self-contained |
+| Knowledge is in the tree | `grep -c "Measuring one script's footprint" AGENTS.md` | `1` |
+| Spare device reachable | `myhome ctl shelly call -B tcp://192.168.1.2:1883 -T 60s development Shelly.GetDeviceInfo` | `shellyplus1-08b61fd98f44`, fw `1.7.5` |
+| Baseline tests green | `make test` | 47 packages ok, 0 failures |
+
+If the spare device is unreachable the agent can still do the code work, but **cannot** produce the
+before/after measurement that is the entire point of #429. Do not accept the work without it.
+
+---
+
+## 3. The agent prompt — paste verbatim
+
+> You are implementing GitHub issue #429 in the `asnowfix/home-automation` repo, in your own
+> isolated git worktree. Branch off **`docs/shelly-device-constraints`** (not `main`) — that branch
+> carries the `AGENTS.md` guidance you need. Name your branch `perf/429-watchdog-footprint`.
+>
+> **Read first, in this order:**
+> 1. `gh issue view 429` — full context, measurements, method, and test plan. Authoritative.
+> 2. `AGENTS.md` sections "JS Heap Budget", "Measuring one script's footprint (differential
+>    method)", and "Testing memory on a spare device" — these encode hard-won facts; follow them
+>    rather than improvising a measurement method.
+> 3. `CLAUDE.md` "Shelly JavaScript" — ES5/Espruino constraints that crash devices if violated.
+> 4. `internal/shelly/scripts/watchdog.js` — the script under test (236 lines).
+> 5. `internal/shelly/scripts/pool-pump.js` — read `CALL_SLOTS` and `processTaskQueue` for the
+>    allocate-once pattern proven to work. **Do not modify this file** — it is owned by PR #426.
+>
+> **Goal**: reduce `watchdog.js`'s steady-state heap footprint (measured ~2156 bytes) while
+> preserving its behaviour exactly. This is NOT a minification task — top-level mangling saves only
+> ~145 bytes here, and the runtime footprint is ~2.5x the minified code size. The win is in runtime
+> state and allocation.
+>
+> **Method** (see #429 for detail): hunt per-call and per-tick allocation first (closures created
+> per RPC or per timer tick, object literals rebuilt per call, string concatenation in hot paths);
+> prefer fixed allocate-once structures; reduce retained state such as nested config objects and
+> duplicated values. Keep the KVS-configurable surface intact.
+>
+> **Measure on real hardware.** Use the differential method from `AGENTS.md` on the spare device
+> `development` (`shellyplus1-08b61fd98f44`): read `mem_free`, stop the script, read again. Report
+> before/after. Match production conditions — same resident scripts, and replicate the real KVS
+> config; a near-empty KVS gives a falsely-easy result that cost several hours during #421.
+>
+> **Device rules — read carefully:**
+> - You MAY use `development`. Its relay drives nothing; toggling it is safe.
+> - You MUST NOT touch `filtration-hiver` / `shellypro1-ec62608c0230`. That is the live pool pump.
+> - You MUST NOT switch on any real pump.
+> - Always restart any script you stop. `watchdog.js` is load-bearing (MQTT-failure reboots,
+>   firmware updates). Leave the device exactly as you found it.
+> - `script upload` takes a **bare embedded-FS name**, not a path, and frequently reports a
+>   *successful* upload as a failure when a post-upload RPC times out (issue #428) — always verify
+>   with `Script.GetStatus` before concluding anything failed.
+> - Use `-T 60s` on device RPCs; the default 14s is too short, and devices go briefly unresponsive
+>   right after `Script.Start`.
+>
+> **Behaviour must be preserved** — `watchdog.js` is auto-uploaded by the daemon to every device
+> with no human in the loop. A regression silently breaks fleet-wide self-healing. Verify the MQTT
+> watchdog still reboots after the configured consecutive failures, and the firmware check still
+> schedules and runs.
+>
+> **Verification**: `make generate && make build` succeed; `make test` = 47 packages ok, 0 failures;
+> minified output still runs in the goja emulator harness.
+>
+> **Hard constraints**: do NOT `git push`, do NOT create a PR, do NOT run `gh pr` anything — commit
+> locally only; a push hangs on a permission prompt and will stall you indefinitely. The coordinator
+> handles all pushing and merging.
+>
+> **Report back**: before/after footprint with the exact commands used; what you changed and why;
+> anything you judged too risky to cut; how you verified behaviour is unchanged; `make test` result;
+> your worktree path, branch name, commit SHAs; and a ready-to-use PR description body.
+>
+> Work autonomously and completely. Do not stop to ask questions — make reasonable engineering
+> judgements, document them, and keep going.
+
+---
+
+## 4. How to control and review it
+
+**Expect it to stall before reporting.** Every implementation agent in this campaign stopped with
+"waiting for the background test run" and never produced its final report or commit. If that
+happens, do not re-launch it — review its worktree directly (`git -C <worktree> status/diff`), run
+the verification yourself, and commit on its behalf.
+
+**Accept only if all of these hold:**
+
+1. A **real before/after measurement on hardware**, not an estimate. If it only reports minified
+   byte counts, it has done the wrong task — send it back to the runtime-footprint goal.
+2. `make test` = **47 packages ok, 0 failures**, verified by you, not just claimed.
+3. `development` left as found: `watchdog.js` (id 1) and `myhome-link.js` (id 2) both `running:
+   true`. Check with `Script.List`.
+4. `filtration-hiver` untouched — grep the agent's report for it; any command naming it is a
+   protocol breach worth investigating.
+5. Behaviour preservation is argued concretely (which code path still reboots after N failures),
+   not asserted.
+
+**Reject or push back if:** it pursues minification, weakens existing tests to make them pass,
+introduces a daemon dependency (violates `AGENTS.md` "Resilience Rules"), or reports a footprint
+reduction without saying how it was measured.
+
+**A negative result is acceptable.** If the footprint cannot be meaningfully reduced without
+changing behaviour, a clear "not achievable, here is the breakdown of where the ~2156 bytes go" is a
+genuinely useful outcome. Say so in the prompt if you re-issue it.
+
+---
+
+## 5. Verification commands (for the reviewer)
+
+```bash
+W=<agent worktree>
+cd $W && make generate && make test          # expect: 47 ok, 0 FAIL
+GOOS=linux GOARCH=arm64 go build -o /tmp/x ./myhome   # NB: -o required, ./myhome is a directory
+
+B="./myhome/myhome ctl shelly call -B tcp://192.168.1.2:1883 -T 60s development"
+$B Script.List                                # watchdog.js + myhome-link.js must both be running
+$B Script.GetStatus '{"id":1}'                # mem_used / mem_peak / mem_free
+```
+
+Differential footprint check (restart both afterwards):
+
+```bash
+$B Script.GetStatus '{"id":1}'   # baseline mem_free
+$B Script.Stop      '{"id":1}'
+$B Script.GetStatus '{"id":1}'   # delta = watchdog.js footprint
+$B Script.Start     '{"id":1}'
+```
+
+---
+
+## 6. Known hazards
+
+- **The heap is shared across all scripts**; `mem_used + mem_free` is not constant (~23030 while a
+  script runs, `mem_free` ~25200 with all stopped — the VM itself costs ~2 KB). Compare like-for-like
+  states only.
+- **`error_msg` is stale** until a newly-uploaded script actually runs. A crash trace naming a
+  function the installed version does not contain is left over from the previous version.
+- **UDP debug lines truncate at ~128 chars**; netcat drops datagrams on macOS even with `-k`. Use the
+  Python listener in `AGENTS.md`.
+- The repo **auto-merges PRs when CI goes green** — open anything gated as a **draft**.
+
+---
+
+## 7. State at time of writing (2026-08-05, ~01:00 CEST)
+
+- `filtration-hiver`: v0.11.9 `pool-pump.js`, `mem_peak 17136`, pump OFF, schedules intact
+  (`handleMorningStart()` 09:25, `handleEveningStop()` 16:35). **Leave alone.**
+- `development`: `watchdog.js` + `myhome-link.js` running, `pool-pump.js` (id 3) stopped. Carries 24
+  replicated production KVS keys and test Schedule jobs retimed to 01:00/02:00 — see PR #427's
+  restore steps.
+- Open: #425 (#406, gated draft), #426 (#421, draft), #427 (#422), #428, #429.
+  Merged: #424 (#423 UTF-8 chunk fix).
+- Branch `feat/minifier-toplevel-mangling` (esbuild + symbol map) is implemented and verified
+  locally but **not yet pushed or PR'd** — separate from #429.


### PR DESCRIPTION
Captures knowledge learned the expensive way during #421's live-hardware work, so it is not rediscovered.

## AGENTS.md

- **JS Heap Budget** — the heap is ONE pool shared across all scripts on a device (~23030 bytes while a script runs). `mem_peak`, not `mem_used` or file size, decides survival. Includes the measured table showing that trimming 1519 minified bytes changed nothing while removing a single per-call closure moved peak by ~1050 bytes and turned `out_of_memory` into a working script, plus the fixed call-slot pattern that fixed it.
- **Measuring one script's footprint (differential method)** — no API reports a single script's cost, so measure by difference. Includes measured footprints (`watchdog.js` ~2156 B, `myhome-link.js` ~1694 B) and the caveat that `mem_used + mem_free` is not constant.
- **Testing memory on a spare device** — a spare is only a valid proxy if resident scripts AND KVS config match production; ~7.9 KB of `pool-pump.js`'s footprint is config-driven runtime state, so a 5-key spare passes where a 24-key production device OOMs. This mistake cost several hours.
- **Script upload gotchas** — `upload` takes a bare embedded-FS name, not a path; a reported failure is usually a *successful* upload whose post-upload RPC timed out (#428); `error_msg` is stale until the new script runs.
- **Capturing live device debug output** — debug lines truncate at ~128 chars (so write short diagnostic lines), netcat drops datagrams on macOS even with `-k` (use the included Python listener), logs are NUL-separated, and `log()` is gated on `CONFIG.enableLogging` so always-visible diagnostics must use `print()`.

## docs/429-watchdog-agent-handover.md

A self-contained launch and control package for issue #429, so a different coordinating agent can start and supervise the implementation agent with no memory of this session: verbatim prompt, preconditions, acceptance criteria, verification commands, hazards, and current device/PR state.

No code changes.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- docs(agents): record device heap budget, memory-test method, and live-debug gotchas ([83da265](https://github.com/asnowfix/home-automation/commit/83da265195c6ca9d272bbf7e0c4a7f3a588653b3))
- docs(agents): add differential method for measuring one script's heap footprint ([97c5894](https://github.com/asnowfix/home-automation/commit/97c58940fd74a2375f4869bf1c8952ac1c9978d5))
- docs(429): agent launch & control package for the watchdog footprint task ([b9e4580](https://github.com/asnowfix/home-automation/commit/b9e4580c52087f1c7503c323e567c58a9668d13f))
- docs(agents): warn sub-agents not to background make test (#432) ([3067068](https://github.com/asnowfix/home-automation/commit/306706865356df3cacb34b6ea3e02afe387b48ab))
- docs(agents): warn that a bad Script.Eval kills the running script ([b5e07c6](https://github.com/asnowfix/home-automation/commit/b5e07c6eb2a6c8d998e2a347b98861d586057c3d))
<!-- END-AUTO-GENERATED-COMMITS -->