### PR TITLE
fix(pool-pump): re-evaluate the pump when a schedule rewrite moves the run window (#441) [v0.11.x]

### DIFF
--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1761,6 +1761,71 @@ function makeTimespec(fractHours) {
   return '0 ' + m + ' ' + h + ' * * SUN,MON,TUE,WED,THU,FRI,SAT';
 }
 
+// Inverse of makeTimespec(): pulls the "M H" fields out of a Shelly cron
+// timespec built by makeTimespec() ("0 M H * * DAYS") or a fixed literal
+// ("0 15 23 * * ..."), and returns minutes since midnight. Returns null for a
+// spec that carries no concrete time yet — notably the symbolic
+// "@sunrise"/"@sunset" forms createSchedules() lays down before
+// updateScheduleMode() has ever rewritten them. Callers must treat null as
+// "unknown", never as a time.
+function parseHM(timespec) {
+  if (!timespec || timespec.indexOf('@') === 0) return null;
+  var parts = timespec.split(' ');
+  if (parts.length < 3) return null;
+  var m = Number(parts[1]);
+  var h = Number(parts[2]);
+  if (isNaN(h) || isNaN(m)) return null;
+  return h * 60 + m;
+}
+
+// The single "should the pump be running right now?" predicate. Answers from
+// the active mode's start/stop pair read straight out of Schedule.List — the
+// same source of truth updateScheduleMode() writes to — rather than from any
+// remembered value, so it stays correct across a restart mid-window (#421) and
+// a schedule rewrite that moves the window under a running script (#441).
+//
+// Mode-aware on purpose: only one of the two job pairs is ever enabled at a
+// time on a real device (updateScheduleMode() disables the other), so matching
+// the currently active mode avoids any ambiguity about which pair governs "now".
+//
+// Calls back with true, false, or **null** when the window cannot be resolved
+// (Schedule.List failed, or the timespecs are still symbolic). null means
+// "don't know" and callers must not act on it — see reconcileRunState().
+function isWithinRunWindow(cb) {
+  var summer = STATE.scheduleMode === 'summer';
+  var sc = summer ? 'handleMorningStart()' : 'handleNightStart()';
+  var ec = summer ? 'handleEveningStop()' : 'handleNightStop()';
+
+  Shelly.call('Schedule.List', {}, function(result, err) {
+    if (err && false) {}
+    if (err || !result || !result.jobs) { cb(null); return; }
+
+    var a = null;
+    var b = null;
+    for (var i = 0; i < result.jobs.length; i++) {
+      var job = result.jobs[i];
+      if (!job.enable || !job.calls || job.calls.length === 0) continue;
+      var code = job.calls[0].params && job.calls[0].params.code;
+      if (code === sc) a = parseHM(job.timespec);
+      else if (code === ec) b = parseHM(job.timespec);
+    }
+
+    if (a === null || b === null) { cb(null); return; }
+
+    var d = new Date();
+    var n = d.getHours() * 60 + d.getMinutes();
+    // A start > stop pair wraps past midnight (the fixed winter 23:15 -> 00:15 run).
+    cb(a <= b ? (n >= a && n < b) : (n >= a || n < b));
+  });
+}
+
+// True when applying `upd` to the Schedule.List `job` it was built from would
+// actually move the run window — the job gets enabled or disabled, or it gets
+// a start/stop time different from the one already on the device.
+function moves(job, upd) {
+  return upd.enable !== job.enable || (!!upd.timespec && upd.timespec !== job.timespec);
+}
+
 function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
   var hasTimings = morningStartHours !== null && morningStartHours !== undefined;
   var modeChanged = STATE.scheduleMode !== newMode;
@@ -1793,6 +1858,12 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
     }
 
     var schedulesToUpdate = [];
