### PR TITLE
docs: JS heap allocation guide + costed pool-pump proposal (#433)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -649,6 +649,11 @@ myhome ctl shelly call -B tcp://<broker>:1883 -T 60s <device> Script.GetStatus '
 **Rule of thumb**: aim for `mem_free` ≥ ~5 KB steady-state. A script that boots with 1–2 KB free is
 one allocation away from `out_of_memory` and will die unpredictably later.
 
+**Full guide**: `docs/shelly-heap-allocation.md` — where the heap goes, allocation sources ranked by
+cost, the preallocate-at-load technique, ES5-legal before/after snippets, a Q&A, and the open
+questions that still need hardware. `docs/433-pool-pump-heap-proposal.md` applies it to
+`pool-pump.js` as a prioritised change list.
+
 #### Measuring one script's footprint (differential method)
 
 Because the heap is shared, no API reports a single script's cost directly. Measure it by

--- a/docs/433-pool-pump-heap-proposal.md
+++ b/docs/433-pool-pump-heap-proposal.md
@@ -1,0 +1,440 @@
+# Heap Proposal for `pool-pump.js` — closing issue #433
+
+**Purpose**: a prioritised, specific change list that makes `internal/shelly/scripts/pool-pump.js`
+fit the Shelly Pro1's JS heap **with the #405 solar path enabled**, which is what issue #433 blocks
+on today.
+
+**Method and rationale**: [`shelly-heap-allocation.md`](shelly-heap-allocation.md). Read at least
+its §0 and §6 before acting on anything here — every estimate below rests on the allocation model
+described there, and on a static→resident conversion ratio derived from a single measurement.
+
+**This document is analysis only. No `.js` or Go source was changed.** Implementation is a separate,
+reviewed task.
+
+**Related**: #433 (this problem), #421 / PR #426 (the crash fix and the allocation-over-size lesson),
+PR #430 (esbuild top-level mangling), #403 (the daemon aggregator publishing the solar payload),
+#401 / #406 (the campaign this unblocks).
+
+---
+
+## 1. The bar to clear
+
+Measured on the production Pro1 `filtration-hiver` (`shellypro1-ec62608c0230`, fw 2.0.0) with
+`watchdog.js` resident and the production 24-key KVS config, per #433 and `AGENTS.md`:
+
+| build | solar | minified | `mem_peak` | `mem_free` | result |
+|---|---|---|---|---|---|
+| v0.11.9 (no solar code at all) | n/a | 30409 | 17234 | 11956 | comfortable |
+| `main` @ `ae4c5da` | disabled | 36155 | 22330 | 10276 | runs, ~700 B headroom |
+| PR #426 (#421 fix) | disabled | 37739 | 21350 | 6398 | stable overnight |
+| PR #426 | **enabled** | 37739 | 22274 **and climbing** | — | **`out_of_memory`** |
+| PR #430 mangling, on `main` | disabled | 31010 | 21686 | 12040 | runs |
+
+Total heap is **~23030 bytes**, shared device-wide.
+
+(The v0.11.9 row is quoted from #433. `AGENTS.md` "JS Heap Budget" records the same build as
+`mem_peak` 17136 / `mem_free` 12068 — a ~100 B discrepancy between two separate readings of the
+same build, which is a useful reminder that a single reading has noise of that order. Treat
+differences under ~200 B as not measured.)
+
+**The gap.** Death occurs at ~23030. The solar build was last seen at 22274 and rising, so the
+minimum saving is **≥800 B of peak** just to survive — but surviving at 22.5 KB is not a fix, it is
+the same lottery #421 already lost twice. `AGENTS.md`'s rule of thumb is `mem_free` ≥ 5 KB at idle.
+
+> **Target: `mem_peak` ≤ 20000 with solar enabled — a saving of ~2.5–3.5 KB.**
+
+Note what the table already tells you: PR #426 has **higher** resident use than `main` (16632 vs
+12754) yet a **lower** peak (21350 vs 22330). That is the `CALL_SLOTS` trade — +3878 resident bought
+−980 peak — and it is the shape every recommendation below tries to copy.
+
+---
+
+## 2. What enabling solar actually adds
+
+Per #433, setting `script/pool-pump/solar-enabled=true` adds, at
+`internal/shelly/scripts/pool-pump.js`:
+
+1. `MQTT.subscribe("myhome/energy/solar/available", onSolarAvailable)` — `:1554`
+2. the retained `SOLAR` state object — `:1522`
+3. a 30 s tick timer running `checkSolarHysteresis` — `:2293`
+4. `JSON.parse(message)` on every message, ~60 s cadence — `:1534`
+5. transitively, `computeFlowRate()` **twice per evaluation** via `solarHardCeilingReached()` and
+   `solarSoftTargetReached()` — `:1561`, `:1570`
+
+Item 5 is not listed in #433 and is the cheapest real allocation in the set.
+
+---
+
+## 3. Ranked proposal
+
+Ranked by (estimated saving ÷ risk). "Peak effect" is the estimated movement in `mem_peak`, which is
+the number that decides survival; where a change is primarily a residency reduction that happens to
+sit inside the peak window, that is stated.
+
+Estimation conventions, so the numbers can be argued with:
+- Static byte savings are converted to resident at the **0.34** ratio measured in PR #430
+  (−5145 minified → −1764 `mem_used`). Unique string-literal data may convert closer to 1:1; where
+  that matters the range spans both models.
+- Per-object costs assume a property cell of ~20–24 B and an object cell of ~8 B, typical of a
+  32-bit NaN-boxed embedded engine. **Unverified** — see `shelly-heap-allocation.md` §8.
+
+### P1 — Delete `description:` from `CONFIG_SCHEMA`; keep the text as `//` comments
+**Rank 1. Largest single saving, essentially zero risk.**
+
+- **Site**: `pool-pump.js:37–217`, the 28 entries of `CONFIG_SCHEMA`.
+- **Mechanism**: 28 property cells plus ~1.5 KB of literal string data vanish from an object that is
+  alive for the **entire 24-key async KVS load** — precisely the window in which `mem_peak` is set.
+  Comments are stripped before upload, so the documentation still reaches every human reading the
+  source and costs the device nothing.
+- **Evidence it is dead weight**: the only `.description` access anywhere in
+  `internal/shelly/scripts/` is `heater.js:418–421`, which *deletes* them
+  (`CONFIG_SCHEMA[name].description = null;` — "Drop description strings now that config is loaded").
+  Nothing ever reads one. `tools/extract-pool-defaults/main.go` regexes only `default:` out of the
+  *source text*, never the runtime object, and nothing in `internal/`, `myhome/` or `pkg/`
+  references the field.
+- **Independent corroboration**: someone already found this lever and applied the weaker form of it
+  in `heater.js`. Nulling after load is strictly dominated by deleting outright, because it still
+  pays the full cost **during** the load — which on `pool-pump.js` is exactly the peak window — and
+  still pays the bytecode cost forever. Deleting is also less code.
+- **Estimate**: ~2.0 KB of minified source removed. Resident saving **−700 B** (conservative, at the
+  0.34 ratio) to **−2300 B** (if descriptions materialise as owned property strings). Peak effect
+  equals the resident saving here, because the object is live at peak. **Take −1200 B as the
+  planning figure.**
+- **Risk**: **very low.** No behavioural surface. Also applies to `garden.js` (−434 B of text) and
+  `heater.js` (−394 B) for free.
+- **Verdict**: **do it first.** Best ratio in the list by a wide margin.
+
+### P2 — Stop `JSON.parse`ing switch-status payloads, and stop self-subscribing
+**Rank 2. Largest recurring transient in the script, and it exists on `main` too.**
+
+- **Sites**: `parseSwitchStatus` `:1636–1646`; `subscribePro1Status` `:1658–1667`;
+  `subscribePro3Status` `:1688–1699`; the `topic.split(":")` in `onPro3StatusMessage` `:1675`.
+- **Mechanism**: a Shelly `status/switch:N` payload is a full component status — `id`, `source`,
+  `output`, `apower`, `voltage`, `current`, `aenergy{total, by_minute[3], minute_ts}`,
+  `temperature{tC, tF}` — roughly 200–250 characters. `JSON.parse` materialises ~4 objects and
+  ~15–18 property cells (~450–550 B) plus parser temporaries, on **every** message, **to read one
+  boolean**. Replace with two `indexOf` probes (`shelly-heap-allocation.md` §5.2) which allocate
+  nothing, and replace `split(":")` with `lastIndexOf`/`slice` (§5.4).
+- **Multiplier**: `docs/pool-pump.md:387` documents that `ctl pool add` writes both `pro3-id` and
+  `pro1-id` on every device, so **each device subscribes to 4 peer status topics including its
+  own** — a Pro1 parses its own switch status plus 3 Pro3 channels. The self-subscription is pure
+  waste on both device types and can simply be skipped when the peer id equals `STATE.myDeviceId`.
+- **Estimate**: **−450 to −550 B of transient per message**, times ~4 subscriptions at roughly
+  1 msg/min each (see §5 open questions — this cadence is assumed, not measured). Peak effect
+  **−300 to −800 B**; take **−500 B**. Dropping the self-subscription additionally removes 1 of 4
+  message streams outright.
+- **Risk**: **low**, with two things to get right: (a) the substring probe must not be fooled by
+  another field literally containing `"output":true` — no such field exists in a Shelly switch
+  status, but assert it in the emulator test against captured real payloads; (b) the probe must
+  return `null` on no match so the caller ignores the message, exactly as the `JSON.parse` version
+  does on a parse failure. Fail closed, never guess.
+- **Verdict**: **do it.** Note this benefits the solar-disabled build too, so it also buys margin
+  back for PR #426 independently of #433.
+
+### P3 — Remove the per-call object literal in `computeFlowRate()`
+**Rank 3. Small but free, and it sits directly on the path #433 blames.**
+
+- **Site**: `pool-pump.js:1924–1929`.
+- **Mechanism**: `var speedRpms = {eco:…, mid:…, high:…, max:…}` allocates 1 object + 4 property
+  cells (~100 B) on every call, purely to look up one number. Callers:
+  `computeTurnoverToday` `:1053` (every runtime checkpoint, 60 s while running),
+  `solarHardCeilingReached` `:1561` and `solarSoftTargetReached` `:1570` (both reachable on every
+  solar tick *and* every solar message), `computeRunHours` `:1933`. With solar enabled and the pump
+  running, that is up to 3 allocations per 30 s window. Replace with an `if`/`else` chain
+  (`shelly-heap-allocation.md` §5.1).
+- **Estimate**: **−100 to −300 B** of peak; take **−200 B**.
+- **Risk**: **very low.** Pure refactor; `pool_pump_test.go` already exercises the run-hours and
+  turnover arithmetic.
+- **Verdict**: **do it.**
+
+### P4 — Drop `sources` from the solar payload (daemon-side)
+**Rank 4. Free and correct, but #433 over-rates it as "cheapest first".**
+
+- **Site**: `myhome/daemon/solar_aggregate.go:37–41` (`SolarAvailablePayload.Sources`) and
+  `:127–151` (`buildPayloadLocked`).
+- **Mechanism**: the live payload measured in #433 is
+  `{"available_w":60,"ts":1785908472,"sources":[{"name":"beem","watts":60,"stale":false}]}` — **87
+  bytes**. Without `sources` it is `{"available_w":60,"ts":1785908472}` — **34 bytes**. The device
+  therefore holds 53 fewer bytes of message string, and `JSON.parse` builds 2 fewer objects, 5 fewer
+  property cells and 2 fewer owned key strings (~140 B). The struct's own doc comment already says
+  `Sources` is "Not consumed by pool-pump.js today — informational only."
+- **Estimate**: **−150 to −250 B of transient per message**; peak effect **−100 to −200 B**.
+- **Risk**: **zero on the device** — a pure daemon change. The only cost is observability, fully
+  recoverable by publishing `sources` on its own topic (e.g. `myhome/energy/solar/sources`,
+  retained) so `mosquitto_sub` and the web UI keep working. Preferable to a config flag: no new
+  option to document in four files.
+- **Verdict**: **do it, and expect little.** #433 lists it first on cost, which is right — it is
+  free. But it is **not** a fix on its own: it is at best a quarter of the minimum ≥800 B gap.
+  Doing it and stopping there is the exact mistake #421 made when it trimmed 1519 bytes and still
+  OOM'd.
+
+### P5 — Parse only `available_w` and `ts`; no `JSON.parse` on the solar path
+**Rank 5. Completes P4; together they make the solar message path allocate almost nothing.**
+
+- **Site**: `onSolarAvailable` `:1531–1550`.
+- **Mechanism**: the parsed object is read twice and dropped two statements later. Two `indexOf` +
+  `slice` + `Number` extractions allocate only short strings; hoist the two search keys
+  (`'"available_w":'`, `'"ts":'`) to module-level constants so even those are allocated once
+  (`shelly-heap-allocation.md` §5.3).
+- **Estimate**: with P4 also applied, **−70 to −120 B/message**; without P4, **−200 to −350
+  B/message**. Peak effect **−100 to −200 B**; take **−150 B**.
+- **Risk**: **low-medium.** The parser must tolerate integer and float formatting, key order,
+  absent keys, and must **fail closed**: on a failed extraction leave `SOLAR.publishedTs` untouched
+  so the existing staleness check at `:1586` takes over and the forecast schedule keeps running —
+  which is exactly what the current `catch` path does. Mitigations: an emulator test over several
+  payload shapes, plus a Go test in `myhome/daemon` asserting the marshalled shape the device parser
+  expects, so the two cannot drift.
+- **Verdict**: **do it, together with P4 and not before it** — P4 shrinks what P5 has to handle.
+
+### P6 — Reuse a preallocated object for the parsed solar reading
+**Verdict: do NOT do this. Recorded so it is not re-proposed.**
+
+`SOLAR` already stores plain numbers (`availableW`, `lastMsgTs`, `publishedTs`, `aboveStartSince`,
+`belowStopSince`) — **nothing parsed is retained**. Once P5 removes `JSON.parse` there is no parsed
+object left to pool. Adding a pool here would add resident cost for zero transient saving, which is
+the `CALL_SLOTS` trade run backwards. #433's suggestion 3 phrases this as "avoid retaining parsed
+objects"; the script already does not.
+
+### P7 — Reduce `log()`'s cost
+**Rank 6 as code; rank 0 as an experiment.** Three separable pieces.
+
+- **P7a — set `script/pool-pump/logging` to `false` on the Pro1 and re-measure.** One KVS key,
+  instantly reversible, no code change. `log()` returns before building any string
+  (`:511`), so all 154 call sites become nearly free. **This is the cheapest available experiment
+  and should be run before writing any code**, because it isolates how much of the peak is
+  log-string churn and therefore how much of P7b/P7c is worth doing.
+  Estimate: unknown; plausibly **−500 to −2000 B**, dominated by the ~200 log calls during init,
+  which is where the peak is set. Risk: **very low** (loses production visibility until re-enabled).
+- **P7b — fix the three call sites that do work eagerly**: `:2378` and `:2381` call
+  `JSON.stringify(info)` *before* `log()` can decide to discard it; `:884` does the same for
+  `config`. Pass the object and let `log()` stringify it only when it will print
+  (`shelly-heap-allocation.md` §5.5). Also the 8 call sites that concatenate with `+`.
+  Estimate **−100 to −300 B**; risk **very low**.
+- **P7c — rewrite `log()` to drop the `s +=` accumulator.** Each `+=` allocates a new immutable
+  string; a `k`-argument call allocates ~`2k−1` intermediates totalling O(n²/2) bytes. `print()`
+  accepts multiple arguments (already used at `:527`), so dispatching on `arguments.length` for the
+  common 1–4 arity cases removes the accumulator entirely.
+  Estimate **−100 to −400 B**; risk **medium** — it changes log formatting and separator behaviour,
+  so gate it behind a test that pins the output of representative calls.
+
+### P8 — Delete the unreachable `createSchedules()`, `clearNonUpdateSchedules()`, `loadValue()`
+**Rank 7. Free residency, but verify the runbook first.**
+
+- **Sites**: `:1715–1778`, `:1780–1867`, `:582–599`.
+- **Mechanism**: none of the three is called from anywhere in `pool-pump.js`, and the pool's
+  schedules are created **Go-side** by `internal/myhome/shelly/script/pool.go:391`. A repo-wide
+  search finds external `Script.Eval("clearNonUpdateSchedules(function(){createSchedules(null)})")`
+  only for **`garden.js`**, at `myhome/ctl/garden/setup.go:188` — nothing equivalent for the pool.
+  ~3.4 KB raw / ~1.3 KB minified of bytecode that can never run.
+- **Estimate**: **−300 to −500 B** resident at the 0.34 ratio; take **−350 B**. No transient effect.
+- **Risk**: **low**, with one check: confirm no human runbook or `docs/` procedure invokes them by
+  hand before deleting. If in doubt, delete `loadValue()` (unambiguously dead) and keep the other
+  two pending confirmation.
+- **Also worth checking locally, no device needed**: whether PR #430's esbuild IIFE wrapper already
+  tree-shakes them, which would make this change free of source churn.
+
+### P9 — Lengthen or condition the solar tick
+**Rank 8. Small, safe, and reduces the chance of a bad coincidence.**
+
+- **Site**: `:2292–2294`.
+- **Mechanism**: the tick exists only so staleness is noticed when messages stop arriving. Staleness
+  is judged against `CONFIG.solarStaleMs` (default **300000 ms**), so a 30 s tick is 10× finer than
+  the decision it feeds. Raising it to 60–120 s cuts tick-driven allocation proportionally and eases
+  the 5-timer budget.
+- **Estimate**: **−50 to −150 B** of peak (mostly realised via P3); take **−80 B**.
+- **Risk**: **very low.** Worst case a stale-solar stop is noticed up to 2 minutes later — well
+  inside the 10-minute `solarStopDelayMs`.
+
+### P10 — Remove per-tick closures from the task-queue path
+**Rank 9 overall, but its first sub-item is rank ~1 by ratio.**
+
+- **Sites**: `queueTask` `:448`, `processTaskQueue` `:429`, and ~20 `queueTask(function () { ... })`
+  call sites. Recurring ones: `persistRuntimeState` `:1040`, `:1043` (two closures every 60 s while
+  running); `saveState` `:937`, `:945`; `turnOffAllSwitchesNext` `:1113` and
+  `turnOffOtherOutputsNext` `:1157` (one per switch per transition).
+- **P10a — the free subset.** Roughly a dozen sites are `queueTask(function () { cb(); })`, where
+  `cb` takes no arguments and `processTaskQueue` invokes tasks with no arguments: `:631`, `:637`,
+  `:647`, `:657`, `:689`, `:697`, `:717`, `:720`, `:724`, `:730`, `:738`, `:1874`, `:1899`. These
+  are `queueTask(cb)` with identical behaviour and no allocation.
+  Estimate **−100 to −250 B**; risk **very low**. **Do this one early.**
+- **P10b — the contract change.** Give `queueTask` an optional single argument stored in a parallel
+  preallocated array, so recurring callers pass a named top-level function plus a value instead of
+  a closure (`shelly-heap-allocation.md` §5.6). Note that `TASK_QUEUE` is only reset when it fully
+  drains (`:436`), so during a burst **every** queued closure is alive simultaneously — this is the
+  same shape of problem `CALL_SLOTS` solved on the RPC side.
+  Estimate **−150 to −400 B**; risk **medium** — touches ~20 call sites and the queue contract,
+  which PR #426 also modifies. Sequence it *after* PR #426 lands, behind that PR's emulator tests.
+
+### P11 — Precompute the KVS key strings used on recurring paths
+**Rank 10.**
+
+- **Sites**: `storeValue` `:567–580`; callers `:938`, `:946`, `:1041`, `:1044`.
+- **Mechanism**: every write concatenates `CONFIG_KEY_PREFIX + key` afresh and builds a
+  `{key, value}` params object plus a `String(value)`. `persistRuntimeState` does this twice every
+  60 s while the pump runs, forever. Hoist the full key strings for `runtime-sec`,
+  `turnover-today`, `active-output` and `schedule-mode` to module-level `var`s built once at load.
+- **Estimate**: **−100 to −250 B**; take **−150 B**.
+- **Risk**: **low** for the key hoisting. Reusing a single preallocated `params` object would remove
+  more, but depends on the firmware serialising `params` synchronously at call time — **unverified**
+  (see §5.4 below). Do not ship that half without the experiment.
+
+---
+
+## 4. Is #433 achievable by allocation work alone?
+
+### 4.1 The arithmetic
+
+| item | planning estimate | risk |
+|---|---:|---|
+| P1 — drop `description:` from `CONFIG_SCHEMA` | −1200 B | very low |
+| P2 — no `JSON.parse` of switch status; no self-subscription | −500 B | low |
+| P3 — `computeFlowRate` literal | −200 B | very low |
+| P4 — drop `sources` (daemon-side) | −150 B | zero (device) |
+| P5 — no `JSON.parse` on solar path | −150 B | low-medium |
+| P7b — eager work at `log()` call sites | −200 B | very low |
+| P8 — delete unreachable functions | −350 B | low |
+| P9 — 30 s → 60–120 s solar tick | −80 B | very low |
+| P10a — `queueTask(cb)` trampolines | −175 B | very low |
+| P10b — `queueTask` argument passing | −275 B | medium |
+| P11 — hoist recurring KVS key strings | −150 B | low |
+| **subtotal, code changes only** | **≈ −3430 B** | |
+| P7a — logging off in production (config, not code) | −800 B? | very low |
+| PR #430 mangling on the #426 build (37739 → 31318) | ≈ −800 B peak, ≈ −2200 B resident | medium (unverified on device) |
+
+Plausible range on the code-only subtotal: **−2.0 KB (pessimistic) to −5.5 KB (optimistic)**.
+
+### 4.2 Verdict
+
+**Yes — #433 looks achievable by allocation and residency work alone, but only if most of the list
+lands, and the margin is not comfortable.** The planning subtotal (~3.4 KB) is about equal to the
+target saving (~2.5–3.5 KB), which means the pessimistic case falls short.
+
+Three honest caveats:
+
+1. **The largest single item, P1, is a residency reduction, not an allocation one.** The guide's own
+   thesis says allocation has the better leverage — and P2, P3, P5, P9, P10 and P11 are all
+   allocation work — but the biggest single number here comes from deleting 1.5 KB of documentation
+   strings that happen to be alive during the peak window. Both levers are needed.
+2. **The estimates rest on an unverified engine model.** Every per-object figure assumes property
+   cells of ~20–24 B and objects of ~8 B. If the engine turns out to store literal strings as
+   pointers into bytecode rather than owned heap strings, P1 shrinks toward its −700 B floor and the
+   subtotal drops to ~2.9 KB. `shelly-heap-allocation.md` §8.1 and §8.2 settle this with two
+   uploads.
+3. **Measure each item.** #421 burned two iterations on plausible-but-worthless changes. Land these
+   in the order given, one measurement per item, appending rows to #433's table. If the running
+   total reaches ≤20000 with solar on, stop — the rest is not needed.
+
+**Recommended sequence**: P7a (experiment, no code) → P1 → P10a → P3 → P7b → P2 → P8 → P4 → P5 →
+P9 → P11 → P10b. Re-measure after each. Stop when `mem_peak` ≤ 20000 with solar enabled.
+
+### 4.3 If measurement falls short — structural options
+
+**S1 (recommended fallback): publish a *decision*, not a *measurement*.**
+
+Move the hysteresis into the daemon, which already owns the Beem poll, the thresholds and every
+timer it needs, and have the aggregator publish a retained, **JSON-free** payload on a new topic —
+e.g. `myhome/energy/solar/pump` carrying `1,1785908472` (decision, unix seconds). The device side
+collapses to roughly:
+
+```js
+function onSolarPump(topic, message) {
+  var c = message.indexOf(",");
+  if (c < 1) return;
+  var ts = Number(message.slice(c + 1)) * 1000;
+  if (Date.now() - ts > CONFIG.solarStaleMs) return;   // stale: schedule keeps running untouched
+  if (message.charAt(0) === "1") doStart(CONFIG.preferredSpeed, "Solar");
+  else doStop("Solar");
+}
+```
+
+What this removes from the device: the `SOLAR` object, `checkSolarHysteresis`,
+`solarHardCeilingReached`, `solarSoftTargetReached`, the 30 s tick timer, the `JSON.parse`, and
+**six of the 28 KVS config keys** (`solar-start-w`, `solar-stop-w`, `solar-start-delay`,
+`solar-stop-delay`, `solar-min-turnover`, `solar-max-turnover`) — which also shrinks `CONFIG_SCHEMA`
+and, more importantly, shortens the boot-time KVS load burst that sets the peak. Estimated total:
+**the whole ≥800 B solar delta, plus whatever six fewer config keys are worth** (the 5→24-key
+measurement implies ~400 B/key, though that figure predates the `CALL_SLOTS`/`userdata` rework and
+is probably much smaller now — see `shelly-heap-allocation.md` §8.6).
+
+The daemon needs `runtimeTodaySec` to evaluate the turnover targets — it already has it: the script
+mirrors `runtime-sec` and `turnover-today` to KVS for exactly this reason (`:1041`, `:1044`, and
+`myhome/daemon/pool_notices.go`).
+
+**Degraded mode**, which `CLAUDE.md` requires to be stated explicitly in the PR: if the daemon dies,
+the retained decision goes stale, the device ignores it, and the **entirely on-device**
+forecast-driven schedule continues unchanged. That is *identical* to today's behaviour — the current
+`checkSolarHysteresis` already returns early on staleness (`:1586–1590`). No local capability is
+lost. What moves off-device is only the solar *overlay*, whose input (the Beem reading) comes from
+the daemon in the first place and is unavailable without it either way.
+
+This does partially walk back #405's stated intent of putting the hysteresis on the device, so it
+needs the maintainer's decision, not an implementer's.
+
+**S2: split the solar path into a second script — do NOT do this.**
+
+The heap is one device-wide pool; that is the premise of #433 itself. A second script adds a second
+VM context, its own bytecode, its own copies of `log`, `storeValue`, KVS access and config loading,
+and would need IPC (KVS or MQTT loopback) to reach `doStart`/`doStop`. It **increases** total heap
+use. Recorded here explicitly so it is not proposed again.
+
+The one variant that does work is the inverse — move something *else* off the Pro1, e.g. stop
+`watchdog.js` (measured at 2156 B on a Plus 1, quoted as 3554 B in PR #426). That is PR #426's
+option 1, it is a production behaviour change, and it trades pump *reliability* (watchdog handles
+MQTT-failure reboots and firmware updates) for pump *features*. Not recommended.
+
+**S3: shrink the device's config surface generally.**
+
+28 KVS keys is a lot, and the 5→24-key measurement makes keys the most expensive unit of function on
+this hardware. Several are effectively installation constants: `eco-rpm`, `mid-rpm`, `high-rpm`,
+`max-rpm`, `max-flow-rate`, `pool-volume`, `max-temp`. Packing them into one key
+(`pump-spec = "31,2900,2000,2600,2900,46,35"`, parsed once at load with `indexOf`/`slice`) turns 7
+round-trips into 1. Estimated **−6 KVS round-trips of load-burst garbage**; risk **medium** — CLI,
+`docs/configuration.md`, `myhome-example.yaml` and the generated defaults all change, and it makes
+the config less legible via `KVS.GetMany`. Only worth it if P1–P11 and S1 both fall short.
+
+---
+
+## 5. What could not be verified without hardware
+
+No device access was available while producing this document. In addition to the general list in
+`shelly-heap-allocation.md` §8, these are specific to this proposal:
+
+### 5.1 Every per-item byte estimate
+**Claim**: the figures in §3 and §4.1.
+**Confidence**: order-of-magnitude only. They rest on assumed cell sizes and on a single measured
+static→resident ratio (0.34).
+**Experiment**: the sequence in §4.2 — one change per upload, `Script.Stop`/`Start`, record
+`{mem_used, mem_peak, mem_free}` and minified size, append to #433's table. This is the only thing
+that turns these estimates into facts.
+
+### 5.2 P1's size — do the `description:` strings actually occupy heap?
+**Claim**: −700 B (conservative) to −2300 B (if owned strings).
+**Experiment**: `shelly-heap-allocation.md` §8.2 — upload a control variant with 4 KB of unreferenced
+string-literal padding and diff `mem_used`. Settles the whole 0.34-vs-1.0 conversion question, which
+moves the §4.1 subtotal by ~1.6 KB.
+
+### 5.3 P2's multiplier — status message size and cadence
+**Claim**: ~200–250 bytes per `status/switch:N` payload, roughly one per minute per channel, times
+4 subscriptions.
+**Experiment**: `mosquitto_sub -t 'shellypro1-ec62608c0230/status/switch:0' -v` (and the three Pro3
+channels) for five minutes; count messages and bytes. Broker-only, no device write. If the real
+cadence is once per *state change* rather than once per minute, P2 drops several ranks and P1
+becomes the only item that matters.
+
+### 5.4 P11's second half — can one `params` object be reused across `Shelly.call`s?
+**Claim**: the firmware serialises `params` synchronously at call time.
+**Experiment**: two back-to-back `KVS.Set` calls reusing one mutated params object with different
+key/value pairs; confirm both keys land correctly. Do not ship the reuse without this.
+
+### 5.5 Whether the peak is set during init at all
+**Claim**: `mem_peak` for `pool-pump.js` is set during the boot sequence (24-key KVS load + 4-step
+`initSteps` + `applyComponentNames` + `verifySchedules`), which is why P1's peak-window argument
+works and why P7a is expected to be large.
+**Evidence for**: `main` peaks at 22330 while idling at `mem_used` 12754 — a ~9.6 KB gap that has to
+come from a burst, and init is the largest one. But #433 reports the solar build's peak "climbing"
+*after* boot, which suggests at least one later contributor.
+**Experiment**: poll `Script.GetStatus` every 2 s from `Script.Start` for the first 60 s and plot
+`mem_peak`. If it saturates during init, target init; if it keeps climbing hours later, there is a
+leak or a slow accumulation that none of P1–P11 addresses, and that becomes the priority instead.
+**This experiment should be run before the change sequence, alongside P7a.** It is the cheapest way
+to discover that the whole ranking above is aimed at the wrong window.

--- a/docs/shelly-heap-allocation.md
+++ b/docs/shelly-heap-allocation.md
@@ -1,0 +1,759 @@
+# Reducing JS Heap Use in Shelly Device Scripts
+
+A practical guide to fitting scripts into a Shelly Gen2 device's JavaScript heap, grounded in this
+repo's own hardware measurements (issues #421, #429, #433; PRs #426, #430).
+
+**Companion document**: [`433-pool-pump-heap-proposal.md`](433-pool-pump-heap-proposal.md) — the
+concrete, prioritised change list for `pool-pump.js` that this guide's method produced.
+
+**Prerequisites**: `AGENTS.md` sections "JS Heap Budget", "Measuring one script's footprint
+(differential method)", "Testing memory on a spare device", "Resource Limits", "Resource Limit
+Workarounds", "Data Storage Patterns"; `CLAUDE.md` "Shelly JavaScript" for the ES5/engine
+constraints every snippet here obeys.
+
+---
+
+## 0. The one-paragraph version
+
+A Shelly Gen2 device has **one JavaScript heap of ~23030 bytes shared by every script on it**
+(measured identically on a Pro1 at fw 2.0.0 and a Plus 1 at fw 1.7.5). What kills a script is not
+how much memory it holds steadily — it is **`mem_peak`**, the high-water mark of live data *plus*
+uncollected garbage. Two measurements in this repo say the same thing: trimming **1519** minified
+bytes moved the peak by **zero**, while replacing **one** per-call closure with a fixed pool moved
+it by **~1050 bytes** and turned an `out_of_memory` into a working script. Therefore: **hunt
+allocation, not bytes.** Preallocate at load time and mutate in place; that trade is explicitly
+sanctioned in this repo, and PR #426 measured it converting **+3878 bytes of resident** footprint
+into **−980 bytes of peak** — a straight win, because only the peak decides survival.
+
+---
+
+## 1. Where the heap actually goes
+
+Three tenants share the ~23 KB. They behave completely differently, and conflating them is the
+single most common reason a size-reduction effort produces no result.
+
+### 1.1 Code residency (bytecode + literal data)
+
+The engine compiles your script to bytecode and keeps it resident for the script's lifetime, along
+with the string literals it references. This scales with **minified** source size — comments and
+whitespace are stripped before upload and cost nothing on-device.
+
+The conversion rate is poor. From PR #430's esbuild top-level mangling on `pool-pump.js` at `main`:
+
+| | minified | `mem_peak` | `mem_free` | implied `mem_used` |
+|---|---|---|---|---|
+| tdewolff (current) | 36155 | 22330 | 10276 | 12754 |
+| esbuild + top-level mangle | 31010 | 21686 | 12040 | 10990 |
+| **delta** | **−5145** | **−644** | **+1764** | **−1764** |
+
+(`mem_used` is derived: `mem_used + mem_free` reads ~23030 at any instant, confirmed by a raw
+reading of `{"mem_used":16632,"mem_peak":21350,"mem_free":6398}` in `AGENTS.md`.)
+
+So **~5.1 KB of source bought ~1.8 KB of resident and only ~0.6 KB of peak** — a static→resident
+conversion ratio of roughly **0.34**, and a static→peak ratio of roughly **0.13**. Use 0.34 as the
+default multiplier when estimating what a size cut is worth, and expect the peak effect to be
+about a quarter of that again.
+
+Caveat worth knowing: mangling shortens *identifiers*, which the engine may store once and
+reference repeatedly. **Unique literal data — long string constants — plausibly converts closer to
+1:1**, so removing 2 KB of string literals is likely worth more than removing 2 KB of identifiers.
+This is inferred, not measured; §7 gives the experiment that settles it.
+
+### 1.2 Retained state (the live set)
+
+Every object, array, string and closure your script still holds a reference to. This is what
+`mem_used` measures at an idle moment. It is the only tenant you can reason about by reading the
+code alone.
+
+Two non-obvious contributors dominate here in practice:
+
+- **Configuration schemas.** `pool-pump.js`'s `CONFIG_SCHEMA` is 28 entries × 4–6 properties, plus
+  ~1.5 KB of `description:` strings that **no code ever reads** (verified: no `.description` access
+  in any script; `tools/extract-pool-defaults` regexes only `default:` out of the *source*). It is
+  alive for the entire duration of the async KVS load — i.e. exactly during the peak window — and
+  only then set to `null`.
+- **KVS key count.** Measured on a Plus 1 running identical code: **5 keys → `mem_used` 13748; 24
+  keys → `out_of_memory`. ~7.9 KB of footprint was config-driven, not code-driven** (AGENTS.md
+  "Testing memory on a spare device"). 19 extra `CONFIG` properties and their value strings account
+  for maybe 600 bytes. The other ~7.3 KB is discussed in §1.4 — and it is the single most important
+  number in this document.
+
+### 1.3 Transient allocation (the garbage)
+
+Everything created and dropped inside a function: object literals, string concatenations, parsed
+JSON, closures passed to `Shelly.call`, arrays returned by `split()`. In a desktop JS engine this is
+free. Here it is not, for one reason: **garbage is not collected between statements.** The engine
+collects at safe points, and an async burst — 24 sequential `KVS.Get` round-trips, a 4-step init
+chain, a task queue draining 10 entries — can allocate a great deal before reaching one.
+
+`mem_peak` is therefore approximately:
+
+```
+mem_peak  ≈  max over all time of ( live set  +  garbage allocated since the last collection )
+```
+
+That formula is the whole guide. It explains why size cuts underperform (they shrink only the first
+term, weakly) and why removing one per-call allocation overperforms (it shrinks the second term by
+the *burst length* times the per-item cost).
+
+### 1.4 The arena probably never shrinks
+
+The 7.9 KB figure in §1.2 cannot be explained by 19 extra retained config values. The most likely
+explanation is that the engine's allocation arena **grows on demand and never gives memory back**.
+Under that model a transient burst does not merely risk a momentary `out_of_memory` — it
+**permanently raises the script's resident floor** for the rest of its life.
+
+If that is right, then `mem_used` is itself a high-water-mark-shaped quantity, transient allocation
+is even more expensive than the naive reading suggests, and "it settles down after boot" is false
+comfort. This is the highest-value open question in this document. §7.3 gives the experiment.
+
+**Status: inferred from the 5-vs-24-key measurement. Not verified. Do not cite as fact.**
+
+---
+
+## 2. Allocation sources, ranked by cost
+
+Ranked by observed or estimated cost *per occurrence × plausible frequency* in this repo's scripts.
+
+### 2.1 A closure created per call or per tick — worst by a wide margin
+
+A function value created at runtime is not just an object. It **captures its enclosing scope**,
+which pins that entire call frame — every local variable in it — alive for as long as the closure
+lives, and transitively pins the frames above it in the scope chain.
+
+This is the #421 finding, and it is the strongest evidence in the repo:
+
+> The original #421 fix wrapped every `Shelly.call` in a brand-new closure — one function object
+> per call, purely to decrement a counter. On a device already ~700 bytes from its ceiling, this
+> was the difference between `out_of_memory` and a working script. Replacing it with `CALL_SLOTS`
+> moved `mem_peak` **~1050 bytes below `main`'s own peak**.
+
+And the corroborating one: `main`'s `loadConfig` creates a fresh anonymous `KVS.Get` callback on
+every iteration of a 24-key sequential load. Each captures `key`, `schema`, `kvsKey` and, through
+the scope chain, `loadConfig`'s own frame. With prompt collection the difference between 5 and 24
+keys would be near zero. It was 7.9 KB.
+
+### 2.2 Object and array literals rebuilt per invocation
+
+```js
+// pool-pump.js:1924 — allocates 1 object + 4 properties on EVERY call,
+// to look up exactly one number.
+function computeFlowRate() {
+  var speedRpms = {eco: CONFIG.ecoRpm, mid: CONFIG.midRpm, high: CONFIG.highRpm, max: CONFIG.highRpm};
+  var rpm = speedRpms[CONFIG.preferredSpeed];
+  ...
+}
+```
+
+`computeFlowRate` is reached from the solar tick (every 30 s), from both solar target checks, and
+from every runtime checkpoint (every 60 s while the pump runs). The lookup table is rebuilt each
+time and discarded immediately.
+
+### 2.3 `JSON.parse` of a payload you barely use
+
+Parsing materialises the **whole** payload as an object graph — one object cell plus one property
+cell per key, recursively — and then you read one field and drop it all.
+
+The worst instance in this repo is not the one #433 names. `parseSwitchStatus` (`pool-pump.js:1636`)
+`JSON.parse`s a full Shelly `status/switch:N` payload — `id`, `source`, `output`, `apower`,
+`voltage`, `current`, `aenergy{total, by_minute[3], minute_ts}`, `temperature{tC, tF}` — in order to
+read **one boolean**. And per `docs/pool-pump.md:387`, every device subscribes to **four** peer
+status topics, *including its own* (a documented redundancy). See §7.5 for the measurement that
+would size this precisely.
+
+### 2.4 String concatenation, especially in a loop
+
+Strings are immutable. `s += x` allocates a brand-new string of the combined length and abandons the
+old one. A `k`-argument logging call therefore allocates roughly `2k−1` intermediate strings whose
+total size is **O(n²/2)** in the final length.
+
+```js
+// The accumulator pattern in every script's log() — pool-pump.js:510, garden.js:217, watchdog.js:31
+function log() {
+  if (!CONFIG.enableLogging) return;
+  var s = "";
+  for (var i = 0; i < arguments.length; i++) {
+    ...
+    s += String(a);          // new string every iteration
+    if (i + 1 < arguments.length) s += " ";   // and again
+  }
+  print(SCRIPT_PREFIX, s);
+}
+```
+
+Note that the early return protects the accumulator but **not the call site**. Anything you compute
+as an argument is computed whether or not logging is on:
+
+```js
+log("Unhandled component event:", JSON.stringify(info));   // pool-pump.js:2378 — always stringifies
+```
+
+### 2.5 Callbacks captured in `Shelly.call`
+
+Every `Shelly.call(m, p, function (res, err) { ... })` allocates a closure that stays alive for the
+whole RPC round-trip — which on this hardware is long. With up to 5 concurrent calls, up to 5
+closures and 5 pinned frames coexist. The fix is §3.2's `userdata` pattern.
+
+The `params` object is a second, unavoidable-looking allocation per call: `{key: PREFIX + k, value:
+String(v)}` is one object, two properties, and two fresh strings, every write.
+
+### 2.6 Timer callbacks and event-handler closures
+
+A timer callback registered once at load costs once. A timer *created per operation* costs per
+operation — and the 5-timer limit means you cannot do that anyway. The single-recurring-timer +
+task-queue pattern in `AGENTS.md` is already the right shape; the residual cost is that **every
+`queueTask(function () { ... })` call site allocates a closure**, and `pool-pump.js` has ~20 of
+them, several on recurring paths.
+
+### 2.7 `split()`, `slice()`, and friends
+
+`topic.split(":")` (`pool-pump.js:1675`, per MQTT message) allocates an array plus one string per
+piece. `lastIndexOf(':')` + `slice()` allocates one short string. Cheap to fix, small win, no risk.
+
+---
+
+## 3. Static/startup allocation is the preferred technique
+
+**Allocate once at load, then mutate in place.** This is explicitly allowed here, and the numbers
+justify it: PR #426's `CALL_SLOTS` traded **+3878 bytes of resident footprint for −980 bytes of
+peak** and turned a dead script into a live one. Resident is a fixed, predictable cost you pay once.
+Peak is a lottery you lose exactly once, at the worst possible moment, in production.
+
+### 3.1 The worked example — `CALL_SLOTS`
+
+From `fix/421-pool-pump-crash-catchup-and-heap:internal/shelly/scripts/pool-pump.js`, lightly
+abridged. Read it as a template, not as pool-pump-specific code.
+
+```js
+// Allocated ONCE at load. Sized to the device's real 5-call ceiling + 1 spare,
+// because calls fired straight from event/timer handlers bypass the task queue's throttle.
+var CALL_SLOTS = [];
+for (var CALL_SLOT_INIT_I = 0; CALL_SLOT_INIT_I < 6; CALL_SLOT_INIT_I++) {
+  CALL_SLOTS.push({cb: null, ud: null, used: false});
+}
+
+function acquireCallSlot(cb, ud) {
+  for (var i = 0; i < CALL_SLOTS.length; i++) {
+    if (!CALL_SLOTS[i].used) {
+      CALL_SLOTS[i].used = true;
+      CALL_SLOTS[i].cb = cb;
+      CALL_SLOTS[i].ud = ud;
+      return CALL_SLOTS[i];
+    }
+  }
+  // Never drop a callback: fall back to a fresh record if the pool is somehow exhausted.
+  return {cb: cb, ud: ud, used: true};
+}
+
+// ONE completion handler for the whole script. Not one per call.
+function sharedCallDone(result, error_code, error_message, slot) {
+  CALLS_IN_FLIGHT--;
+  var cb = slot ? slot.cb : null;
+  var ud = slot ? slot.ud : null;
+  if (slot) { slot.used = false; slot.cb = null; slot.ud = null; }
+  if (typeof cb === 'function') { cb(result, error_code, error_message, ud); }
+}
+
+// Fire-and-forget calls need no slot at all — this path allocates nothing per call.
+function decrementOnlyCallDone() { CALLS_IN_FLIGHT--; }
+
+var RAW_CALL = Shelly.call;
+Shelly.call = function (method, params, callback, userdata) {
+  CALLS_IN_FLIGHT++;
+  N_SEEN++;
+  if (typeof callback !== 'function') {
+    return RAW_CALL(method, params, decrementOnlyCallDone, null);
+  }
+  return RAW_CALL(method, params, sharedCallDone, acquireCallSlot(callback, userdata));
+};
+```
+
+Three properties make this work, and any pool you build should have all three:
+
+1. **Fixed size, allocated at load.** The loop runs once, at script start, when the heap is at its
+   emptiest and no other burst is in flight.
+2. **Claimed in place.** `acquireCallSlot` mutates an existing record; it does not build one.
+3. **Always released, on every path.** `sharedCallDone` decrements and frees the slot *before*
+   invoking the user callback, so a throwing callback cannot leak a slot.
+
+And one safety property worth copying verbatim: the fallback in `acquireCallSlot` **allocates rather
+than drops**. A memory optimisation must never be able to lose work.
+
+### 3.2 `userdata` — passing state without a closure
+
+`Shelly.call`'s fourth argument is handed back to the completion handler untouched. That is enough
+to replace almost every per-call closure with one shared named handler:
+
+```js
+// BEFORE — one fresh closure per key, capturing key/schema/kvsKey and, via the
+// scope chain, the entire enclosing loadConfig frame. 24 of these on a real boot.
+function loadNextKey() {
+  var key = configKeys[keyIndex];
+  var schema = CONFIG_SCHEMA[key];
+  var kvsKey = CONFIG_KEY_PREFIX + schema.key;
+  keyIndex++;
+  Shelly.call("KVS.Get", {key: kvsKey}, function (result, err) {
+    /* ...uses key, schema, kvsKey... */
+    queueTask(loadNextKey);
+  });
+}
+
+// AFTER — one handler for the whole load, defined once at top level.
+// Per-key context travels as userdata: a string that already exists, not a new allocation.
+var CONFIG_LOAD_KEYS = null;
+var CONFIG_LOAD_INDEX = 0;
+
+function loadNextConfigKey() {
+  if (CONFIG_LOAD_INDEX >= CONFIG_LOAD_KEYS.length) { finishLoadConfig(); return; }
+  var key = CONFIG_LOAD_KEYS[CONFIG_LOAD_INDEX];
+  CONFIG_LOAD_INDEX++;
+  var schema = CONFIG_SCHEMA[key];
+  Shelly.call("KVS.Get", {key: CONFIG_KEY_PREFIX + schema.key}, onConfigKVSResult, key);
+}
+
+function onConfigKVSResult(result, err, errMsg, key) {
+  var schema = CONFIG_SCHEMA[key];   // re-derive rather than capture
+  /* ... */
+  queueTask(loadNextConfigKey);      // a named function, not a closure
+}
+```
+
+Note the two secondary wins: the loop state moved to module-level `var`s (so there is no enclosing
+frame left to pin), and `queueTask` now receives a **named top-level function** instead of a fresh
+closure.
+
+**Prefer passing a key and re-deriving over passing a bundle.** `onConfigKVSResult` receives one
+string and looks the schema back up. Passing `{key: k, schema: s, kvsKey: x}` would have
+reintroduced a per-call object.
+
+### 3.3 Free memory explicitly when a phase ends
+
+`pool-pump.js` already does this and it is worth imitating:
+
+```js
+CONFIG_SCHEMA = null;    // after the KVS load completes — never needed again
+COMPONENT_NAMES = null;  // after component names are applied
+```
+
+Extend it to phase-scoped working state:
+
+```js
+var doneCb = CONFIG_LOAD_DONE;
+CONFIG_LOAD_KEYS = null;
+CONFIG_LOAD_MISSING = null;
+CONFIG_LOAD_DONE = null;
+doneCb(true);
+```
+
+---
+
+## 4. Retained-state reduction
+
+- **Never duplicate `CONFIG` into `STATE`.** Read `CONFIG.x` where you need it. A mirrored value is
+  a property cell, a string, and a correctness hazard.
+- **Prefer numeric codes to retained strings.** `STATE.scheduleMode` holds `"summer"`/`"winter"`
+  forever and is compared by value in five places; `0`/`1` with a `MODE_SUMMER = 1` constant is a
+  packed number. Small individually, but this pattern repeats.
+- **Drop anything recomputable.** `pool-pump.js` already does the hard version of this well: it
+  keeps `STATE.maxForecastTemp` and discards the 24-element hourly array
+  (`docs/pool-pump.md` "Weather Forecast (Memory-Optimized)"). Look for the same shape elsewhere.
+- **Delete documentation strings from runtime objects.** A `description:` field in a config schema
+  is read by humans reading the *source*. Make it a `//` comment: the minifier strips comments, so
+  the documentation reaches the reader and costs the device nothing. ~1.5 KB in `pool-pump.js`,
+  ~0.4 KB each in `garden.js` and `heater.js`. `heater.js:418–421` already does the weaker version
+  of this — `CONFIG_SCHEMA[name].description = null;` after the load — which is worth copying if you
+  must keep the field, but deleting it outright is strictly better: nulling still pays the full cost
+  *during* the load (the peak window) and still pays the bytecode cost forever.
+- **Treat every KVS key as expensive.** The 5→24-key measurement (§1.2) makes config keys the most
+  expensive unit of function on this hardware. Pack related constants into one key
+  (`"31,2900,2000,2600,2900"`, parsed once) rather than adding a key per knob, and mark keys the
+  script never reads at runtime `cliOnly: true` so the loader skips them entirely — `pool-pump.js`
+  already does this for `mqtt-topic` and `night-duration`.
+- **Delete dead code.** It is pure resident cost with zero benefit. In `pool-pump.js`,
+  `createSchedules()`, `clearNonUpdateSchedules()` and `loadValue()` are unreachable — the pool's
+  schedules are created Go-side by `internal/myhome/shelly/script/pool.go:391`. (`garden.js` is
+  different: `myhome/ctl/garden/setup.go:188` really does `Script.Eval` its copies. Check before
+  deleting.)
+
+---
+
+## 5. Anti-patterns, with before/after
+
+All snippets are ES5/Espruino-legal: `var` only, no arrow functions, every function defined before
+it is referenced, and no empty `catch (e) {}` (which becomes a syntax error after minification).
+
+### 5.1 Rebuilt lookup table
+
+```js
+// BEFORE — 1 object + 4 properties per call
+function computeFlowRate() {
+  var speedRpms = {eco: CONFIG.ecoRpm, mid: CONFIG.midRpm, high: CONFIG.highRpm, max: CONFIG.highRpm};
+  var rpm = speedRpms[CONFIG.preferredSpeed];
+  if (!rpm) rpm = CONFIG.highRpm;
+  return CONFIG.maxFlowRate * (rpm / CONFIG.maxRpm);
+}
+
+// AFTER — allocates nothing
+function speedToRpm(speed) {
+  if (speed === "eco") return CONFIG.ecoRpm;
+  if (speed === "mid") return CONFIG.midRpm;
+  return CONFIG.highRpm;              // "high", "max", and any unknown value
+}
+
+function computeFlowRate() {
+  return CONFIG.maxFlowRate * (speedToRpm(CONFIG.preferredSpeed) / CONFIG.maxRpm);
+}
+```
+
+If the table is genuinely constant, hoist it to a module-level `var` built once at load instead —
+that is the §3 trade, and it is fine.
+
+### 5.2 `JSON.parse` for one field
+
+```js
+// BEFORE — materialises the entire status payload to read one boolean
+function parseSwitchStatus(message) {
+  var data = null;
+  try {
+    data = JSON.parse(message);
+  } catch (e) {
+    if (e && false) {}
+    return null;
+  }
+  if (!data || !("output" in data)) return null;
+  return data.output;
+}
+
+// AFTER — allocates nothing; returns null when the field is absent, exactly as before
+function parseSwitchStatus(message) {
+  if (message.indexOf('"output":true') !== -1) return true;
+  if (message.indexOf('"output":false') !== -1) return false;
+  return null;
+}
+```
+
+**Only do this when you control or can pin the payload format.** Write a test that feeds real
+captured payloads through both versions and asserts identical results, and — where the producer is
+in this repo — a Go test asserting the marshalled shape the device parser expects. Fail closed: on
+no match, return `null` and let the caller ignore the message, never guess a default.
+
+### 5.3 Substring extraction instead of a full parse
+
+```js
+// Extract one numeric field without building an object graph.
+// Returns NaN when absent — callers must check, and must not act on NaN.
+function numField(message, key) {
+  var k = '"' + key + '":';
+  var i = message.indexOf(k);
+  if (i === -1) return NaN;
+  i = i + k.length;
+  var j = i;
+  while (j < message.length) {
+    var c = message.charAt(j);
+    if (c === "," || c === "}" || c === "]") break;
+    j++;
+  }
+  return Number(message.slice(i, j));
+}
+```
+
+The `'"' + key + '":'` concatenation is itself an allocation. On a hot path, hoist the search
+strings to module-level constants built once at load:
+
+```js
+var K_AVAILABLE_W = '"available_w":';
+var K_TS = '"ts":';
+```
+
+### 5.4 Topic parsing
+
+```js
+// BEFORE — allocates an array plus one string per segment, per message
+var parts = topic.split(":");
+if (parts.length >= 2) {
+  var n = Number(parts[parts.length - 1]);
+  if (!isNaN(n)) id = n;
+}
+
+// AFTER — one short string
+var c = topic.lastIndexOf(":");
+if (c !== -1) {
+  var n = Number(topic.slice(c + 1));
+  if (!isNaN(n)) id = n;
+}
+```
+
+### 5.5 Work done for a log line that is discarded
+
+```js
+// BEFORE — JSON.stringify runs even when logging is disabled
+log("Unhandled component event:", JSON.stringify(info));
+
+// AFTER — log() already stringifies object arguments, and only when it will print
+log("Unhandled component event:", info);
+```
+
+Same for concatenation at the call site:
+
+```js
+log("pro3 switch:" + id + " state updated via MQTT:", on);   // BEFORE: 2 strings, always
+log("pro3 switch:", id, "state updated via MQTT:", on);      // AFTER: 0 strings when disabled
+```
+
+### 5.6 A closure per queued task
+
+```js
+// BEFORE — a fresh closure per queued item; several of these fire every 60 s
+queueTask(function () { storeValue("runtime-sec", Math.round(sec)); });
+queueTask(function () { storeValue("turnover-today", computeTurnoverToday(sec)); });
+
+// AFTER — extend queueTask to carry one argument, and pass named top-level functions.
+// (This changes the queue contract; do it once, with tests, not ad hoc.)
+var TASK_ARGS = [];
+
+function queueTask(task, arg) {
+  TASK_QUEUE.push(task);
+  TASK_ARGS.push(arg);
+  if (!TASK_TIMER) { TASK_TIMER = Timer.set(200, true, processTaskQueue); }
+}
+
+function storeRuntimeSec(sec) { storeValue("runtime-sec", Math.round(sec)); }
+function storeTurnover(sec)   { storeValue("turnover-today", computeTurnoverToday(sec)); }
+
+queueTask(storeRuntimeSec, sec);
+queueTask(storeTurnover, sec);
+```
+
+`processTaskQueue` then calls `task(TASK_ARGS[TASK_INDEX])` and must clear both arrays together on
+drain. Keep `AGENTS.md`'s manual-shift rule in mind: `[].shift()` is unavailable, and the existing
+index-based drain is already the right shape.
+
+### 5.7 The free subset of 5.6 — trampolines that wrap nothing
+
+```js
+if (typeof cb === 'function') queueTask(function () { cb(); });   // BEFORE
+if (typeof cb === 'function') queueTask(cb);                      // AFTER — identical behaviour
+```
+
+`processTaskQueue` invokes tasks with no arguments, so the wrapper is pure overhead. There are
+roughly a dozen of these in `pool-pump.js`'s forecast and schedule paths. Zero-risk, do it first.
+
+### 5.8 Recomputed key strings
+
+```js
+// BEFORE — a new concatenated string on every write, every 60 s, forever
+function storeValue(key, value) {
+  Shelly.call("KVS.Set", {key: CONFIG_KEY_PREFIX + key, value: valueStr});
+}
+
+// AFTER — hoist the full keys used on recurring paths, once at load
+var KEY_RUNTIME_SEC = CONFIG_KEY_PREFIX + "runtime-sec";
+var KEY_TURNOVER    = CONFIG_KEY_PREFIX + "turnover-today";
+```
+
+The `{key: ..., value: ...}` params object remains. Reusing one preallocated params object across
+calls **would** remove it, but only if the firmware serialises `params` synchronously at call time.
+That is unverified — see §7.4 before relying on it.
+
+---
+
+## 6. Measurement recipe
+
+Nothing in §2–§5 should be believed on this hardware until it has been measured. The method is the
+differential one from `AGENTS.md`, with the discipline that makes it trustworthy.
+
+### 6.1 Set up a valid proxy
+
+Per `AGENTS.md` "Testing memory on a spare device", a spare device is only valid if it is loaded
+**exactly** like production:
+
+1. **Match the resident scripts.** The heap is shared. Stopping `watchdog.js` "to make room"
+   invalidates the whole test — this exact mistake produced a green spare-device result followed
+   immediately by a production `out_of_memory`.
+2. **Match the KVS configuration.** This is the big one — the 5-vs-24-key difference was 7.9 KB.
+   ```bash
+   B="myhome ctl shelly call -B tcp://192.168.1.2:1883 -T 60s"
+   $B <prod-device> KVS.GetMany '{"match":"script/<name>/*"}'
+   # then KVS.Set each key on the spare, overriding any device-id key to the spare's own id
+   ```
+3. **Record both firmware versions** (`Shelly.GetDeviceInfo` → `ver`). Firmware has not explained an
+   OOM difference in practice, but PR #426 found a build that ran on a Plus 1 at 1.7.5 and failed on
+   a Pro1 at 2.0.0 — so **a Plus 1 is not a sufficient proxy for the Pro1**. Confirm on the target.
+
+### 6.2 Take the baseline
+
+```bash
+B="myhome ctl shelly call -B tcp://192.168.1.2:1883 -T 60s <device>"
+$B Script.GetStatus '{"id":2}'
+# -> {"running":true,"mem_used":16632,"mem_peak":21350,"mem_free":6398}
+```
+
+Any script id returns the same device-wide numbers, so you can keep polling id 1 while stopping
+id 2. `mem_peak` is a high-water mark **since the script started** — always `Script.Stop` +
+`Script.Start` before a measurement run, or you are reading a stale peak from a previous build.
+
+### 6.3 Isolate one script's footprint
+
+```bash
+$B Script.GetStatus '{"id":1}'   # baseline mem_free
+$B Script.Stop       '{"id":2}'
+$B Script.GetStatus  '{"id":1}'  # delta = script 2's footprint
+# ...then Script.Start everything you stopped. On a production device the resident
+# scripts are load-bearing (watchdog.js handles MQTT-failure reboots and firmware updates).
+```
+
+### 6.4 Change one thing at a time
+
+This is where most of the value is, and where #421's two false starts came from.
+
+- Upload variant, `Script.Stop`, `Script.Start`, wait for init to finish, read
+  `{mem_used, mem_peak, mem_free}`. Record all three, plus the minified byte count.
+- **Let the peak-setting event actually happen.** For `pool-pump.js` the peak is set during init,
+  so a post-init reading is meaningful; for a script whose peak comes from a rare coincidence, let
+  it run through one.
+- **Change one variable per run.** A run that changes two optimisations tells you their sum and
+  nothing else — and if they cancel, it tells you they did nothing.
+- **Keep a table.** `AGENTS.md` "JS Heap Budget" and issue #433 both carry one; add rows rather
+  than starting a new table, because the value of these numbers is entirely in comparability.
+
+### 6.5 Decide what you are looking at
+
+| Symptom | Diagnosis | Attack with |
+|---|---|---|
+| `mem_used` high, `mem_peak` ≈ `mem_used` + small | **size/retention problem** | §1.1 minification, §4 retained state, dead code |
+| `mem_peak` ≫ `mem_used` | **allocation problem** | §2, §3 — pools, `userdata`, no per-call literals |
+| `mem_free` < ~5 KB at idle | one allocation from death | both; `AGENTS.md` rule of thumb is ≥5 KB |
+| Runs on the spare, dies in production | proxy invalid | §6.1 — KVS keys and resident scripts first |
+| Size cut produced no peak change | you had an allocation problem | stop trimming, go to §2 |
+
+---
+
+## 7. Q&A
+
+**When is a closure worth it?**
+When it is created **once**, at load or at subscription time, and lives for the script's lifetime —
+an event handler, a timer callback, a module-level helper. It is not worth it when it is created per
+call, per tick, or per loop iteration; there, use a named top-level function plus `userdata` (§3.2)
+or a preallocated slot (§3.1). The rule of thumb: *if you can count the closures your script will
+ever create on your fingers, they are free; if the count scales with anything, they are not.*
+
+**How do I measure one script's footprint?**
+§6.3. Stop it, diff `mem_free`. There is no per-script API — the heap is device-wide.
+
+**How do I tell whether I have a size problem or an allocation problem?**
+§6.5. Short version: compare `mem_peak` to `mem_used`. If the gap is large, the gap is your problem,
+and no amount of minification will close it.
+
+**Does minification help?**
+Yes, but weakly and only against the *residency* tenant. Measured: 5145 minified bytes bought 1764
+bytes of resident and 644 bytes of peak. Always minify — but never expect it to rescue a script
+whose problem is transient allocation, and never upload minified while debugging (`--no-minify`),
+because minification mangles the identifiers in crash traces. PR #430 adds a `demangle` command for
+when you must.
+
+**Is it safe to preallocate on a device with 23 KB?**
+Yes, and it is the recommended technique here. PR #426's `CALL_SLOTS` cost **+3878 bytes resident**
+and returned **−980 bytes of peak**, converting a dead script into a live one. Preallocate at load,
+when the heap is emptiest. Size the pool from a real device limit (5 concurrent RPCs, 5 timers) plus
+a small margin, and always include a fallback that allocates rather than drops work.
+
+**What does `mem_peak` vs `mem_free` tell me?**
+`mem_peak` is the high-water mark since the script started — it decides whether the script survives.
+`mem_free` is the instantaneous headroom — it tells you how much slack a *future* burst has.
+`mem_used + mem_free` ≈ 23030 while any script runs (with all scripts stopped `mem_free` reaches
+~25200, so the VM itself costs ~2 KB — treat "total heap" as approximate and always compare
+like-for-like states). Aim for `mem_free` ≥ ~5 KB at idle and `mem_peak` ≤ ~20 KB. A script booting
+with 1–2 KB free is one allocation from `out_of_memory` and will die unpredictably later.
+
+**How do I test this without touching production?**
+§6.1, and honestly: you cannot fully. A Plus 1 at fw 1.7.5 was proven *not* to be a valid proxy for
+a Pro1 at fw 2.0.0 (PR #426). Use the spare for iteration with matched scripts and matched KVS, then
+confirm the winner on the target hardware during a window when the controlled equipment can safely
+be off — and have the last-known-good script ready to re-upload. Remember that with the script dead,
+every device `Schedule` job (they all use `script.eval`) becomes a no-op and the equipment is left
+uncontrolled.
+
+**Can I split a big script into two smaller ones to fit?**
+**No.** The heap is one device-wide pool. A second script adds a second VM context, its own
+bytecode, its own copy of shared helpers (`log`, `storeValue`, config loading) and needs IPC to talk
+to the first. It strictly increases total heap use. What *does* work is moving a script off the
+device entirely, or moving logic to the daemon — see the `pool-pump.js` proposal's structural
+options.
+
+**The minifier changes my identifiers — how do I debug a crash trace?**
+Upload with `--no-minify` while debugging (`go run ./myhome ctl shelly script upload <device>
+<script.js> --no-minify`). If the unminified build does not fit — which is the case for
+`pool-pump.js` — use PR #430's symbol map and `myhome ctl shelly script demangle`.
+
+**Is it Espruino or mJS?**
+`AGENTS.md:77` says "a modified version of Espruino". PR #426's own hardware log says "Wrapper
+installs on mJS". The documented constraints (no `[].shift()`/`unshift()`, `let`/`const` unsafe,
+`Array.prototype.slice.call(arguments)` unreliable) match mJS, not Espruino. This matters for
+estimating §1.1, so §7.1 below gives the experiment. Everything else in this guide holds either way:
+both engines are mark-and-sweep, both have immutable strings, and in both a closure pins its
+enclosing scope.
+
+---
+
+## 8. Open questions and the experiments that settle them
+
+No device access was available while writing this. Everything below is a claim this document
+*relies on* but could not verify. Each has a cheap, non-destructive experiment.
+
+### 8.1 Which engine is it?
+**Why it matters**: decides whether string literals are foreign pointers into bytecode (mJS, cheap)
+or owned heap strings (Espruino, expensive) — a ~3× swing in what removing 1.5 KB of `description:`
+strings is worth.
+**Experiment**: one `Script.Eval` — `typeof ffi` (mJS-only global) and `typeof E` / `typeof
+process` (Espruino-only). Read-only, no state change.
+
+### 8.2 Does `mem_used` include bytecode, and at what rate?
+**Why it matters**: the 0.34 static→resident ratio in §1.1 is a single data point extrapolated to
+every size estimate in this repo.
+**Experiment**: upload a variant with 4 KB of pure string-literal padding in a never-referenced
+top-level `var`; diff `mem_used`. Then a control variant with 4 KB of extra *comments* (stripped by
+the minifier), which must show zero change.
+
+### 8.3 Does the arena shrink after a burst? (§1.4)
+**Why it matters**: this is the central mechanism claim of the whole document. If garbage is
+collected promptly and the arena returns memory, then per-call allocation is far less important than
+argued here — though the #421 measurement would then need another explanation.
+**Experiment**: drive a task-queue loop that allocates a known object N times, restarting the script
+between runs, and read `mem_peak` for N = 1, 5, 20, 50. Linear growth in N ⇒ garbage accumulates
+across ticks. Separately, read `mem_used` immediately after boot and again after 10 idle minutes: if
+it does not fall back, the arena does not shrink.
+
+### 8.4 Can a preallocated `params` object be reused across `Shelly.call`s?
+**Why it matters**: gates §5.8's second half and roughly 2 allocations per KVS write.
+**Experiment**: fire two `KVS.Set` calls back to back reusing one params object with different
+key/value pairs; confirm both keys land with the correct values.
+
+### 8.5 How big and how frequent are Shelly `status/switch:N` payloads really?
+**Why it matters**: §2.3 ranks this as the largest recurring transient in `pool-pump.js`, on an
+assumed ~200–250 bytes at roughly one message per minute per channel, times four subscriptions.
+**Experiment**: `mosquitto_sub -t '<device>/status/switch:0' -v` for five minutes; count messages
+and bytes. Broker-only, no device write.
+
+### 8.6 Is the 5→24-key +7.9 KB still true after the `CALL_SLOTS`/`userdata` rework?
+**Why it matters**: it is the evidence base for "KVS keys are expensive". If the rework already
+collapsed it, then most of that cost was per-key closures — which would *confirm* §2.1 while
+removing config-key count as a remaining lever.
+**Experiment**: on the spare, run the PR #426 build with 5 keys and with the full 24, restarting
+between, and compare `mem_used` and `mem_peak`.
+
+---
+
+## 9. Checklist for a new or modified script
+
+- [ ] Every function value created at runtime is created **once**, not per call/tick/iteration.
+- [ ] Sequential async chains pass context via `Shelly.call`'s `userdata` to one named handler.
+- [ ] No object or array literal inside a function that runs more than a few times.
+- [ ] No `JSON.parse` of a payload you read fewer than ~3 fields from, where you control the format.
+- [ ] No work (`JSON.stringify`, `+`) done at a `log()` call site that `log()` may discard.
+- [ ] No `description:` or other human-only strings inside runtime objects — use `//` comments.
+- [ ] Phase-scoped state (`CONFIG_SCHEMA`, working arrays) set to `null` when the phase ends.
+- [ ] Every new KVS key justified; unread-at-runtime keys marked `cliOnly`.
+- [ ] Pools sized from a real device limit, with a fallback that allocates rather than drops work.
+- [ ] Measured on the **target** hardware with matched resident scripts and matched KVS, one change
+      per run, `Script.Stop`/`Start` before each reading, results appended to the existing table.
+- [ ] `mem_free` ≥ ~5 KB at idle and `mem_peak` ≤ ~20 KB before calling it done.


### PR DESCRIPTION
Documentation only — no `.js` or Go source changed. Implementation is a separate, reviewed task.

## What this adds

- **`docs/shelly-heap-allocation.md`** (759 lines) — a reusable guide to reducing JS heap on Shelly/Espruino, grounded in this repo's hardware measurements rather than generic JS advice. Covers where the heap actually goes (code residency vs retained state vs transient allocation), allocation sources ranked by measured cost, static/startup preallocation as the preferred technique (with `CALL_SLOTS` as the worked example), retained-state reduction, a Q&A, ES5-legal before/after snippets, and a measurement recipe.
- **`docs/433-pool-pump-heap-proposal.md`** (440 lines) — a prioritised, costed change list aimed at making `pool-pump.js` fit the Pro1 heap **with solar enabled**, which is what #433 blocks on.
- **`AGENTS.md`** — pointer so both are findable.

## Top recommendations

| # | change | est. peak saving | risk |
|---|---|---|---|
| P1 | Delete `description:` from `CONFIG_SCHEMA`; keep the text as `//` comments | **−1200 B** (−700…−2300) | very low |
| P2 | Replace `parseSwitchStatus`'s `JSON.parse` with `indexOf` probes; stop self-subscribing to own status topic | −500 B | low |
| P8 | Delete unreachable `createSchedules` / `clearNonUpdateSchedules` / `loadValue` | −350 B | low |
| P10 | Give `queueTask` an argument slot so callers pass named functions, not wrapper closures | −450 B | medium |
| P3 | Remove per-call `{eco,mid,high,max}` literal in `computeFlowRate()` | −200 B | very low |

Subtotal ≈ **−3.4 KB** (−2.0…−5.5) against a needed 2.5–3.5 KB. Achievable, but thin.

## Two findings worth highlighting

**#433's own "cheapest first" suggestion is worth much less than assumed.** Dropping the unused `sources` field from the solar payload saves ~150 B — about a fifth of the minimum gap. It is free, so do it, but shipping only that would repeat #421's mistake of trimming 1519 static bytes and still OOMing.

**P1 is independently corroborated**: `heater.js:418-421` already nulls its own `description` fields after load, so a maintainer found this lever before. Deleting outright strictly dominates nulling, which still pays the full cost *during* the load — the peak window.

## Structural options

- **Rejected — splitting solar into a second script.** The heap is one device-wide pool, so a second script adds a VM context, duplicate helpers and IPC. It makes things worse.
- **Fallback if measurement falls short — publish a decision, not a measurement.** The daemon would publish retained `myhome/energy/solar/pump` = `1,1785908472` (JSON-free). Device side becomes ~6 lines: no `SOLAR` object, no tick timer, no `JSON.parse`, and 6 of 28 KVS keys disappear, shortening the boot load burst that sets the peak. Degraded mode is identical to today, so it still satisfies the daemon-optional rule — but it partly walks back #405's intent and needs a maintainer decision.

## Caveats — read before acting

Every per-object figure rests on an **unverified engine model**, and the static→resident ratio behind the size estimates is **one data point** from PR #430. The document is explicit about this and lists the experiments that would settle each open question.

The most consequential: **it is not established where the peak actually occurs.** The proposal argues it is at init (a 9.6 KB gap between `main`'s peak and idle), but #433 observed the solar build's peak *climbing after* boot. If the latter, there is a leak and the entire ranking targets the wrong window. The recommended first experiment is to poll `Script.GetStatus` every 2 s for 60 s from start.

The doc also notes that two readings of the same build differed by ~100 B, and advises treating any difference under ~200 B as unmeasured noise — which applies to several of its own line items.

A same-model, same-firmware test bed (Pro1, fw 2.0.0) has since been prepared, so these estimates can be replaced with measurements before anything is implemented.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- docs: JS heap allocation guide + concrete pool-pump proposal (#433) ([feaa2ba](https://github.com/asnowfix/home-automation/commit/feaa2ba1675defb33d410743f4629cc7618b7fd9))
<!-- END-AUTO-GENERATED-COMMITS -->