### PR TITLE
fix(pool-pump): bound in-flight RPCs and catch up on restart (#421) — v0.11.x

### DIFF
--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -34,134 +34,124 @@ var SCRIPT_PREFIX = "[" + SCRIPT_NAME + "] ";
 // Configuration schema
 // Both Pro3 and Pro1 run this same script with shared KVS configuration
 // Script compares preferred_device_id against its own device ID to decide if it should run
+//
+// NOTE (#421 heap follow-up): "description" fields were deliberately removed
+// from every entry below. They were pure documentation — nothing in this
+// script or in tools/extract-pool-defaults/main.go (which regex-parses this
+// object at build time, matching on "key"/"default"/"type"/"cliOnly" only)
+// ever reads schema.description. CONFIG_SCHEMA stays fully allocated on the
+// heap for the entire async loadConfig() KVS round-trip sequence at boot
+// (freed only after the last key loads), so every byte of dead weight here
+// is retained heap for that whole window, not just extra script size. If you
+// need the human-readable text, see `git log -p` this hunk to recover it.
 var CONFIG_SCHEMA = {
   enableLogging: {
-    description: "Enable logging when true",
     key: "logging",
     default: true,
     type: "boolean"
   },
   mqttTopicPrefix: {
-    description: "MQTT topic prefix (written by CLI, not used by script)",
     key: "mqtt-topic",
     default: "pool/pump",
     type: "string",
     cliOnly: true
   },
   preferredDeviceId: {
-    description: "Which device ID should run (actual Shelly device ID). Script compares this to its own ID",
     key: "preferred",
     default: null,
     type: "string",
     required: true
   },
   pro3DeviceId: {
-    description: "Pro3 device ID (for MQTT subscriptions - cross-device status tracking)",
     key: "pro3-id",
     default: null,
     type: "string",
     required: false
   },
   pro1DeviceId: {
-    description: "Pro1 device ID (for MQTT subscriptions - cross-device status tracking)",
     key: "pro1-id",
     default: null,
     type: "string",
     required: false
   },
   preferredSpeed: {
-    description: "Speed: 'eco', 'mid', 'high', 'max'. Maps to switches based on device capabilities",
     key: "speed",
     default: "eco",
     type: "string",
     required: false
   },
   ecoSpeed: {
-    description: "Pro3 switch ID for eco/low speed (0, 1, or 2)",
     key: "eco-speed",
     default: 2,
     type: "number",
     required: false
   },
   midSpeed: {
-    description: "Pro3 switch ID for mid speed (0, 1, or 2)",
     key: "mid-speed",
     default: 1,
     type: "number",
     required: false
   },
   highSpeed: {
-    description: "Pro3 switch ID for high speed (0, 1, or 2)",
     key: "high-speed",
     default: 0,
     type: "number",
     required: false
   },
   nightRunDurationMs: {
-    description: "Night run duration in ms (written by CLI, not used by script)",
     key: "night-duration",
     default: 3600000,
     type: "number",
     cliOnly: true
   },
   graceDelayMs: {
-    description: "Cross-device grace delay in ms (minimum 10000)",
     key: "grace-delay",
     default: 10000,
     type: "number",
     required: false
   },
   temperatureThreshold: {
-    description: "Temperature threshold (°C) for summer mode (day schedule)",
     key: "temp-threshold",
     default: 20,
     type: "number",
     required: false
   },
   poolVolume: {
-    description: "Pool volume in m³",
     key: "pool-volume",
     default: 46,
     type: "number"
   },
   turnover: {
-    description: "Daily turnover target (number of full pool volumes to filter per day)",
     key: "turnover",
     default: 5,
     type: "number"
   },
   maxFlowRate: {
-    description: "Pump max flow rate in m³/h at max RPM",
     key: "max-flow-rate",
     default: 31,
     type: "number"
   },
   maxRpm: {
-    description: "Pump rated max RPM",
     key: "max-rpm",
     default: 2900,
     type: "number"
   },
   ecoRpm: {
-    description: "Variator RPM setting for eco speed",
     key: "eco-rpm",
     default: 2000,
     type: "number"
   },
   midRpm: {
-    description: "Variator RPM setting for mid speed",
     key: "mid-rpm",
     default: 2600,
     type: "number"
   },
   highRpm: {
-    description: "Variator RPM setting for high speed",
     key: "high-rpm",
     default: 2900,
     type: "number"
   },
   maxTemp: {
-    description: "Temperature (°C) at which run time reaches one full turnover",
     key: "max-temp",
     default: 35,
     type: "number"
@@ -368,6 +358,147 @@ var STATE_KEYS = {
   activeOutput: "active-output"     // -1 (all off), 0, 1, 2 for pro3; 0 for pro1
 };
 
+// === IN-FLIGHT RPC TRACKING (#421 Bug A) ===
+// Real Gen2 firmware allows at most 5 concurrent Shelly.call RPCs per script
+// (see CLAUDE.md "Per-script limits"); the 6th concurrent call raises an
+// uncaught "Too many calls in progress" exception that kills the ENTIRE
+// script, not just the offending call. processTaskQueue's 200ms tick (below)
+// only serialises *when* queued task functions run — it has no idea how many
+// of the underlying async RPCs those tasks fire are still in flight. That gap
+// is the root cause of the live crash (saveState's active-output mirror, a
+// storeValue() fire-and-forget write) documented in issue #421.
+//
+// CALLS_IN_FLIGHT tracks every Shelly.call this script makes. It is wired up
+// once here by wrapping Shelly.call itself, rather than editing every call
+// site in this file — every callback still receives exactly the arguments it
+// always did, so this is purely additive bookkeeping.
+var CALLS_IN_FLIGHT = 0;
+var N_SEEN = 0;               // lifetime count — proves tracking actually runs
+var MAX_CALLS_IN_FLIGHT = 4;  // stay one below the real 5-call device ceiling
+
+// CALL_SLOTS is a small fixed pool of plain {cb, ud, used} records, allocated
+// ONCE at script load. Each Shelly.call claims a free slot in place instead
+// of allocating a brand-new closure per call — a per-call closure measurably
+// raised peak heap on real hardware in issue #421's reference fix. Sized to
+// the real 5-call device ceiling + 1 spare, not just MAX_CALLS_IN_FLIGHT:
+// calls fired directly from event/timer handlers (not funneled through
+// queueTask) are not subject to that throttle.
+var CALL_SLOTS = [];
+for (var CALL_SLOT_INIT_I = 0; CALL_SLOT_INIT_I < 6; CALL_SLOT_INIT_I++) {
+  CALL_SLOTS.push({cb: null, ud: null, used: false});
+}
+
+function acquireCallSlot(cb, ud) {
+  for (var i = 0; i < CALL_SLOTS.length; i++) {
+    if (!CALL_SLOTS[i].used) {
+      CALL_SLOTS[i].used = true;
+      CALL_SLOTS[i].cb = cb;
+      CALL_SLOTS[i].ud = ud;
+      return CALL_SLOTS[i];
+    }
+  }
+  // Pool exhausted (should not happen — see sizing note above): fall back
+  // to a fresh record rather than losing the callback.
+  return {cb: cb, ud: ud, used: true};
+}
+
+// Shared completion handler for calls that passed a callback. Decrements
+// unconditionally before invoking the caller's callback, so a slot is always
+// freed even if the callback itself throws (caught by processTaskQueue's
+// try/catch below, or top-level error handling).
+function sharedCallDone(result, error_code, error_message, slot) {
+  CALLS_IN_FLIGHT--;
+  var cb = slot ? slot.cb : null;
+  var ud = slot ? slot.ud : null;
+  if (slot) {
+    slot.used = false;
+    slot.cb = null;
+    slot.ud = null;
+  }
+  if (typeof cb === 'function') {
+    cb(result, error_code, error_message, ud);
+  }
+}
+
+// Shared completion handler for fire-and-forget calls (storeValue() and
+// friends) — nothing to forward, so no slot is needed at all.
+function decrementOnlyCallDone() {
+  CALLS_IN_FLIGHT--;
+}
+
+var RAW_CALL = Shelly.call;
+Shelly.call = function (method, params, callback, userdata) {
+  CALLS_IN_FLIGHT++;
+  N_SEEN++;
+  if (typeof callback !== 'function') {
+    return RAW_CALL(method, params, decrementOnlyCallDone, null);
+  }
+  return RAW_CALL(method, params, sharedCallDone, acquireCallSlot(callback, userdata));
+};
+
+// --- Self-check: fail LOUDLY, never silently (#421) ---------------------
+// This depends on reassigning a method on the native Shelly object, which is
+// not guaranteed to be permitted on every firmware. If the assignment is
+// ever rejected, CALLS_IN_FLIGHT stays 0 forever, the throttle below never
+// engages, and the crash this fix exists to prevent comes back — while every
+// emulator test still passes, because goja allows a reassignment a device
+// might refuse. That silent-inert failure is the dangerous case, so it is
+// asserted here rather than assumed.
+//
+// print() is used deliberately instead of log(): log() is gated on
+// CONFIG.enableLogging and would hide this exact message in production, and
+// log() is defined later in this file (no hoisting on Espruino) so it does
+// not exist yet at this point anyway.
+// The device truncates each UDP debug line at ~128 chars, so every line
+// below is kept short.
+var P421 = "[pool-pump] #421: ";
+
+function printHit() {
+  print(P421 + "throttle INERT; >5 calls kills whole script as-is.");
+  print(P421 + "DO NOT re-investigate -- read issue #421 first.");
+}
+
+function printFail() {
+  print(P421 + "FATAL: Shelly.call wrapper did NOT install.");
+  printHit();
+  print(P421 + "alt fix: storeValue() callback should drive queue.");
+}
+
+var WRAP_OK = (Shelly.call !== RAW_CALL);
+if (!WRAP_OK) {
+  printFail();
+}
+
+function emitBroken(reason) {
+  Shelly.emitEvent("pool.call_tracking_broken", {
+    reason: reason,
+    calls_tracked: N_SEEN
+  });
+}
+
+// Runtime counterpart to the check above: the assignment can succeed while
+// tracking still never happens (e.g. something captured Shelly.call before
+// this point and calls the original directly). A healthy boot makes many
+// KVS.Get calls, so N_SEEN must be well above zero by the end of init.
+// Called from continueInit(), by which time log()/Shelly.emitEvent() exist.
+function checkTrack() {
+  if (!WRAP_OK) {
+    // Repeated here as well as at install time: the install-time prints fire
+    // before a debug capture attached after boot would see anything.
+    printFail();
+    emitBroken("wrapper-not-installed");
+    return;
+  }
+  if (N_SEEN === 0) {
+    print(P421 + "FATAL: wrapper OK but tracked 0 calls -- something");
+    print(P421 + "calls the unwrapped Shelly.call, captured earlier.");
+    printHit();
+    emitBroken("zero-calls-tracked");
+    return;
+  }
+  log("Tracking OK (#421): seen", N_SEEN, "max", MAX_CALLS_IN_FLIGHT);
+}
+
 // === TASK QUEUE (SINGLE TIMER FOR ALL SEQUENTIAL OPERATIONS) ===
 var TASK_QUEUE = [];
 var TASK_INDEX = 0;
@@ -385,11 +516,30 @@ function processTaskQueue() {
     return;
   }
 
+  // Bug A root-cause fix (#421): don't dispatch another queued task while
+  // too many of this script's own Shelly.call RPCs are still in flight — a
+  // fixed 200ms tick is not a promise the device has actually kept up with.
+  // Skip this tick; TASK_INDEX is unchanged so the same task is retried on
+  // the next one, once a slot frees up.
+  if (CALLS_IN_FLIGHT >= MAX_CALLS_IN_FLIGHT) {
+    log('Task queue throttled, calls in flight:', CALLS_IN_FLIGHT);
+    return;
+  }
+
   // Execute next task; new tasks queued by the task itself extend TASK_QUEUE
   // and will be picked up on subsequent timer ticks.
   var task = TASK_QUEUE[TASK_INDEX];
   TASK_INDEX++;
-  task();
+
+  // Second, independent layer of defense (#421): one queued task throwing
+  // must not be able to kill the entire script the way it did in the live
+  // incident this issue documents.
+  try {
+    task();
+  } catch (e) {
+    log('ERROR: queued task threw, continuing:', e);
+    if (e && false) {}
+  }
 }
 
 function queueTask(task) {
@@ -1858,6 +2008,101 @@ function handleNightStop() {
   doStop('Night stop event');
 }
 
+// === RESTART CATCH-UP (#421 Bug B) ===
+// enforceOutputState() (below) only mirrors whatever physical state the
+// switch already has at boot — it never asks "should I actually be running
+// right now, given today's schedule window?". A restart (crash recovery,
+// script re-upload, device reboot) landing mid-window therefore silently
+// adopts a stale on/off state and only self-corrects whenever the next
+// schedule tick fires, which can be hours away. This is exactly what left a
+// live pump running hours past its scheduled evening-stop (see issue #421).
+// restartCatchUp() compares "now" against the currently active mode's
+// window — read straight from Schedule.List, the same source of truth
+// updateScheduleMode() writes to — and calls doStart()/doStop() immediately
+// if the physical state disagrees, instead of waiting for the next tick.
+
+// Parses the "M H" fields out of a Shelly cron timespec built by
+// makeTimespec() ("0 M H * * DAYS") or a fixed literal ("0 15 23 * * ...").
+// Returns minutes-since-midnight, or null for formats it can't resolve
+// (e.g. still-symbolic "@sunrise" specs on a schedule that has never had
+// updateScheduleMode() compute real times for it yet) — those windows are
+// left alone rather than guessed at.
+function parseHM(timespec) {
+  if (!timespec || timespec.indexOf('@') === 0) return null;
+  var parts = timespec.split(' ');
+  if (parts.length < 3) return null;
+  var m = Number(parts[1]);
+  var h = Number(parts[2]);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+var RC = 'Restart catch-up: '; // shared log/reason prefix
+
+function restartCatchUp() {
+  if (!isMyTurnToRun()) {
+    return;
+  }
+
+  // Mode-aware on purpose: only one of these two job pairs is ever enabled
+  // at a time on a real device (updateScheduleMode() disables the other),
+  // so matching against the currently active mode avoids any ambiguity
+  // about which pair's timespec actually governs "now".
+  var mode = STATE.scheduleMode || 'winter';
+  var startCode = mode === 'summer' ? 'handleMorningStart()' : 'handleNightStart()';
+  var stopCode = mode === 'summer' ? 'handleEveningStop()' : 'handleNightStop()';
+
+  Shelly.call('Schedule.List', {}, function (result, err) {
+    // A failed lookup or an empty schedule is not the "unresolvable
+    // timespec" case below — it just means there is nothing to catch up
+    // against, so bail out quietly rather than guessing.
+    if (err || !result || !result.jobs) {
+      log(RC + 'lookup failed');
+      if (err && false) {}
+      return;
+    }
+
+    var startMin = null;
+    var stopMin = null;
+    for (var i = 0; i < result.jobs.length; i++) {
+      var job = result.jobs[i];
+      if (!job.enable || !job.calls || job.calls.length === 0) continue;
+      var code = job.calls[0].params && job.calls[0].params.code;
+      if (code === startCode) {
+        startMin = parseHM(job.timespec);
+      } else if (code === stopCode) {
+        stopMin = parseHM(job.timespec);
+      }
+    }
+
+    // Unresolvable timespec (e.g. still-symbolic "@sunrise", see parseHM
+    // above) — skip rather than act on a guess (#421 Bug B requirement).
+    if (startMin === null || stopMin === null) {
+      log(RC + 'unresolved', mode);
+      return;
+    }
+
+    var d = new Date();
+    var nowMin = d.getHours() * 60 + d.getMinutes();
+    // Handles windows that wrap past midnight (the fixed winter night-run
+    // 23:15 -> 00:15) by treating a start > stop pair as wrapping.
+    var shouldRun = startMin <= stopMin
+      ? (nowMin >= startMin && nowMin < stopMin)
+      : (nowMin >= startMin || nowMin < stopMin);
+    var isRunning = STATE.activeOutput !== -1;
+
+    log(RC, mode, nowMin, startMin, stopMin, shouldRun, isRunning);
+
+    if (shouldRun && !isRunning) {
+      doStart(CONFIG.preferredSpeed, RC + 'inside window');
+    } else if (!shouldRun && isRunning) {
+      doStop(RC + 'outside window');
+    } else {
+      log(RC + 'state OK');
+    }
+  });
+}
+
 // === INITIALIZATION ===
 function enforceOutputState() {
   log("Enforcing output state at startup...");
@@ -1967,6 +2212,14 @@ function continueInit() {
       log('✓ All initialization steps complete - script is now running');
       log('Current mode:', STATE.scheduleMode || 'winter');
       log('Should I run?', isMyTurnToRun());
+      // #421: assert the in-flight RPC tracking this script's crash-safety
+      // depends on is actually live, and shout if it is not (see the
+      // self-check block near CALLS_IN_FLIGHT for why silence is dangerous).
+      checkTrack();
+      // #421 Bug B: correct any stale physical state against the current
+      // schedule window immediately, before the (possibly hours-away) next
+      // schedule tick.
+      queueTask(restartCatchUp);
       queueTask(handleDailyCheck);
       return;
     }

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +90,49 @@ func poolPumpSchedules() []map[string]interface{} {
 	}
 }
 
+// activeNightWindowSchedules returns poolPumpSchedules() with the night-run
+// window (handleNightStart/handleNightStop) widened to bracket time.Now()
+// instead of the fixed 23:15/00:15 literals. Tests that leave the pump
+// already "on" in ComponentStatus at boot (simulating a legitimate
+// in-progress run carried across a restart) need this: pool-pump.js's #421
+// Bug B restart catch-up (restartCatchUp(), wired into continueInit())
+// compares "now" against the currently active mode's schedule window and
+// calls doStop() if they disagree. scheduleMode defaults to "winter" when
+// Storage doesn't carry a saved mode (as in these fixtures), so catch-up
+// looks at the night-start/night-stop jobs — and the fixed 23:15-00:15 band
+// essentially never contains the real time these tests run at, which would
+// otherwise make catch-up immediately stop the pump these tests are trying
+// to exercise.
+func activeNightWindowSchedules() []map[string]interface{} {
+	schedules := poolPumpSchedules()
+	now := time.Now()
+	start := now.Add(-30 * time.Minute)
+	stop := now.Add(3 * time.Hour)
+	startSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", start.Minute(), start.Hour())
+	stopSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", stop.Minute(), stop.Hour())
+	for _, job := range schedules {
+		calls, ok := job["calls"].([]interface{})
+		if !ok || len(calls) == 0 {
+			continue
+		}
+		call, ok := calls[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		params, ok := call["params"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch params["code"] {
+		case "handleNightStart()":
+			job["timespec"] = startSpec
+		case "handleNightStop()":
+			job["timespec"] = stopSpec
+		}
+	}
+	return schedules
+}
+
 func pro3ComponentStatus() map[string]interface{} {
 	return map[string]interface{}{
 		"switch:0": map[string]interface{}{"id": 0, "output": false},
@@ -118,6 +162,25 @@ func shellyInputEvent(inputID int, state bool) []byte {
 		"info": map[string]interface{}{
 			"component": fmt.Sprintf("input:%d", inputID),
 			"id":        inputID,
+			"state":     state,
+		},
+	}
+	data, _ := json.Marshal(event)
+	return data
+}
+
+// shellySwitchEvent simulates a raw device-level "switch:<id> state changed"
+// event, the same shape Shelly.addEventHandler receives on real hardware
+// when a switch physically flips. handleSwitchEvent's Pro1 branches call
+// saveState() synchronously in response — no Shelly.call round trip needed
+// to trigger it — which is what makes it useful for piling multiple
+// queueTask() entries onto TASK_QUEUE back-to-back, faster than any single
+// RPC's round trip.
+func shellySwitchEvent(switchID int, state bool) []byte {
+	event := map[string]interface{}{
+		"info": map[string]interface{}{
+			"component": fmt.Sprintf("switch:%d", switchID),
+			"id":        switchID,
 			"state":     state,
 		},
 	}
@@ -231,7 +294,7 @@ func TestPoolPump_WaterSupplyRestoresSpeed(t *testing.T) {
 		KVS:             controllerKVS(),
 		Storage:         make(map[string]interface{}),
 		ComponentStatus: cs,
-		Schedules:       poolPumpSchedules(),
+		Schedules:       activeNightWindowSchedules(),
 		EventInjector:   injector,
 	}
 
@@ -476,4 +539,225 @@ func TestPoolPump_Pro1ToggleAndWaterSupply(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+// === #421 Bug A: "Too many calls in progress" concurrent-call ceiling ===
+//
+// Reproduces the live crash from issue #421: processTaskQueue's 200ms tick
+// only serializes *when* queued task functions run — it has no idea how many
+// of the underlying async Shelly.call RPCs those tasks fire are still in
+// flight. handleSwitchEvent's Pro1 branches call saveState() synchronously
+// in direct response to a raw switch-state event (no Shelly.call round trip
+// needed to trigger it), and saveState() queues two fire-and-forget
+// storeValue() writes (active-output, schedule-mode) per call — exactly the
+// storeValue()/queueTask() call sites issue #421's live crash dumps named.
+// Injecting a rapid burst of switch:0 events piles many queueTask() entries
+// onto TASK_QUEUE almost instantly; a task queue that dispatches one new
+// Shelly.call per fixed 200ms tick regardless of how many previous ones are
+// still in flight (DeviceState.CallDelay simulates each RPC's real,
+// slower-than-200ms round trip) reliably pushes concurrent in-flight calls
+// past the real device's 5-call ceiling, recreating "Too many calls in
+// progress" (see issue #421).
+func TestPoolPump_ConcurrentCallCeiling_SwitchEventBurstDoesNotCrash(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	// Generous: boot alone (18 sequential config keys, each round-tripping
+	// through CallDelay) takes on the order of 20-25s with this delay, plus
+	// a settle buffer and the burst/drain phase.
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		90*time.Second,
+	)
+	defer cancel()
+
+	injector := make(chan []byte, 16)
+
+	deviceState := &script.DeviceState{
+		KVS:             pro1KVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: pro1ComponentStatus(),
+		Schedules:       pro1Schedules(),
+		EventInjector:   injector,
+		Mode:            script.DeviceTestMode,
+		// Long enough (relative to the fixed 200ms task-queue tick) that
+		// several queued Shelly.call dispatches stay "in flight"
+		// simultaneously — a ~1.2s/200ms = 6x pileup factor comfortably
+		// exceeds the real device's 5-call ceiling once enough tasks are
+		// queued, while still draining within this test's deadline once the
+		// fix's MAX_CALLS_IN_FLIGHT=4 throttle caps concurrency.
+		CallDelay: 1200 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	initDone := waitFor(60*time.Second, 200*time.Millisecond, func() bool {
+		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		return exists
+	})
+	if !initDone {
+		cancel()
+		<-done
+		t.Fatalf("init did not complete within timeout")
+	}
+
+	// schedule-mode appears early (right after STATE.initializing flips to
+	// false) — well before the 4 sequential initSteps (Sys.SetConfig,
+	// applyComponentNames, verifySchedules, ...), restartCatchUp(), and
+	// handleDailyCheck()'s forecast fetch finish draining, each of which
+	// dispatches its own CallDelay-deferred Shelly.call. Give that leftover
+	// init activity time to fully settle so the burst below is the only
+	// concurrent-call activity in play — otherwise it can trip the ceiling
+	// (or fail to, post-fix) for reasons unrelated to what this test targets.
+	time.Sleep(8 * time.Second)
+
+	// Fire the burst: eight alternating raw switch:0 state events with no
+	// delay in between. Each synchronously triggers saveState() (two
+	// queueTask() calls each) — see the doc comment above.
+	for i := 0; i < 8; i++ {
+		injector <- shellySwitchEvent(0, i%2 == 0)
+	}
+
+	deadline := time.After(25 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	var runErr error
+settleLoop:
+	for {
+		select {
+		case runErr = <-done:
+			break settleLoop
+		case <-deadline:
+			break settleLoop
+		case <-ticker.C:
+			// No specific end state to poll for (the deliberately-raced
+			// toggles make the final active-output unpredictable) — just
+			// give queued/deferred work time to drain without crashing.
+		}
+	}
+
+	cancel()
+	if runErr == nil {
+		runErr = <-done
+	}
+
+	if runErr != nil && strings.Contains(runErr.Error(), "Too many calls in progress") {
+		t.Fatalf("script crashed on the concurrent-call ceiling (issue #421 Bug A): %v", runErr)
+	}
+}
+
+// === #421 Bug B: restart catch-up against the active schedule window ===
+//
+// enforceOutputState() only mirrors whatever physical switch state it finds
+// at boot — it never asks "should I actually be running right now, given
+// today's schedule window?". This simulates a restart landing well outside
+// the active summer-mode window (morning-start/evening-stop, computed here
+// relative to time.Now() so the test is deterministic regardless of when it
+// runs) with the pump physically left "on", and asserts the fixed
+// restartCatchUp() path calls doStop() and the switch ends up off — without
+// waiting for any schedule tick (there is no cron emulation in this
+// harness).
+func TestPoolPump_RestartCatchUp_StopsOutsideScheduleWindow(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	now := time.Now()
+	winStart := now.Add(3 * time.Hour)
+	winStop := now.Add(4 * time.Hour)
+	startSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", winStart.Minute(), winStart.Hour())
+	stopSpec := fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", winStop.Minute(), winStop.Hour())
+
+	schedules := []map[string]interface{}{
+		{
+			"id": 1, "enable": true,
+			"timespec": "@sunrise * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleDailyCheck()"},
+			}},
+		},
+		{
+			"id": 2, "enable": true,
+			"timespec": startSpec, // 3h from now — "now" is outside this window
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleMorningStart()"},
+			}},
+		},
+		{
+			"id": 3, "enable": true,
+			"timespec": stopSpec,
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleEveningStop()"},
+			}},
+		},
+		{
+			"id": 4, "enable": false, // disabled: summer mode, night schedules off
+			"timespec": "0 15 23 * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleNightStart()"},
+			}},
+		},
+		{
+			"id": 5, "enable": false,
+			"timespec": "0 15 0 * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": "handleNightStop()"},
+			}},
+		},
+	}
+
+	cs := pro1ComponentStatus()
+	cs["switch:0"] = map[string]interface{}{"id": 0, "output": true} // physically on at "restart"
+
+	deviceState := &script.DeviceState{
+		KVS:             pro1KVS(),
+		Storage:         map[string]interface{}{"schedule-mode": "summer"},
+		ComponentStatus: cs,
+		Schedules:       schedules,
+	}
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		15*time.Second,
+	)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	stopped := waitFor(10*time.Second, 100*time.Millisecond, func() bool {
+		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		return ok && v == "-1"
+	})
+	cancel()
+	<-done
+
+	if !stopped {
+		t.Fatalf("restart outside scheduled window: expected catch-up to stop the pump (active-output=-1), got %v",
+			deviceState.KVS["script/pool-pump/active-output"])
+	}
+
+	entry, ok := deviceState.ComponentStatus["switch:0"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("switch:0 component status missing or malformed: %v", deviceState.ComponentStatus["switch:0"])
+	}
+	if on, _ := entry["output"].(bool); on {
+		t.Errorf("restart outside scheduled window: switch:0 still physically on after catch-up")
+	}
 }