+    // #441: set when this call actually moves the active run window (a job is
+    // enabled/disabled, or a start/stop time is rewritten to a different
+    // value). A no-op re-run — the common case at sunrise when the forecast
+    // yields the same window as yesterday — leaves it false so we don't
+    // re-reconcile for nothing.
+    var windowChanged = false;
     for (var i = 0; i < result.jobs.length; i++) {
       var job = result.jobs[i];
       if (job.calls && job.calls.length > 0) {
@@ -1802,15 +1873,19 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
           if (hasTimings && newMode === 'summer') {
             updM.timespec = makeTimespec(morningStartHours);
           }
+          if (moves(job, updM)) windowChanged = true;
           schedulesToUpdate.push(updM);
         } else if (code === 'handleEveningStop()') {
           var updE = {id: job.id, enable: newMode === 'summer', name: code};
           if (hasTimings && newMode === 'summer') {
             updE.timespec = makeTimespec(eveningStopHours);
           }
+          if (moves(job, updE)) windowChanged = true;
           schedulesToUpdate.push(updE);
         } else if (code === 'handleNightStart()' || code === 'handleNightStop()') {
-          schedulesToUpdate.push({id: job.id, enable: newMode === 'winter', name: code});
+          var updN = {id: job.id, enable: newMode === 'winter', name: code};
+          if (moves(job, updN)) windowChanged = true;
+          schedulesToUpdate.push(updN);
         }
       }
     }
