### PR TITLE
fix(pool-pump): re-evaluate the pump when a schedule rewrite moves the run window (#441)

### DIFF
--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1959,6 +1959,79 @@ function makeTimespec(fractHours) {
   return '0 ' + m + ' ' + h + ' * * SUN,MON,TUE,WED,THU,FRI,SAT';
 }
 
+// Inverse of makeTimespec(): pulls the "M H" fields out of a Shelly cron
+// timespec ("0 M H * * DAYS") and returns minutes since midnight. Returns
+// null for a spec that carries no concrete time yet — notably the symbolic
+// "@sunrise"/"@sunset" forms createSchedules() lays down before
+// updateScheduleMode() has ever rewritten them. Callers must treat null as
+// "unknown", never as a time.
+function parseHM(ts) {
+  if (!ts || ts.indexOf('@') === 0) return null;
+  var p = ts.split(' ');
+  if (p.length < 3) return null;
+  var m = Number(p[1]);
+  var h = Number(p[2]);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+// The single "should the pump be running right now?" predicate. Answers from
+// the active mode's start/stop pair read straight out of Schedule.List — the
+// same source of truth updateScheduleMode() writes to — rather than from any
+// remembered value, so it stays correct across a restart mid-window (#421), a
+// schedule rewrite that moves the window under a running script (#441), and a
+// water-supply clear after the window has ended (#436).
+//
+// Calls back with true, false, or **null** when the window cannot be resolved
+// (Schedule.List failed, or the timespecs are still symbolic). null means
+// "don't know" and callers must not act on it — see reconcileRunState().
+function isWithinRunWindow(cb) {
+  var mode = STATE.scheduleMode || 'winter';
+  var sc = mode === 'summer' ? 'handleMorningStart()' : 'handleNightStart()';
+  var ec = mode === 'summer' ? 'handleEveningStop()' : 'handleNightStop()';
+
+  Shelly.call('Schedule.List', {}, function(result, err) {
+    if (err && false) {}
+    if (err || !result || !result.jobs) { cb(null); return; }
+
+    var startMin = null;
+    var stopMin = null;
+    for (var i = 0; i < result.jobs.length; i++) {
+      var job = result.jobs[i];
+      if (!job.enable || !job.calls || job.calls.length === 0) continue;
+      var code = job.calls[0].params && job.calls[0].params.code;
+      if (code === sc) {
+        startMin = parseHM(job.timespec);
+      } else if (code === ec) {
+        stopMin = parseHM(job.timespec);
+      }
+    }
+
+    if (startMin === null || stopMin === null) { cb(null); return; }
+
+    var d = new Date();
+    var nowMin = d.getHours() * 60 + d.getMinutes();
+    // A start > stop pair wraps past midnight (the fixed winter 23:15 -> 00:15 run).
+    cb(startMin <= stopMin
+      ? (nowMin >= startMin && nowMin < stopMin)
+      : (nowMin >= startMin || nowMin < stopMin));
+  });
+}
+
+// True when applying `upd` to the Schedule.List `job` it was built from would
+// actually move the run window — the job gets enabled or disabled, or it gets
+// a start/stop time different from the one already on the device.
+function movesWindow(job, upd) {
+  if (upd.enable !== job.enable) return true;
+  return !!(upd.timespec && upd.timespec !== job.timespec);
+}
+
+// Queued (not called directly) from updateScheduleMode() once its
+// Schedule.Update calls have all landed — see the #441 comment there.
+function reconcileAfterRewrite() {
+  reconcileRunState('Schedule rewrite');
+}
+
 function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
   var hasTimings = morningStartHours !== null && morningStartHours !== undefined;
   var modeChanged = STATE.scheduleMode !== newMode;
@@ -1991,6 +2064,12 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
     }
 
     var schedulesToUpdate = [];
+    // #441: set when this call actually moves the active run window (a job is
+    // enabled/disabled, or a start/stop time is rewritten to a different
+    // value). A no-op re-run — the common case at sunrise when the forecast
+    // yields the same window as yesterday — leaves it false so we don't
+    // re-reconcile for nothing.
+    var windowChanged = false;
     for (var i = 0; i < result.jobs.length; i++) {
       var job = result.jobs[i];
       if (job.calls && job.calls.length > 0) {
@@ -2000,15 +2079,19 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
           if (hasTimings && newMode === 'summer') {
             updM.timespec = makeTimespec(morningStartHours);
           }
+          if (movesWindow(job, updM)) windowChanged = true;
           schedulesToUpdate.push(updM);
         } else if (code === 'handleEveningStop()') {
           var updE = {id: job.id, enable: newMode === 'summer', name: code};
           if (hasTimings && newMode === 'summer') {
             updE.timespec = makeTimespec(eveningStopHours);
           }
+          if (movesWindow(job, updE)) windowChanged = true;
           schedulesToUpdate.push(updE);
         } else if (code === 'handleNightStart()' || code === 'handleNightStop()') {
-          schedulesToUpdate.push({id: job.id, enable: newMode === 'winter', name: code});
+          var updN = {id: job.id, enable: newMode === 'winter', name: code};
+          if (movesWindow(job, updN)) windowChanged = true;
+          schedulesToUpdate.push(updN);
         }
       }
     }