--- a/pkg/shelly/script/device_state.go
+++ b/pkg/shelly/script/device_state.go
@@ -5,14 +5,59 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/go-logr/logr"
 )
+
+// ExecutionMode controls how strictly the goja-based emulator enforces
+// Shelly Gen2 per-script resource limits (see AGENTS.md "Per-script
+// limits"). This is a minimal slice of issue #250 — only the concurrent
+// Shelly.call ceiling is modeled here; timer/event-handler/status-handler/
+// MQTT-subscription count limits are #250's remaining scope, not this one's.
+type ExecutionMode int
+
+const (
+	// DeviceTestMode is the zero value / default: the emulator mirrors the
+	// real device's concurrent-call ceiling, panicking with a message
+	// matching the real device's "Too many calls in progress" error once
+	// MaxConcurrentCalls calls are already in flight. Use for all unit
+	// tests exercising scripts against simulated device behavior.
+	DeviceTestMode ExecutionMode = iota
+	// DeviceExtensionMode disables the ceiling entirely, for daemon-side
+	// script execution that intentionally aggregates state across multiple
+	// devices and must not be constrained by any single device's per-script
+	// limits.
+	DeviceExtensionMode
+)
+
+// MaxConcurrentCalls mirrors the real Shelly Gen2 per-script ceiling on
+// in-flight Shelly.call RPCs (see AGENTS.md "Per-script limits"). Exceeding
+// it on real hardware raises an uncaught "Too many calls in progress"
+// exception that kills the entire script (see issue #421).
+const MaxConcurrentCalls = 5
 
 // DeviceState represents the persistent state of a Shelly device for testing
 type DeviceState struct {
 	KVS     map[string]interface{} `json:"kvs"`
 	Storage map[string]interface{} `json:"storage"`
+
+	// Mode selects resource-limit enforcement (see ExecutionMode). The zero
+	// value is DeviceTestMode, so existing callers that don't set this field
+	// keep getting strict enforcement by default.
+	Mode ExecutionMode `json:"-"`
+
+	// CallDelay, when non-zero and Mode is DeviceTestMode, artificially
+	// delays the *release* of a Shelly.call's in-flight slot (not the
+	// call's dispatch or its callback — those stay synchronous, preserving
+	// every script's existing callback-ordering assumptions). This lets a
+	// test create genuinely overlapping in-flight calls — e.g. several
+	// calls dispatched a fixed tick apart, each taking longer than that
+	// tick to "complete" from the device's perspective — to exercise the
+	// concurrent-call ceiling (see issue #421). Zero (default) preserves
+	// the emulator's original synchronous-release behavior. Ignored in
+	// DeviceExtensionMode.
+	CallDelay time.Duration `json:"-"`
 
 	// Schedules tracks jobs created via Schedule.Create during script execution.
 	// Each entry is the raw params map passed to Schedule.Create, plus an "id" field.

--- a/pkg/shelly/script/event_handler.go
+++ b/pkg/shelly/script/event_handler.go
@@ -107,12 +107,17 @@ func (eh *eventsHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byt
 
 	log.Info("Processing event", "event", eventData)
 
-	// Call all registered event handlers
+	// Call all registered event handlers. On real Shelly firmware an
+	// uncaught exception in any callback kills the entire script — mirror
+	// that here (see the equivalent fix in RunWithDeviceState's event loop,
+	// issue #421) by stopping and propagating the first error instead of
+	// logging and continuing to the next handler.
 	for i, handler := range eh.handlers {
 		eh.log.Info("Calling event handler", "handler", i, "event", eventData)
 		_, err := handler.callback(goja.Undefined(), eventObj, handler.userdata)
 		if err != nil {
 			log.Error(err, "Event handler failed", "handler", i, "event", eventData)
+			return err
 		}
 	}
 

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -110,7 +110,17 @@ func RunWithDeviceState(ctx context.Context, name string, buf []byte, minify boo
 			msg := value.Bytes()
 			handlerCountBefore := len(handlers)
 			if err := handlers[handlerIdx].Handle(ctx, vm, msg); err != nil {
-				log.Error(err, "Handler failed", "handler", handlerIdx)
+				// On real Shelly firmware, an uncaught exception in *any*
+				// script callback (timer tick, event handler, MQTT message)
+				// kills the entire script — not just that one callback.
+				// Mirror that here: a handler error is a full script crash,
+				// not a log-and-continue. Without this, Bug A's crash (see
+				// issue #421), which happens inside a Timer-driven
+				// processTaskQueue tick rather than the initial synchronous
+				// script evaluation, would be silently swallowed and the
+				// emulator could never observe it.
+				log.Error(err, "Handler failed - script crashed", "handler", handlerIdx)
+				return err
 			}
 			// Check if new handlers were added during Handle()
 			if len(handlers) != handlerCountBefore {
@@ -165,6 +175,16 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	timers := make(map[int]*timerHandler)
 	nextTimerHandle := 1
 
+	// callsInFlight tracks concurrent Shelly.call RPCs for this VM, enforced
+	// only in DeviceTestMode (see issue #421 / #250). Only ever read and
+	// mutated from the single goroutine that drives script execution: the
+	// initial synchronous vm.RunScript() call, or a later handler Handle()
+	// call from RunWithDeviceState's event loop — never concurrently, so no
+	// synchronization is needed even though its release (see CallDelay) may
+	// be scheduled from a timer-like goroutine that only ever *sends on a
+	// channel*, never touches this variable directly.
+	callsInFlight := 0
+
 	vm := goja.New()
 
 	// Shelly event handler system
@@ -189,7 +209,52 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 		log.Info("Shelly.call()", "method", method, "params", params.Export())
 
 		if fn, ok := methods[method]; ok {
+			if deviceState.Mode == DeviceTestMode {
+				if callsInFlight >= MaxConcurrentCalls {
+					// Mirrors the real Gen2 firmware's uncaught exception
+					// when a script exceeds its concurrent-call budget (see
+					// AGENTS.md "Per-script limits", issue #421). Using
+					// vm.NewGoError (an *Object) rather than a plain Go
+					// panic keeps this catchable by a script-level
+					// try/catch, exactly like the real device's exception —
+					// necessary for testing pool-pump.js's own try/catch
+					// defense layer.
+					panic(vm.NewGoError(fmt.Errorf("Too many calls in progress")))
+				}
+				callsInFlight++
+			}
+
+			dispatch := func() {
+				_, err := fn(vm, method, params, callback, userdata)
+				if deviceState.Mode == DeviceTestMode {
+					callsInFlight--
+				}
+				if err != nil {
+					log.Error(err, "Shelly.call() failed (deferred)", "method", method)
+				}
+			}
+
+			if deviceState.Mode == DeviceTestMode && deviceState.CallDelay > 0 {
+				// Defer the entire dispatch — method execution AND its
+				// callback — by CallDelay, rather than just this call's
+				// internal in-flight accounting. A script's own real
+				// in-flight tracking (built from its callbacks, like the
+				// #421 fix) can only throttle against overlap it can
+				// actually observe; deferring just the accounting would be
+				// invisible to it. Shelly.call() always returns undefined
+				// on real hardware, so there's no synchronous result to
+				// preserve here (the one caller in this codebase that reads
+				// a return value, loadValue() in pool-pump.js, is unused
+				// dead code).
+				deferDispatch(handlers, deviceState.CallDelay, dispatch)
+				return goja.Undefined()
+			}
+
 			result, err := fn(vm, method, params, callback, userdata)
+			if deviceState.Mode == DeviceTestMode {
+				callsInFlight--
+			}
+
 			if err != nil {
 				log.Error(err, "Shelly.call() failed", "method", method)
 				return vm.ToValue(err)
@@ -757,6 +822,45 @@ type testEventForwarder struct {
 func (f *testEventForwarder) Wait() <-chan []byte { return f.ch }
 func (f *testEventForwarder) Handle(ctx context.Context, vm *goja.Runtime, msg []byte) error {
 	return f.eh.Handle(ctx, vm, msg)
+}
+
+// deferredCallHandler is a one-shot handler (same shape as a one-shot Timer,
+// see timerHandler below) that fires `dispatch` after `delay` elapses. It
+// exists solely to let DeviceState.CallDelay simulate a real RPC's async
+// round-trip: the method call and its callback both happen only once the
+// delay elapses, rather than synchronously (see issue #421). It never
+// errors itself — any error from `dispatch` (i.e. from the wrapped
+// Shelly.call) is handled by `dispatch` before it returns.
+type deferredCallHandler struct {
+	delay    time.Duration
+	dispatch func()
+	ch       chan []byte
+}
+
+func (h *deferredCallHandler) Wait() <-chan []byte {
+	if h.ch != nil {
+		return h.ch
+	}
+	h.ch = make(chan []byte)
+	go func() {
+		time.Sleep(h.delay)
+		h.ch <- []byte{}
+		close(h.ch)
+	}()
+	return h.ch
+}
+
+func (h *deferredCallHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byte) error {
+	h.dispatch()
+	return nil
+}
+
+// deferDispatch registers a deferredCallHandler so `dispatch` fires once
+// `delay` has elapsed, driven by RunWithDeviceState's normal event loop (see
+// reflect.Select there) rather than a raw goroutine touching VM state
+// directly.
+func deferDispatch(handlers *[]handler, delay time.Duration, dispatch func()) {
+	*handlers = append(*handlers, &deferredCallHandler{delay: delay, dispatch: dispatch})
 }
 
 type methodFunc func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error)


### PR DESCRIPTION
Backports #421's two fixes to the **v0.11.x release line**, which has no solar code. Split out of
PR #426 (against `main`) at the maintainer's request, so the crash fix can ship without #405's
solar feature.

**Why the split matters, not just tidiness**: live measurement on the production Pro1 showed the
solar feature is what exhausts the device's JS heap, not the #421 fix — see #433. With solar
disabled the fixed script runs at `mem_peak 21350` / `mem_free 6398`; with solar enabled it climbs
past 22274 and dies with `out_of_memory`. The v0.11.x line has no solar code at all, so this
backport is the half that fits comfortably.

The production pool pump currently runs v0.11.9's script, which still contains the crash bug this
fixes.

## Bug A — `Too many calls in progress` killed the whole script

`processTaskQueue` dispatched one queued task per 200ms tick but never tracked how many
`Shelly.call` RPCs those tasks left in flight, and `storeValue()` is fire-and-forget. Real Gen2
firmware caps concurrent RPCs at 5; the 6th raises an uncaught error that kills the entire script,
stopping all schedule-driven pump control. Every device Schedule job here uses `script.eval`, so a
dead script silently turns all of them into no-ops — which is how a live pump was found running
hours past its scheduled evening stop.

Fix: track in-flight calls and have `processTaskQueue` skip a tick while `MAX_CALLS_IN_FLIGHT` (4,
one below the device ceiling) are outstanding, leaving `TASK_INDEX` unchanged so the task retries.
Plus a `try/catch` around `task()` as an independent second layer.

Tracking uses `CALL_SLOTS` — a fixed pool of `{cb, ud, used}` records allocated **once** at load,
claimed in place and passed via `Shelly.call`'s `userdata` to one shared completion handler. An
earlier version allocated a fresh closure per call and that alone raised `mem_peak` enough to cause
`out_of_memory` on real hardware; the slot pool brought peak ~1050 bytes *below* baseline. On this
smaller script headroom is comfortable, but the correct pattern is used regardless.

## Bug B — no catch-up against the schedule window on restart

`enforceOutputState()` only mirrored the physical switch at boot; it never asked whether *now* falls
inside today's window, so a restart mid-window adopted stale state until the next schedule tick,
possibly hours later. Adds `restartCatchUp()`, which reads the active mode's start/stop jobs from
`Schedule.List` and calls `doStart()`/`doStop()` when reality disagrees. Handles windows wrapping
past midnight; skips unresolvable/symbolic timespecs rather than guessing.

`updateScheduleMode`'s mode↔job mapping was verified to match `main` exactly
(`summer`→`handleMorningStart`/`handleEveningStop`, `winter`→`handleNightStart`/`handleNightStop`),
so this logic ported unchanged.

## Fail-loudly self-check

The throttle depends on wrapping `Shelly.call`. If that ever stops working the counter stays 0, the
throttle goes inert, and the crash returns — while every emulator test still passes, because goja
permits a reassignment a device might refuse. Failing open and silently is the dangerous case, so it
is asserted: both failure modes (wrapper never installed; installed but zero calls tracked) print a
diagnostic naming the cause, the consequence and an explicit "read issue #421 first", and emit a
`pool.call_tracking_broken` notice event. A healthy boot logs a positive confirmation, so silence is
never ambiguous.

Uses `print()` rather than `log()` (which is gated on `CONFIG.enableLogging` and would hide it in
production), in short lines because the device truncates UDP debug output at ~128 chars.

Verified on the production Pro1 from the `main` variant of this change: `Tracking OK (#421): seen 33
max 4`.

## Emulator + tests

Ports the concurrent-call ceiling and artificial completion delay to `pkg/shelly/script`
(`DeviceTestMode` only) so the crash is reproducible without hardware — the minimal slice of #250
needed here.

v0.11.x has no runtime-accounting hooks (`persistRuntimeState`, turnover tracking are `main`-only),
so `main`'s reproduction does not apply. A new one drives a burst of raw `switch:0` state events,
which synchronously trigger `saveState()` → two queued `storeValue()` calls each — the same call
sites named in the live crash dumps. Confirmed it genuinely crashes with "Too many calls in
progress" against the throttle-removed script and passes with the fix in place.

## Size

Minified `pool-pump.js`: 30409 → 32020 bytes (+1611). Kept under budget partly by dropping
`CONFIG_SCHEMA`'s unused `description` fields — verified safe: `tools/extract-pool-defaults` matches
`fieldName:\s*\{[^}]*default:\s*...` and never reads `description`, and
`pool_defaults_generated.go` still generates correctly during `make test`.

For context this device has ~23 KB of shared JS heap and v0.11.9 currently runs at `mem_peak 17234`
with ~12 KB free, so there is ample room.

## Test plan

- [x] `make generate && make build`
- [x] `make test` — **46 packages ok, 0 failures**, matching v0.11.x's own baseline (not `main`'s 47;
      measured on the branch point before any changes, and re-verified independently by the reviewer)
- [x] New Bug A reproduction fails without the fix, passes with it
- [x] Zero "solar" occurrences in `pool-pump.js`
- [ ] Device verification on the real pump after merge
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): bound in-flight RPCs and catch up on restart (#421) ([acddc17](https://github.com/asnowfix/home-automation/commit/acddc175e4bb1ea8b2d3adf21a35748912999b7b))
<!-- END-AUTO-GENERATED-COMMITS -->