@@ -1824,6 +1899,16 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
     function updateNext() {
       if (updateIndex >= schedulesToUpdate.length) {
         log('All schedules updated for', newMode, 'mode');
+        // #441: the window we just wrote may already contain (or no longer
+        // contain) "now" — e.g. the sunrise re-forecast moves the morning
+        // start into the past, or a restart re-runs this after the old
+        // window's start instant has passed. Nothing else re-evaluates:
+        // handleMorningStart()/handleEveningStop() only ever fire at their
+        // scheduled instant, and a schedule that was rewritten past that
+        // instant never fires at all — which is how the pool lost two whole
+        // days of filtration on 2026-08-05/06 under v0.11.10. Reconcile here,
+        // once, in the one place that knows the window moved.
+        if (windowChanged) queueTask(reconcileRunState);
         return;
       }
       var sched = schedulesToUpdate[updateIndex];
@@ -2008,99 +2093,50 @@ function handleNightStop() {
   doStop('Night stop event');
 }
 
-// === RESTART CATCH-UP (#421 Bug B) ===
+// === RUN-STATE RECONCILIATION (#421 Bug B, #441) ===
 // enforceOutputState() (below) only mirrors whatever physical state the
 // switch already has at boot — it never asks "should I actually be running
-// right now, given today's schedule window?". A restart (crash recovery,
-// script re-upload, device reboot) landing mid-window therefore silently
-// adopts a stale on/off state and only self-corrects whenever the next
-// schedule tick fires, which can be hours away. This is exactly what left a
-// live pump running hours past its scheduled evening-stop (see issue #421).
-// restartCatchUp() compares "now" against the currently active mode's
-// window — read straight from Schedule.List, the same source of truth
-// updateScheduleMode() writes to — and calls doStart()/doStop() immediately
-// if the physical state disagrees, instead of waiting for the next tick.
+// right now, given today's schedule window?". Two separate situations need
+// that question answered outside a schedule tick:
+//
+//   - #421 Bug B: a restart (crash recovery, script re-upload, device reboot)
+//     landing mid-window silently adopts a stale on/off state and only
+//     self-corrects at the next tick, which can be hours away. That left a
+//     live pump running hours past its scheduled evening-stop.
+//   - #441: updateScheduleMode() rewrites the window under a live script. If
+//     the new start instant is already in the past, its schedule job never
+//     fires at all — the pump simply never starts. That cost two full days of
+//     filtration on 2026-08-05/06 under v0.11.10.
+//
+// Both are the same question, so they share one predicate (isWithinRunWindow,
+// defined above next to makeTimespec) and one actuator (reconcileRunState).
 
-// Parses the "M H" fields out of a Shelly cron timespec built by
-// makeTimespec() ("0 M H * * DAYS") or a fixed literal ("0 15 23 * * ...").
-// Returns minutes-since-midnight, or null for formats it can't resolve
-// (e.g. still-symbolic "@sunrise" specs on a schedule that has never had
-// updateScheduleMode() compute real times for it yet) — those windows are
-// left alone rather than guessed at.
-function parseHM(timespec) {
-  if (!timespec || timespec.indexOf('@') === 0) return null;
-  var parts = timespec.split(' ');
-  if (parts.length < 3) return null;
-  var m = Number(parts[1]);
-  var h = Number(parts[2]);
-  if (isNaN(h) || isNaN(m)) return null;
-  return h * 60 + m;
+// Brings the physical pump state back in line with isWithinRunWindow().
+// Deliberately does nothing when the window is unresolvable (isWithinRunWindow
+// calls back null) or when the state already agrees — acting on a guess here
+// would start or stop the pump for no reason.
+//
+// `reason` is optional so this can be handed straight to queueTask(), which
+// invokes its tasks with no arguments.
+function reconcileRunState(reason) {
+  if (!isMyTurnToRun()) return;
+  var why = (reason || 'Schedule rewrite') + ': ';
+
+  isWithinRunWindow(function(shouldRun) {
+    var running = STATE.activeOutput !== -1;
+    if (shouldRun === null || shouldRun === running) {
+      log(why + 'no action', shouldRun, running);
+      return;
+    }
+    if (shouldRun) doStart(CONFIG.preferredSpeed, why + 'inside window');
+    else doStop(why + 'outside window');
+  });
 }
 
-var RC = 'Restart catch-up: '; // shared log/reason prefix
-
+// Named wrapper so init()'s call site keeps its #421 identity in the logs.
+// A closure at the call site would cost heap on every init; this does not.
 function restartCatchUp() {
-  if (!isMyTurnToRun()) {
-    return;
-  }
-
-  // Mode-aware on purpose: only one of these two job pairs is ever enabled
-  // at a time on a real device (updateScheduleMode() disables the other),
-  // so matching against the currently active mode avoids any ambiguity
-  // about which pair's timespec actually governs "now".
-  var mode = STATE.scheduleMode || 'winter';
-  var startCode = mode === 'summer' ? 'handleMorningStart()' : 'handleNightStart()';
-  var stopCode = mode === 'summer' ? 'handleEveningStop()' : 'handleNightStop()';
-
-  Shelly.call('Schedule.List', {}, function (result, err) {
-    // A failed lookup or an empty schedule is not the "unresolvable
-    // timespec" case below — it just means there is nothing to catch up
-    // against, so bail out quietly rather than guessing.
-    if (err || !result || !result.jobs) {
-      log(RC + 'lookup failed');
-      if (err && false) {}
-      return;
-    }
-
-    var startMin = null;
-    var stopMin = null;
-    for (var i = 0; i < result.jobs.length; i++) {
-      var job = result.jobs[i];
-      if (!job.enable || !job.calls || job.calls.length === 0) continue;
-      var code = job.calls[0].params && job.calls[0].params.code;
-      if (code === startCode) {
-        startMin = parseHM(job.timespec);
-      } else if (code === stopCode) {
-        stopMin = parseHM(job.timespec);
-      }
-    }
-
-    // Unresolvable timespec (e.g. still-symbolic "@sunrise", see parseHM
-    // above) — skip rather than act on a guess (#421 Bug B requirement).
-    if (startMin === null || stopMin === null) {
-      log(RC + 'unresolved', mode);
-      return;
-    }
-
-    var d = new Date();
-    var nowMin = d.getHours() * 60 + d.getMinutes();
-    // Handles windows that wrap past midnight (the fixed winter night-run
-    // 23:15 -> 00:15) by treating a start > stop pair as wrapping.
-    var shouldRun = startMin <= stopMin
-      ? (nowMin >= startMin && nowMin < stopMin)
-      : (nowMin >= startMin || nowMin < stopMin);
-    var isRunning = STATE.activeOutput !== -1;
-
-    log(RC, mode, nowMin, startMin, stopMin, shouldRun, isRunning);
-
-    if (shouldRun && !isRunning) {
-      doStart(CONFIG.preferredSpeed, RC + 'inside window');
-    } else if (!shouldRun && isRunning) {
-      doStop(RC + 'outside window');
-    } else {
-      log(RC + 'state OK');
-    }
-  });
+  reconcileRunState('Restart catch-up');
 }
 
 // === INITIALIZATION ===

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -759,5 +762,339 @@ func TestPoolPump_RestartCatchUp_StopsOutsideScheduleWindow(t *testing.T) {
 	}
 	if on, _ := entry["output"].(bool); on {
 		t.Errorf("restart outside scheduled window: switch:0 still physically on after catch-up")
+	}
+}
+
+// === Schedule-rewrite re-evaluation (#441) ===
+//
+// updateScheduleMode() rewrites the morning-start / evening-stop schedule jobs
+// from the day's forecast. Before #441 nothing re-evaluated the pump
+// afterwards, so a rewrite that moved the start into the past silently skipped
+// the whole day's filtration: handleMorningStart() only ever fires at its
+// scheduled instant, and an instant that has already passed never fires. That
+// is exactly what happened on the production pump on 2026-08-06.
+//
+// These tests drive the real path — init → handleDailyCheck() →
+// performDailyModeCheck() → forecast → decideModeFromForecast() →
+// updateScheduleMode() — against a local forecast server, and assert on the
+// pump state that results.
+
+// poolPumpForecastServer serves an Open-Meteo response shaped the way
+// pool-pump.js's onForecast() parses it: 24 hourly temperatures whose index is
+// the hour of day (so the index of the maximum becomes STATE.peakForecastHour)
+// plus one daily sunrise/sunset pair, which decideModeFromForecast() turns
+// into the window's start floor (sunrise + 1h) and stop ceiling (sunset - 0.5h).
+//
+// Local on purpose: the forecast fetch is a plain Shelly.call("HTTP.GET"),
+// which the emulator executes for real. Pointing it at a test server keeps
+// these tests deterministic and offline.
+func poolPumpForecastServer(t *testing.T, peakHour int, sunrise, sunset string) *httptest.Server {
+	t.Helper()
+
+	temps := make([]float64, 24)
+	for i := range temps {
+		temps[i] = 25
+	}
+	// Above poolPumpWindowKVS's max-temp, so computeRunHours()'s temperature
+	// scale clamps to 1 and run hours land exactly on the configured base hours.
+	temps[peakHour] = 40
+
+	body, err := json.Marshal(map[string]interface{}{
+		"hourly": map[string]interface{}{"temperature_2m": temps},
+		"daily": map[string]interface{}{
+			"sunrise": []string{"2026-08-07T" + sunrise},
+			"sunset":  []string{"2026-08-07T" + sunset},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build forecast body: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// poolPumpWindowKVS is pro1KVS() with the pool geometry rigged so
+// computeRunHours() returns exactly runHours: flow rate is
+// max-flow-rate × (eco-rpm / max-rpm) = 1 m³/h, and base hours are
+// pool-volume × turnover / flow = runHours.
+func poolPumpWindowKVS(runHours float64) map[string]interface{} {
+	kvs := pro1KVS()
+	kvs["script/pool-pump/pool-volume"] = strconv.FormatFloat(runHours, 'f', -1, 64)
+	kvs["script/pool-pump/turnover"] = "1"
+	kvs["script/pool-pump/max-flow-rate"] = "1"
+	kvs["script/pool-pump/eco-rpm"] = "2900"
+	kvs["script/pool-pump/max-rpm"] = "2900"
+	kvs["script/pool-pump/max-temp"] = "35"
+	kvs["script/pool-pump/temp-threshold"] = "20"
+	return kvs
+}
+
+// poolPumpTimespec renders the cron form makeTimespec() produces.
+func poolPumpTimespec(h, m int) string {
+	return fmt.Sprintf("0 %d %d * * SUN,MON,TUE,WED,THU,FRI,SAT", m, h)
+}
+
+// poolPumpSummerSchedules is a complete summer-mode job set: a daily check, a
+// morning/evening pair at the given times, and the two night jobs already
+// disabled — which is what summer mode looks like on a real device.
+func poolPumpSummerSchedules(start, stop time.Time) []map[string]interface{} {
+	job := func(id int, code, timespec string, enable bool) map[string]interface{} {
+		return map[string]interface{}{
+			"id": id, "enable": enable, "timespec": timespec,
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": code},
+			}},
+		}
+	}
+	return []map[string]interface{}{
+		job(1, "handleDailyCheck()", "@sunrise * * SUN,MON,TUE,WED,THU,FRI,SAT", true),
+		job(2, "handleMorningStart()", poolPumpTimespec(start.Hour(), start.Minute()), true),
+		job(3, "handleEveningStop()", poolPumpTimespec(stop.Hour(), stop.Minute()), true),
+		job(4, "handleNightStart()", poolPumpTimespec(23, 15), false),
+		job(5, "handleNightStop()", poolPumpTimespec(0, 15), false),
+	}
+}
+
+// poolPumpScheduleTimespec reads back the timespec currently on the job whose
+// script.eval code matches, so a test can prove the rewrite actually landed
+// before asserting on what the rewrite should have caused.
+func poolPumpScheduleTimespec(schedules []map[string]interface{}, code string) string {
+	for _, job := range schedules {
+		calls, ok := job["calls"].([]interface{})
+		if !ok || len(calls) == 0 {
+			continue
+		}
+		call, ok := calls[0].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		params, ok := call["params"].(map[string]interface{})
+		if !ok || params["code"] != code {
+			continue
+		}
+		if ts, ok := job["timespec"].(string); ok {
+			return ts
+		}
+	}
+	return ""
+}
+
+// poolPumpRewriteResult runs the script against the given fixture, waits for
+// the schedule rewrite to land, then reports the active-output the script
+// settled on. wantOutput is what the caller expects; the helper polls for it
+// so a passing test finishes quickly and a failing one still reports the
+// value actually reached.
+func poolPumpRewriteResult(t *testing.T, deviceState *script.DeviceState, wantOutput string) (string, []map[string]interface{}) {
+	t.Helper()
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	ctx, cancel := context.WithTimeout(
+		logr.NewContext(context.Background(), testr.New(t)),
+		30*time.Second,
+	)
+	defer cancel()
+
+	buf := readPoolPumpScript(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	// The rewrite has to land before the reconciliation it triggers can be
+	// judged, so wait for the morning job's timespec to change first.
+	initial := poolPumpScheduleTimespec(deviceState.Schedules, "handleMorningStart()")
+	if !waitFor(15*time.Second, 100*time.Millisecond, func() bool {
+		return poolPumpScheduleTimespec(deviceState.Schedules, "handleMorningStart()") != initial
+	}) {
+		cancel()
+		<-done
+		t.Fatalf("schedule rewrite never happened (morning start still %q)", initial)
+	}
+
+	// Then give the reconciliation its own window to act — or to provably not.
+	waitFor(8*time.Second, 100*time.Millisecond, func() bool {
+		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		return ok && v == wantOutput
+	})
+
+	got, _ := deviceState.KVS["script/pool-pump/active-output"].(string)
+	schedules := deviceState.Schedules
+	cancel()
+	<-done
+	return got, schedules
+}
+
+// Two window shapes, both derived from the forecast by decideModeFromForecast():
+//
+//   - wide: sunrise 00:00 → start floor 01:00; sunset 23:59 → stop ceiling
+//     23:29; peak at noon with 22.48 run hours. The unclamped window starts
+//     before the floor, so it is pinned to [01:00, 23:29) — containing almost
+//     any "now".
+//   - narrow: peak at 02:00 with 0.1 run hours → [01:57, 02:03), excluding
+//     almost any "now".
+const (
+	poolPumpWideRunHours   = 22.48
+	poolPumpWidePeakHour   = 12
+	poolPumpWideStartMin   = 60   // 01:00
+	poolPumpWideStopMin    = 1409 // 23:29
+	poolPumpNarrowRunHours = 0.1
+	poolPumpNarrowPeakHour = 2
+	poolPumpNarrowStartMin = 117 // 01:57
+	poolPumpNarrowStopMin  = 123 // 02:03
+)
+
+// nowMinutes is the minutes-since-midnight value pool-pump.js's
+// isWithinRunWindow() computes from new Date().
+func nowMinutes() int {
+	now := time.Now()
+	return now.Hour()*60 + now.Minute()
+}
+
+// skipUnlessNowInside guards the one wall-clock dependency these tests cannot
+// design away: pool-pump.js derives the window from a real forecast and
+// compares it against the device's real clock, and its own clamps refuse to
+// schedule a start before 01:00 — so "now is inside the window" is simply not
+// expressible during the midnight hour.
+func skipUnlessNowInside(t *testing.T, startMin, stopMin int) {
+	t.Helper()
+	if n := nowMinutes(); n < startMin || n >= stopMin {
+		t.Skipf("local time %02d:%02d is outside the [%d, %d) minute window this scenario builds",
+			n/60, n%60, startMin, stopMin)
+	}
+}
+
+func skipIfNowInside(t *testing.T, startMin, stopMin int) {
+	t.Helper()
+	if n := nowMinutes(); n >= startMin && n < stopMin {
+		t.Skipf("local time %02d:%02d falls inside the [%d, %d) minute window this scenario builds",
+			n/60, n%60, startMin, stopMin)
+	}
+}
+
+// A rewrite that moves the morning start from the future into the past, with
+// "now" inside the new window, must start the pump. This is the 2026-08-06
+// production failure: without the fix the pump stays off for the whole day.
+func TestPoolPump_ScheduleRewriteIntoPastStartsPump(t *testing.T) {
+	skipUnlessNowInside(t, poolPumpWideStartMin, poolPumpWideStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpWidePeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpWideRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off
+		// Old window: the start is still ahead of us, so nothing was due yet.
+		Schedules: poolPumpSummerSchedules(now.Add(2*time.Hour), now.Add(4*time.Hour)),
+	}
+
+	got, schedules := poolPumpRewriteResult(t, deviceState, "0")
+
+	if ts := poolPumpScheduleTimespec(schedules, "handleMorningStart()"); ts != poolPumpTimespec(1, 0) {
+		t.Fatalf("expected morning start rewritten to 01:00, got %q", ts)
+	}
+	if got != "0" {
+		t.Fatalf("rewrite moved the start into the past with now inside the new window: "+
+			"expected the pump to start (active-output=0), got %q", got)
+	}
+}
+
+// The sunrise case, with no restart involved: the previous window has already
+// elapsed, the daily re-forecast rewrites it to one containing "now", and the
+// pump must start even though no schedule job fires.
+func TestPoolPump_SunriseRewriteStartsPump(t *testing.T) {
+	skipUnlessNowInside(t, poolPumpWideStartMin, poolPumpWideStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpWidePeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpWideRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off, correctly so
+		// Yesterday's window, entirely behind us.
+		Schedules: poolPumpSummerSchedules(now.Add(-5*time.Hour), now.Add(-4*time.Hour)),
+	}
+
+	got, _ := poolPumpRewriteResult(t, deviceState, "0")
+	if got != "0" {
+		t.Fatalf("sunrise rewrite brought now inside the window: "+
+			"expected the pump to start (active-output=0), got %q", got)
+	}
+}
+
+// The converse: a rewrite that moves the window off "now" must stop a pump
+// that is currently running, rather than leave it running until an
+// evening-stop instant that no longer matches anything.
+func TestPoolPump_ScheduleRewriteAwayStopsPump(t *testing.T) {
+	skipIfNowInside(t, poolPumpNarrowStartMin, poolPumpNarrowStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpNarrowPeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	cs := pro1ComponentStatus()
+	cs["switch:0"] = map[string]interface{}{"id": 0, "output": true} // running
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpNarrowRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: cs,
+		// Old window contains "now", which is why the pump is running.
+		Schedules: poolPumpSummerSchedules(now.Add(-1*time.Hour), now.Add(1*time.Hour)),
+	}
+
+	got, schedules := poolPumpRewriteResult(t, deviceState, "-1")
+
+	if ts := poolPumpScheduleTimespec(schedules, "handleMorningStart()"); ts != poolPumpTimespec(1, 57) {
+		t.Fatalf("expected morning start rewritten to 01:57, got %q", ts)
+	}
+	if got != "-1" {
+		t.Fatalf("rewrite moved the window off now: "+
+			"expected the running pump to stop (active-output=-1), got %q", got)
+	}
+}
+
+// Regression guard: a rewrite that leaves the pump correctly off — "now" is
+// outside both the old and the new window — must not start it.
+func TestPoolPump_ScheduleRewriteOutsideWindowDoesNotStartPump(t *testing.T) {
+	skipIfNowInside(t, poolPumpNarrowStartMin, poolPumpNarrowStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpNarrowPeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpNarrowRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off
+		Schedules:       poolPumpSummerSchedules(now.Add(-5*time.Hour), now.Add(-4*time.Hour)),
+	}
+
+	// Ask for "0" so the helper spends its full budget looking for a start
+	// that must never come.
+	got, _ := poolPumpRewriteResult(t, deviceState, "0")
+	if got != "-1" {
+		t.Fatalf("now is outside the rewritten window: "+
+			"expected the pump to stay off (active-output=-1), got %q", got)
 	}
 }

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -865,6 +865,21 @@ func deferDispatch(handlers *[]handler, delay time.Duration, dispatch func()) {
 
 type methodFunc func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error)
 
+// scheduleID normalises a job's "id" field to an int. Jobs reach
+// DeviceState.Schedules either from a Go test fixture (int), from JSON
+// (float64) or from AddSchedule (int), so a bare type assertion is not enough.
+func scheduleID(v interface{}) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	}
+	return -1
+}
+
 func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 	return map[string]methodFunc{
 		"shelly.detectlocation": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
@@ -1052,6 +1067,67 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
 				if callable, ok := goja.AssertFunction(callback); ok {
 					result := map[string]interface{}{"id": id}
+					callable(goja.Undefined(), vm.ToValue(result), vm.ToValue(0), goja.Null(), userdata)
+				}
+			}
+			return nil, nil
+		},
+
+		// Schedule.Update — merge the given fields into an existing job.
+		// https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Schedule#scheduleupdate
+		// Without this, Shelly.call('Schedule.Update', ...) fell through to the
+		// unknown-method path: the callback fired with a null result and the
+		// job was never modified, so a script that rewrites its own schedule
+		// (pool-pump.js updateScheduleMode) appeared to succeed while
+		// Schedule.List kept returning the old window — see #441.
+		"schedule.update": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
+			paramsObj := params.ToObject(vm)
+			id := int(paramsObj.Get("id").ToInteger())
+			updates, _ := params.Export().(map[string]interface{})
+
+			var updated map[string]interface{}
+			for _, job := range deviceState.Schedules {
+				if scheduleID(job["id"]) != id {
+					continue
+				}
+				for k, v := range updates {
+					if k == "id" {
+						continue
+					}
+					job[k] = v
+				}
+				updated = job
+				break
+			}
+
+			if updated == nil {
+				if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
+					if callable, ok := goja.AssertFunction(callback); ok {
+						callable(goja.Undefined(), goja.Null(), vm.ToValue(-105),
+							vm.ToValue(fmt.Sprintf("no schedule with id %d", id)), userdata)
+					}
+				}
+				return nil, nil
+			}
+
+			// Keep the schedule:N component view in step with the job, the
+			// same way Schedule.Create does.
+			if deviceState.ComponentStatus != nil {
+				deviceState.ComponentStatus[fmt.Sprintf("schedule:%d", id)] = map[string]interface{}{
+					"id":       id,
+					"enable":   updated["enable"],
+					"timespec": updated["timespec"],
+					"calls":    updated["calls"],
+				}
+			}
+
+			if deviceState.OnModified != nil {
+				deviceState.OnModified()
+			}
+
+			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
+				if callable, ok := goja.AssertFunction(callback); ok {
+					result := map[string]interface{}{"rev": 1}
 					callable(goja.Undefined(), vm.ToValue(result), vm.ToValue(0), goja.Null(), userdata)
 				}
 			}