@@ -2022,6 +2105,16 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
     function updateNext() {
       if (updateIndex >= schedulesToUpdate.length) {
         log('All schedules updated for', newMode, 'mode');
+        // #441: the window we just wrote may already contain (or no longer
+        // contain) "now" — e.g. the sunrise re-forecast moves the morning
+        // start into the past, or a restart re-runs this after the old
+        // window's start instant has passed. Nothing else re-evaluates:
+        // handleMorningStart()/handleEveningStop() only ever fire at their
+        // scheduled instant, and a schedule that was rewritten past that
+        // instant never fires at all — which is how the pool lost a whole
+        // day of filtration on 2026-08-06. Reconcile here, once, in the one
+        // place that knows the window moved.
+        if (windowChanged) queueTask(reconcileAfterRewrite);
         return;
       }
       var sched = schedulesToUpdate[updateIndex];
@@ -2207,6 +2300,38 @@ function handleNightStop() {
   // check in persistRuntimeState/ensureRuntimeDay (#402).
   ensureRuntimeDay();
   doStop('Night stop event');
+}
+
+// Brings the physical pump state back in line with isWithinRunWindow() —
+// the shared reconciliation for every situation where the answer to "should
+// I be running?" changes without the corresponding schedule job firing:
+//
+//   - the script restarts part-way through a run window (#421),
+//   - updateScheduleMode() rewrites the window under a live script (#441),
+//   - water-supply protection clears after the window moved or ended (#436).
+//
+// Deliberately does nothing when the window is unresolvable (isWithinRunWindow
+// calls back null) or when the state already agrees — acting on a guess here
+// would start or stop the pump for no reason.
+function reconcileRunState(reason) {
+  if (!isMyTurnToRun()) return;
+
+  isWithinRunWindow(function(shouldRun) {
+    if (shouldRun === null) {
+      log(reason + ': window unresolved, leaving pump alone');
+      return;
+    }
+    var running = STATE.activeOutput !== -1;
+    if (shouldRun === running) {
+      log(reason + ': state already correct');
+      return;
+    }
+    if (shouldRun) {
+      doStart(CONFIG.preferredSpeed, reason + ': inside window');
+    } else {
+      doStop(reason + ': outside window');
+    }
+  });
 }
 
 // === INITIALIZATION ===

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1986,50 +1986,38 @@ function parseHM(ts) {
 // (Schedule.List failed, or the timespecs are still symbolic). null means
 // "don't know" and callers must not act on it — see reconcileRunState().
 function isWithinRunWindow(cb) {
-  var mode = STATE.scheduleMode || 'winter';
-  var sc = mode === 'summer' ? 'handleMorningStart()' : 'handleNightStart()';
-  var ec = mode === 'summer' ? 'handleEveningStop()' : 'handleNightStop()';
+  var summer = STATE.scheduleMode === 'summer';
+  var sc = summer ? 'handleMorningStart()' : 'handleNightStart()';
+  var ec = summer ? 'handleEveningStop()' : 'handleNightStop()';
 
   Shelly.call('Schedule.List', {}, function(result, err) {
     if (err && false) {}
     if (err || !result || !result.jobs) { cb(null); return; }
 
-    var startMin = null;
-    var stopMin = null;
+    var a = null;
+    var b = null;
     for (var i = 0; i < result.jobs.length; i++) {
       var job = result.jobs[i];
       if (!job.enable || !job.calls || job.calls.length === 0) continue;
       var code = job.calls[0].params && job.calls[0].params.code;
-      if (code === sc) {
-        startMin = parseHM(job.timespec);
-      } else if (code === ec) {
-        stopMin = parseHM(job.timespec);
-      }
+      if (code === sc) a = parseHM(job.timespec);
+      else if (code === ec) b = parseHM(job.timespec);
     }
 
-    if (startMin === null || stopMin === null) { cb(null); return; }
+    if (a === null || b === null) { cb(null); return; }
 
     var d = new Date();
-    var nowMin = d.getHours() * 60 + d.getMinutes();
+    var n = d.getHours() * 60 + d.getMinutes();
     // A start > stop pair wraps past midnight (the fixed winter 23:15 -> 00:15 run).
-    cb(startMin <= stopMin
-      ? (nowMin >= startMin && nowMin < stopMin)
-      : (nowMin >= startMin || nowMin < stopMin));
+    cb(a <= b ? (n >= a && n < b) : (n >= a || n < b));
   });
 }
 
 // True when applying `upd` to the Schedule.List `job` it was built from would
 // actually move the run window — the job gets enabled or disabled, or it gets
 // a start/stop time different from the one already on the device.
-function movesWindow(job, upd) {
-  if (upd.enable !== job.enable) return true;
-  return !!(upd.timespec && upd.timespec !== job.timespec);
-}
-
-// Queued (not called directly) from updateScheduleMode() once its
-// Schedule.Update calls have all landed — see the #441 comment there.
-function reconcileAfterRewrite() {
-  reconcileRunState('Schedule rewrite');
+function moves(job, upd) {
+  return upd.enable !== job.enable || (!!upd.timespec && upd.timespec !== job.timespec);
 }
 
 function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
@@ -2079,18 +2067,18 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
           if (hasTimings && newMode === 'summer') {
             updM.timespec = makeTimespec(morningStartHours);
           }
-          if (movesWindow(job, updM)) windowChanged = true;
+          if (moves(job, updM)) windowChanged = true;
           schedulesToUpdate.push(updM);
         } else if (code === 'handleEveningStop()') {
           var updE = {id: job.id, enable: newMode === 'summer', name: code};
           if (hasTimings && newMode === 'summer') {
             updE.timespec = makeTimespec(eveningStopHours);
           }
-          if (movesWindow(job, updE)) windowChanged = true;
+          if (moves(job, updE)) windowChanged = true;
           schedulesToUpdate.push(updE);
         } else if (code === 'handleNightStart()' || code === 'handleNightStop()') {
           var updN = {id: job.id, enable: newMode === 'winter', name: code};
-          if (movesWindow(job, updN)) windowChanged = true;
+          if (moves(job, updN)) windowChanged = true;
           schedulesToUpdate.push(updN);
         }
       }
@@ -2114,7 +2102,7 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
         // instant never fires at all — which is how the pool lost a whole
         // day of filtration on 2026-08-06. Reconcile here, once, in the one
         // place that knows the window moved.
-        if (windowChanged) queueTask(reconcileAfterRewrite);
+        if (windowChanged) queueTask(reconcileRunState);
         return;
       }
       var sched = schedulesToUpdate[updateIndex];