### PR DESCRIPTION
Backport of #442 to the release line. Fixes #441 on `v0.11.x`.

**This is the branch that matters for the live system.** v0.11.10 is installed on the production
pump today and carries the regression: the last `pool.pump_start` before 2026-08-07 was
**2026-08-04 14:52:45** — two full days (08-05, 08-06) with zero filtration. The `main` fix (#442)
does not help the device that is actually broken.

## The bug

`restartCatchUp()` read the run window and `handleDailyCheck()` rewrote it immediately afterwards,
on every script init — not just at sunrise. When the rewrite moved the morning start into the past,
nothing re-evaluated: a schedule job whose instant has already passed never fires, so the pump
simply never started. The evening stop still fired, which is why the log looked superficially normal.

## Adapted, not cherry-picked

The release line has diverged from `main`: it already carries `parseHM()` and `restartCatchUp()`
from #434, which `main` does not have (they live in still-draft PR #426 there). So this is a
port of the *design*, not the patch:

- **`parseHM()` is reused, not duplicated** — and moved up next to `makeTimespec()`, whose inverse
  it is, matching #442's layout so the two branches stay comparable for future backports.
- **`restartCatchUp()`'s body becomes `isWithinRunWindow()`** — the single "should I be running
  now?" predicate — **plus `reconcileRunState()`**, the single actuator. `restartCatchUp()` survives
  as a one-line named wrapper so `init()`'s call site keeps its #421 identity in the logs; a closure
  at the call site would cost heap on every init, a named function does not.
- **`updateScheduleMode()` now tracks whether it actually moved the window** (`moves()`) and queues
  one reconciliation when it did. A no-op sunrise re-run — the common case, and the reason the pump
  happened to work on 2026-08-07 — reconciles nothing.

Net effect: exactly one window predicate on this branch, as #441 required. #437's `isWithinRunWindow`
should call this one when it lands rather than adding a copy.

## Emulator gap — same on this branch

`Schedule.Update` was **never implemented** in `pkg/shelly/script/run.go` here either. It fell
through to the unknown-method path: the callback fired with a null result and the job was never
modified, so a script rewriting its own schedule appeared to succeed while `Schedule.List` kept
returning the old window. Without this, the new tests cannot observe anything at all. Ported from
#442 unchanged.

## Test evidence

Four tests from #441's test plan, driving the real path (init → `handleDailyCheck()` →
`performDailyModeCheck()` → forecast → `decideModeFromForecast()` → `updateScheduleMode()`) against
a local `httptest` forecast server.

**Before the JS fix** (fix stashed, emulator + tests in place):

```
--- FAIL: TestPoolPump_ScheduleRewriteIntoPastStartsPump  (14.71s)
    rewrite moved the start into the past with now inside the new window:
    expected the pump to start (active-output=0), got "-1"
--- FAIL: TestPoolPump_SunriseRewriteStartsPump           (14.72s)
    sunrise rewrite brought now inside the window:
    expected the pump to start (active-output=0), got "-1"
--- FAIL: TestPoolPump_ScheduleRewriteAwayStopsPump       (14.72s)
    rewrite moved the window off now:
    expected the running pump to stop (active-output=-1), got "0"
```

**After:** all four pass.

`make test` (foreground, canonical): **46 ok, 0 failures** — exactly the documented `v0.11.x`
baseline. (Note `main` currently carries one pre-existing failure,
`TestGarden_LawnFiresTogetherBedsIndependent`; this branch does not.)

## Heap cost — measured on real hardware

`mezzanine` (Pro1, fw 2.0.0), with all 27 of the production pump's `script/pool-pump/*` KVS keys
replicated and `watchdog.js` running alongside, sampled via `Script.GetStatus` until `mem_peak`
settled:

| script on `mezzanine` | `mem_peak` | reproduced |
|---|---|---|
| `v0.11.x` @c444f9c (baseline) | **17038** | 2/2 cycles |
| this branch | **17290** | 2/2 cycles |