@@ -2313,24 +2301,20 @@ function handleNightStop() {
 // Deliberately does nothing when the window is unresolvable (isWithinRunWindow
 // calls back null) or when the state already agrees — acting on a guess here
 // would start or stop the pump for no reason.
+//
+// `reason` is optional so this can be handed straight to queueTask().
 function reconcileRunState(reason) {
   if (!isMyTurnToRun()) return;
+  var why = (reason || 'Schedule rewrite') + ': ';
 
   isWithinRunWindow(function(shouldRun) {
-    if (shouldRun === null) {
-      log(reason + ': window unresolved, leaving pump alone');
-      return;
-    }
     var running = STATE.activeOutput !== -1;
-    if (shouldRun === running) {
-      log(reason + ': state already correct');
+    if (shouldRun === null || shouldRun === running) {
+      log(why + 'no action', shouldRun, running);
       return;
     }
-    if (shouldRun) {
-      doStart(CONFIG.preferredSpeed, reason + ': inside window');
-    } else {
-      doStop(reason + ': outside window');
-    }
+    if (shouldRun) doStart(CONFIG.preferredSpeed, why + 'inside window');
+    else doStop(why + 'outside window');
   });
 }
 

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1094,5 +1097,339 @@ func TestPoolPump_SolarStaleTsFallsBackImmediately(t *testing.T) {
 
 	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "-1" {
 		t.Fatalf("stale ts: expected pump to stay off (stale detected immediately on receipt), got active-output=%v", v)
+	}
+}
+
+// === Schedule-rewrite re-evaluation (#441) ===
+//
+// updateScheduleMode() rewrites the morning-start / evening-stop schedule jobs
+// from the day's forecast. Before #441 nothing re-evaluated the pump
+// afterwards, so a rewrite that moved the start into the past silently skipped
+// the whole day's filtration: handleMorningStart() only ever fires at its
+// scheduled instant, and an instant that has already passed never fires. That
+// is exactly what happened on the production pump on 2026-08-06.
+//
+// These tests drive the real path — init → handleDailyCheck() →
+// performDailyModeCheck() → forecast → decideModeFromForecast() →
+// updateScheduleMode() — against a local forecast server, and assert on the
+// pump state that results.
+
+// poolPumpForecastServer serves an Open-Meteo response shaped the way
+// pool-pump.js's onForecast() parses it: 24 hourly temperatures whose index is
+// the hour of day (so the index of the maximum becomes STATE.peakForecastHour)
+// plus one daily sunrise/sunset pair, which decideModeFromForecast() turns
+// into the window's start floor (sunrise + 1h) and stop ceiling (sunset - 0.5h).
+//
+// Local on purpose: the forecast fetch is a plain Shelly.call("HTTP.GET"),
+// which the emulator executes for real. Pointing it at a test server keeps
+// these tests deterministic and offline.
+func poolPumpForecastServer(t *testing.T, peakHour int, sunrise, sunset string) *httptest.Server {
+	t.Helper()
+
+	temps := make([]float64, 24)
+	for i := range temps {
+		temps[i] = 25
+	}
+	// Above poolPumpWindowKVS's max-temp, so computeRunHours()'s temperature
+	// scale clamps to 1 and run hours land exactly on the configured base hours.
+	temps[peakHour] = 40
+
+	body, err := json.Marshal(map[string]interface{}{
+		"hourly": map[string]interface{}{"temperature_2m": temps},
+		"daily": map[string]interface{}{
+			"sunrise": []string{"2026-08-07T" + sunrise},
+			"sunset":  []string{"2026-08-07T" + sunset},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build forecast body: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// poolPumpWindowKVS is pro1KVS() with the pool geometry rigged so
+// computeRunHours() returns exactly runHours: flow rate is
+// max-flow-rate × (eco-rpm / max-rpm) = 1 m³/h, and base hours are
+// pool-volume × turnover / flow = runHours.
+func poolPumpWindowKVS(runHours float64) map[string]interface{} {
+	kvs := pro1KVS()
+	kvs["script/pool-pump/pool-volume"] = strconv.FormatFloat(runHours, 'f', -1, 64)
+	kvs["script/pool-pump/turnover"] = "1"
+	kvs["script/pool-pump/max-flow-rate"] = "1"
+	kvs["script/pool-pump/eco-rpm"] = "2900"
+	kvs["script/pool-pump/max-rpm"] = "2900"
+	kvs["script/pool-pump/max-temp"] = "35"
+	kvs["script/pool-pump/temp-threshold"] = "20"
+	return kvs
+}
+
+// poolPumpTimespec renders the cron form makeTimespec() produces.
+func poolPumpTimespec(h, m int) string {
+	return fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", m, h)
+}
+
+// poolPumpSummerSchedules is a complete summer-mode job set: a daily check, a
+// morning/evening pair at the given times, and the two night jobs already
+// disabled — which is what summer mode looks like on a real device.
+func poolPumpSummerSchedules(start, stop time.Time) []map[string]interface{} {
+	job := func(id int, code, timespec string, enable bool) map[string]interface{} {
+		return map[string]interface{}{
+			"id": id, "enable": enable, "timespec": timespec,
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": code},
+			}},
+		}
+	}
+	return []map[string]interface{}{
+		job(1, "handleDailyCheck()", "@sunrise * * SUN,MON,TUE,WED,THU,FRI,SAT", true),
+		job(2, "handleMorningStart()", poolPumpTimespec(start.Hour(), start.Minute()), true),
+		job(3, "handleEveningStop()", poolPumpTimespec(stop.Hour(), stop.Minute()), true),
+		job(4, "handleNightStart()", poolPumpTimespec(23, 15), false),
+		job(5, "handleNightStop()", poolPumpTimespec(0, 15), false),
+	}
+}
+
+// poolPumpScheduleTimespec reads back the timespec currently on the job whose
+// script.eval code matches, so a test can prove the rewrite actually landed
+// before asserting on what the rewrite should have caused.
+func poolPumpScheduleTimespec(schedules []map[string]interface{}, code string) string {
+	for _, job := range schedules {
+		calls, ok := job["calls"].([]interface{})
+		if !ok || len(calls) == 0 {
+			continue
+		}
+		call, ok := calls[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		params, ok := call["params"].(map[string]interface{})
+		if !ok || params["code"] != code {
+			continue
+		}
+		if ts, ok := job["timespec"].(string); ok {
+			return ts
+		}
+	}
+	return ""
+}
+
+// poolPumpRewriteResult runs the script against the given fixture, waits for
+// the schedule rewrite to land, then reports the active-output the script
+// settled on. wantOutput is what the caller expects; the helper polls for it
+// so a passing test finishes quickly and a failing one still reports the
+// value actually reached.
+func poolPumpRewriteResult(t *testing.T, deviceState *script.DeviceState, wantOutput string) (string, []map[string]interface{}) {
+	t.Helper()
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		30*time.Second,
+	)
+	defer cancel()
+
+	buf := readPoolPumpScript(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	// The rewrite has to land before the reconciliation it triggers can be
+	// judged, so wait for the morning job's timespec to change first.
+	initial := poolPumpScheduleTimespec(deviceState.Schedules, "handleMorningStart()")
+	if !waitFor(15*time.Second, 100*time.Millisecond, func() bool {
+		return poolPumpScheduleTimespec(deviceState.Schedules, "handleMorningStart()") != initial
+	}) {
+		cancel()
+		<-done
+		t.Fatalf("schedule rewrite never happened (morning start still %q)", initial)
+	}
+
+	// Then give the reconciliation its own window to act — or to provably not.
+	waitFor(8*time.Second, 100*time.Millisecond, func() bool {
+		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		return ok && v == wantOutput
+	})
+
+	got, _ := deviceState.KVS["script/pool-pump/active-output"].(string)
+	schedules := deviceState.Schedules
+	cancel()
+	<-done
+	return got, schedules
+}
+
+// Two window shapes, both derived from the forecast by decideModeFromForecast():
+//
+//   - wide: sunrise 00:00 → start floor 01:00; sunset 23:59 → stop ceiling
+//     23:29; peak at noon with 22.48 run hours. The unclamped window starts
+//     before the floor, so it is pinned to [01:00, 23:29) — containing almost
+//     any "now".
+//   - narrow: peak at 02:00 with 0.1 run hours → [01:57, 02:03), excluding
+//     almost any "now".
+const (
+	poolPumpWideRunHours   = 22.48
+	poolPumpWidePeakHour   = 12
+	poolPumpWideStartMin   = 60   // 01:00
+	poolPumpWideStopMin    = 1409 // 23:29
+	poolPumpNarrowRunHours = 0.1
+	poolPumpNarrowPeakHour = 2
+	poolPumpNarrowStartMin = 117 // 01:57
+	poolPumpNarrowStopMin  = 123 // 02:03
+)
+
+// nowMinutes is the minutes-since-midnight value pool-pump.js's
+// isWithinRunWindow() computes from new Date().
+func nowMinutes() int {
+	now := time.Now()
+	return now.Hour()*60 + now.Minute()
+}
+
+// skipUnlessNowInside guards the one wall-clock dependency these tests cannot
+// design away: pool-pump.js derives the window from a real forecast and
+// compares it against the device's real clock, and its own clamps refuse to
+// schedule a start before 01:00 — so "now is inside the window" is simply not
+// expressible during the midnight hour.
+func skipUnlessNowInside(t *testing.T, startMin, stopMin int) {
+	t.Helper()
+	if n := nowMinutes(); n < startMin || n >= stopMin {
+		t.Skipf("local time %02d:%02d is outside the [%d, %d) minute window this scenario builds",
+			n/60, n%60, startMin, stopMin)
+	}
+}
+
+func skipIfNowInside(t *testing.T, startMin, stopMin int) {
+	t.Helper()
+	if n := nowMinutes(); n >= startMin && n < stopMin {
+		t.Skipf("local time %02d:%02d falls inside the [%d, %d) minute window this scenario builds",
+			n/60, n%60, startMin, stopMin)
+	}
+}
+
+// A rewrite that moves the morning start from the future into the past, with
+// "now" inside the new window, must start the pump. This is the 2026-08-06
+// production failure: without the fix the pump stays off for the whole day.
+func TestPoolPump_ScheduleRewriteIntoPastStartsPump(t *testing.T) {
+	skipUnlessNowInside(t, poolPumpWideStartMin, poolPumpWideStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpWidePeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpWideRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off
+		// Old window: the start is still ahead of us, so nothing was due yet.
+		Schedules: poolPumpSummerSchedules(now.Add(2*time.Hour), now.Add(4*time.Hour)),
+	}
+
+	got, schedules := poolPumpRewriteResult(t, deviceState, "0")
+
+	if ts := poolPumpScheduleTimespec(schedules, "handleMorningStart()"); ts != poolPumpTimespec(1, 0) {
+		t.Fatalf("expected morning start rewritten to 01:00, got %q", ts)
+	}
+	if got != "0" {
+		t.Fatalf("rewrite moved the start into the past with now inside the new window: "+
+			"expected the pump to start (active-output=0), got %q", got)
+	}
+}
+
+// The sunrise case, with no restart involved: the previous window has already
+// elapsed, the daily re-forecast rewrites it to one containing "now", and the
+// pump must start even though no schedule job fires.
+func TestPoolPump_SunriseRewriteStartsPump(t *testing.T) {
+	skipUnlessNowInside(t, poolPumpWideStartMin, poolPumpWideStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpWidePeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpWideRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off, correctly so
+		// Yesterday's window, entirely behind us.
+		Schedules: poolPumpSummerSchedules(now.Add(-5*time.Hour), now.Add(-4*time.Hour)),
+	}
+
+	got, _ := poolPumpRewriteResult(t, deviceState, "0")
+	if got != "0" {
+		t.Fatalf("sunrise rewrite brought now inside the window: "+
+			"expected the pump to start (active-output=0), got %q", got)
+	}
+}
+
+// The converse: a rewrite that moves the window off "now" must stop a pump
+// that is currently running, rather than leave it running until an
+// evening-stop instant that no longer matches anything.
+func TestPoolPump_ScheduleRewriteAwayStopsPump(t *testing.T) {
+	skipIfNowInside(t, poolPumpNarrowStartMin, poolPumpNarrowStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpNarrowPeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	cs := pro1ComponentStatus()
+	cs["switch:0"] = map[string]interface{}{"id": 0, "output": true} // running
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpNarrowRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: cs,
+		// Old window contains "now", which is why the pump is running.
+		Schedules: poolPumpSummerSchedules(now.Add(-1*time.Hour), now.Add(1*time.Hour)),
+	}
+
+	got, schedules := poolPumpRewriteResult(t, deviceState, "-1")
+
+	if ts := poolPumpScheduleTimespec(schedules, "handleMorningStart()"); ts != poolPumpTimespec(1, 57) {
+		t.Fatalf("expected morning start rewritten to 01:57, got %q", ts)
+	}
+	if got != "-1" {
+		t.Fatalf("rewrite moved the window off now: "+
+			"expected the running pump to stop (active-output=-1), got %q", got)
+	}
+}
+
+// Regression guard: a rewrite that leaves the pump correctly off — "now" is
+// outside both the old and the new window — must not start it.
+func TestPoolPump_ScheduleRewriteOutsideWindowDoesNotStartPump(t *testing.T) {
+	skipIfNowInside(t, poolPumpNarrowStartMin, poolPumpNarrowStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpNarrowPeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpNarrowRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off
+		Schedules:       poolPumpSummerSchedules(now.Add(-5*time.Hour), now.Add(-4*time.Hour)),
+	}
+
+	// Ask for "0" so the helper spends its full budget looking for a start
+	// that must never come.
+	got, _ := poolPumpRewriteResult(t, deviceState, "0")
+	if got != "-1" {
+		t.Fatalf("now is outside the rewritten window: "+
+			"expected the pump to stay off (active-output=-1), got %q", got)
 	}
 }

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -761,6 +761,21 @@ func (f *testEventForwarder) Handle(ctx context.Context, vm *goja.Runtime, msg [
 
 type methodFunc func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error)
 
+// scheduleID normalises a job's "id" field to an int. Jobs reach
+// DeviceState.Schedules either from a Go test fixture (int), from JSON
+// (float64) or from AddSchedule (int), so a bare type assertion is not enough.
+func scheduleID(v interface{}) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	}
+	return -1
+}
+
 func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 	return map[string]methodFunc{
 		"shelly.detectlocation": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
@@ -948,6 +963,67 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
 				if callable, ok := goja.AssertFunction(callback); ok {
 					result := map[string]interface{}{"id": id}
+					callable(goja.Undefined(), vm.ToValue(result), vm.ToValue(0), goja.Null(), userdata)
+				}
+			}
+			return nil, nil
+		},
+
+		// Schedule.Update — merge the given fields into an existing job.
+		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Schedule#scheduleupdate
+		// Without this, Shelly.call('Schedule.Update', ...) fell through to the
+		// unknown-method path: the callback fired with a null result and the
+		// job was never modified, so a script that rewrites its own schedule
+		// (pool-pump.js updateScheduleMode) appeared to succeed while
+		// Schedule.List kept returning the old window — see #441.
+		"schedule.update": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
+			paramsObj := params.ToObject(vm)
+			id := int(paramsObj.Get("id").ToInteger())
+			updates, _ := params.Export().(map[string]interface{})
+
+			var updated map[string]interface{}
+			for _, job := range deviceState.Schedules {
+				if scheduleID(job["id"]) != id {
+					continue
+				}
+				for k, v := range updates {
+					if k == "id" {
+						continue
+					}
+					job[k] = v
+				}
+				updated = job
+				break
+			}
+
+			if updated == nil {
+				if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
+					if callable, ok := goja.AssertFunction(callback); ok {
+						callable(goja.Undefined(), goja.Null(), vm.ToValue(-105),
+							vm.ToValue(fmt.Sprintf("no schedule with id %d", id)), userdata)
+					}
+				}
+				return nil, nil
+			}
+
+			// Keep the schedule:N component view in step with the job, the
+			// same way Schedule.Create does.
+			if deviceState.ComponentStatus != nil {
+				deviceState.ComponentStatus[fmt.Sprintf("schedule:%d", id)] = map[string]interface{}{
+					"id":       id,
+					"enable":   updated["enable"],
+					"timespec": updated["timespec"],
+					"calls":    updated["calls"],
+				}
+			}
+
+			if deviceState.OnModified != nil {
+				deviceState.OnModified()
+			}
+
+			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
+				if callable, ok := goja.AssertFunction(callback); ok {
+					result := map[string]interface{}{"rev": 1}
 					callable(goja.Undefined(), vm.ToValue(result), vm.ToValue(0), goja.Null(), userdata)
 				}
 			}


### PR DESCRIPTION
Fixes #441.

## The bug

`restartCatchUp()` evaluated the schedule window and `handleDailyCheck()` rewrote it, with the
rewrite queued immediately after the evaluation — and `handleDailyCheck()` runs on *every* script
init, not just at sunrise. So the catch-up decision was always made against a window that was about
to be replaced.

Live impact on the production pump (`filtration-hiver`, running v0.11.10): the last
`pool.pump_start` before 2026-08-07 was **2026-08-04 14:52:45**. Zero starts on 2026-08-05 and
2026-08-06 — two full days with no filtration. Only stop events appear in the log, which is why the
failure looked superficially normal.

## The fix

Not a swap of the two `queueTask` lines — that fixes restart but still misses the sunrise rewrite,
where `handleDailyCheck()` moves the window on an already-running script with no restart involved.

Instead, `internal/shelly/scripts/pool-pump.js` gains:

- `isWithinRunWindow(cb)` + `parseHM(ts)` — the shared "should I be running now?" predicate, reading
  the active mode's start/stop pair from `Schedule.List`. Calls back `true` / `false` / `null`,
  where `null` means unresolvable (symbolic `@sunrise`, or the RPC failed) and nothing should act.
- `reconcileRunState(reason)` — the single place that turns that answer into a `doStart` / `doStop`.
- `updateScheduleMode()` now tracks whether it *actually moved* the window (enable flipped, or the
  timespec genuinely differs) and queues `reconcileRunState` once its `Schedule.Update` calls land.
  A no-op sunrise re-run reconciles nothing.

This covers restart, sunrise, and any future caller in one place.

### Consolidation

#441 asked that the three call sites needing this predicate share one implementation rather than
adding a fourth copy. `main` currently has neither #426's `restartCatchUp` nor #437's
`isWithinRunWindow` — both are still draft — so this PR lands the single implementation first.
On rebase, #426's `restartCatchUp()` becomes `reconcileRunState('Restart catch-up')` and #437's
water-supply path calls `isWithinRunWindow` directly; both should drop their own `parseHM` and
window-scanning copies.

## Emulator gap this exposed

`Schedule.Update` was **never implemented** in `pkg/shelly/script/run.go`. It fell through to the
unknown-method path: the callback fired with a null result and the job was never modified. A script
rewriting its own schedule appeared to succeed while `Schedule.List` kept returning the old window —
which is precisely why this class of bug was invisible to CI. Implemented here as a field merge over
the tracked job, with a `scheduleID` normaliser for int/int64/float64 ids.

## Tests

All four cases from #441's test plan, in `internal/shelly/scripts/pool_pump_test.go`, driving the
real path (init → `handleDailyCheck` → forecast → `decideModeFromForecast` → `updateScheduleMode`)
against a local `httptest` forecast server.

With the JS fix stashed and the tests unchanged:

```
--- FAIL: TestPoolPump_ScheduleRewriteIntoPastStartsPump    expected active-output=0, got "-1"
--- FAIL: TestPoolPump_SunriseRewriteStartsPump             expected active-output=0, got "-1"
--- FAIL: TestPoolPump_ScheduleRewriteAwayStopsPump         expected active-output=-1, got "0"
     PASS: TestPoolPump_ScheduleRewriteOutsideWindowDoesNotStartPump   (regression guard)
```

With the fix: all four pass.

`make test`: 46 ok, 1 pre-existing failure — `TestGarden_LawnFiresTogetherBedsIndependent`, which
fails identically on clean `origin/main` (introduced by `23e7307`), unrelated to this change.

## Heap cost — measured on real hardware

`mezzanine` (Pro1, fw 2.0.0) with the pump's 24 production KVS keys replicated and `watchdog.js`
running, `Script.GetStatus` sampled from script start. Total heap 23030.

| script | `mem_peak` | free at peak |
|---|---|---|
| `main` @2de30c8 (baseline) | 22526 | 504 |
| this PR, first draft | 22988 | 42 |
| **this PR, as shipped** | **22904** | **126** |

**+378 bytes.** Baseline and shipped each reproduced across two upload+restart cycles.

Read the absolute numbers with #433 in mind: `main`'s *unmodified* `pool-pump.js` already peaks at
22526 on a Pro1, so `main`'s script is near the ceiling independently of this change. The release
line — where this regression actually shipped — reports `mem_peak 20454` on the live pump, i.e.
2576 bytes of headroom, ample for +378. A `v0.11.x` backport follows separately.

`mezzanine` was fully restored afterwards: script and KVS purged, the 5 pool schedules deleted,
`switch:0` back to `in_mode: momentary`, input names cleared, `sys_btn_toggle` restored, light OFF.

## Degraded mode

No change: this moves no logic off the device. The pump's start/stop decision stays entirely on
`filtration-hiver` and continues to work with the daemon down.

## Not in this PR

- **`v0.11.x` backport** — feasible and mostly mechanical (that branch already carries `parseHM` and
  `restartCatchUp` from #434, and `updateScheduleMode`'s job loop is structurally identical).
- **The 02:00 `Evening stop event` anomaly** from #441 is root-caused and is *not* the pump: those
  events came from `development`, the spare Plus 1, which still holds leftover retimed test jobs
  (id 3 at `0 0 2` → `handleEveningStop()`). See
  https://github.com/asnowfix/home-automation/issues/441#issuecomment-5213930074. No code fix needed.
- **On-device verification covers heap and init survival, not the reconcile's start action.**
  `speed=off` was set on `mezzanine` so a start decision could never energise a real light; `doStart`
  provably ran its guard path but never closed a relay. The start/stop behaviour itself is proven by
  the four emulator tests.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): re-evaluate the pump when a schedule rewrite moves the run window (#441) ([b981f4a](https://github.com/asnowfix/home-automation/commit/b981f4abda704fef4784a2712bcdb9eb6e3bd412))
- perf(pool-pump): trim the #441 reconciliation to fit the Pro1 heap ([e9e657a](https://github.com/asnowfix/home-automation/commit/e9e657ab405557755e7bcd2a1adb4cca500f225d))
- Merge main into bugfix/441-schedule-rewrite-reevaluate ([57f4abf](https://github.com/asnowfix/home-automation/commit/57f4abfc8c1dabd7bdb7b4f0652aa155ee0ebd52))
<!-- END-AUTO-GENERATED-COMMITS -->