**+252 bytes.** `mem_peak` was watched until flat rather than sampled once — it climbs for ~30s
after start before settling, so a single early sample under-reports it.

Against the production pump, read live during this work:

```
filtration-hiver  script 2 (pool-pump.js)  mem_used 12782  mem_peak 20454  mem_free 10248
```

Total heap 23030 → **2576 bytes free at peak**, leaving ~2324 after this change. Comfortable.

`mezzanine` was fully restored afterwards and verified field by field: script deleted, all 27 KVS
keys purged (back to its original 3 keys), `switch:0` back to `in_mode: momentary` with no name,
input names cleared, **light OFF**. It created no schedules, so none needed deleting. Its
`status-listener.js` / `blu-listener.js` remain stopped — that is the pre-existing restore
obligation recorded in #440, not something this work introduced.

## Merge readiness

I consider this mergeable, with one caveat stated plainly: **merging here auto-tags a patch release
and drafts a GitHub release**, so it ships to the pump.

The caveat: the on-device run proves init survival and heap cost, not the reconciliation's *start*
action. `mezzanine` was deliberately configured so it could never energise a real light —
`script/pool-pump/preferred` left pointing at the pump's ID (so `isMyTurnToRun()` is false) and
`speed=off`. The start/stop behaviour itself is proven by the four emulator tests. Fully exercising
`doStart` on hardware would mean switching on a real household light.

## Related

- #441 (the bug), #442 (the `main` fix this ports), #434 / #421 (what shipped in v0.11.10),
  #437 / #436 (should reuse `isWithinRunWindow` rather than adding a copy), #440 (campaign handover).
- The 02:00 `Evening stop event` anomaly noted in #441 is **not** the pump and needs no code change —
  it came from `development`'s leftover retimed test jobs. See
  https://github.com/asnowfix/home-automation/issues/441#issuecomment-5213930074.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): re-evaluate the pump when a schedule rewrite moves the run window (#441) ([d20d749](https://github.com/asnowfix/home-automation/commit/d20d749ea5db189e5025293605a49e8231e2303b))
<!-- END-AUTO-GENERATED-COMMITS -->