### PR TITLE
test(garden): unblock main — stop asserting the lawn zones' shipped enabled state in a grouping test

### DIFF
--- a/internal/shelly/scripts/garden_test.go
+++ b/internal/shelly/scripts/garden_test.go
@@ -98,6 +98,15 @@ func zonePlanIDs(t *testing.T, raw string) map[int]int {
 func TestGarden_LawnFiresTogetherBedsIndependent(t *testing.T) {
 	vm := gardenVM(t)
 
+	// The lawn zones ship disabled (23e7307, "disable zone-0/1 by default, as
+	// KVS is not read (yet)"), and computeZonePlan() skips disabled zones
+	// before any grouping logic runs — so with the shipped defaults this test
+	// would assert nothing at all. Enable them explicitly: what is under test
+	// here is the grouping rule, not which zones happen to be switched on in
+	// production. TestGarden_DisabledZoneStaysOutOfPlan below covers the
+	// shipped default itself.
+	mustEval(t, vm, `ZONES[0].enabled = true; ZONES[1].enabled = true;`)
+
 	// Zone 0 above its 12mm trigger, zone 1 below it (but in the same "lawn"
 	// group as zone 0), zone 2 (massifs) below its 8mm trigger.
 	mustEval(t, vm, `storeStorageValue(deficitKey(0), 15);`)
@@ -125,6 +134,12 @@ func TestGarden_LawnFiresTogetherBedsIndependent(t *testing.T) {
 // the script's current default is instead of silently going stale.
 func TestGarden_GroupCadenceGate(t *testing.T) {
 	vm := gardenVM(t)
+
+	// Same reason as above: with the shipped defaults the lawn zones are
+	// disabled, which would make this test's two "lawn stays gated"
+	// assertions pass vacuously — they would hold even if cadence gating were
+	// completely broken. Enable them so the gate is actually exercised.
+	mustEval(t, vm, `ZONES[0].enabled = true; ZONES[1].enabled = true;`)
 
 	// All zones comfortably over trigger so deficit never gates the result —
 	// only the group-cadence check should determine inclusion/exclusion.
@@ -160,5 +175,44 @@ func TestGarden_GroupCadenceGate(t *testing.T) {
 	}
 	if _, ok := plan[2]; !ok {
 		t.Errorf("expected massifs (zone 2) to be due again, got %v", plan)
+	}
+}
+
+// TestGarden_DisabledZoneStaysOutOfPlan covers the shipped ZONE_DEFAULTS
+// directly: the lawn zones are disabled (23e7307, "disable zone-0/1 by
+// default, as KVS is not read (yet)"), so they must not appear in a plan even
+// when their deficit is far over trigger, while the enabled beds zone still
+// does.
+//
+// This exists so the default is asserted by a test whose subject it actually
+// is. Before this, the only thing standing on it was
+// TestGarden_LawnFiresTogetherBedsIndependent — a grouping test — which
+// simply started failing when the default flipped, blocking every PR into
+// main rather than reporting a garden regression.
+func TestGarden_DisabledZoneStaysOutOfPlan(t *testing.T) {
+	vm := gardenVM(t)
+
+	if enabled := mustEval(t, vm, `ZONES[0].enabled || ZONES[1].enabled`).ToBoolean(); enabled {
+		t.Fatalf("expected the shipped defaults to leave both lawn zones disabled; " +
+			"if that changed deliberately, update this test and the two above it")
+	}
+
+	// Every zone far over its trigger: only the enabled/disabled flag can
+	// decide who makes the plan.
+	mustEval(t, vm, `storeStorageValue(deficitKey(0), 25);`)
+	mustEval(t, vm, `storeStorageValue(deficitKey(1), 25);`)
+	mustEval(t, vm, `storeStorageValue(deficitKey(2), 25);`)
+
+	raw := mustEval(t, vm, `JSON.stringify(computeZonePlan())`).String()
+	plan := zonePlanIDs(t, raw)
+
+	if _, ok := plan[0]; ok {
+		t.Errorf("disabled lawn zone 0 must stay out of the plan, got %v", plan)
+	}
+	if _, ok := plan[1]; ok {
+		t.Errorf("disabled lawn zone 1 must stay out of the plan, got %v", plan)
+	}
+	if _, ok := plan[2]; !ok {
+		t.Errorf("enabled beds zone 2 should still be planned, got %v", plan)
 	}
 }


### PR DESCRIPTION
`TestGarden_LawnFiresTogetherBedsIndependent` has been failing on `main` since **23e7307**
("bug: disable zone-0/1 by default, as KVS is not read (yet)"), which blocks the `build` job and
therefore **every PR into `main`** — including #442, the pool-pump #441 fix.

## Why it broke

`23e7307` flipped `ZONE_DEFAULTS[0].enabled` and `[1].enabled` to `false`. That is a deliberate
production change, not a bug. But `computeZonePlan()` skips disabled zones before any grouping logic
runs:

```js
for (...) {
  if (!z.enabled) continue;
  ...
}
```

so a test asserting "lawn zones 0 and 1 fire together" now asserts nothing and fails:

```
--- FAIL: TestGarden_LawnFiresTogetherBedsIndependent
    garden_test.go:111: expected zone 0 (over trigger) in plan, got map[]
    garden_test.go:114: expected lawn zone 1 to fire together with zone 0, got map[]
```

The script is correct. The test was standing on an incidental property of the shipped defaults.

## What this changes

- **`TestGarden_LawnFiresTogetherBedsIndependent`** enables zones 0 and 1 explicitly before
  computing a plan. What it is about is the grouping rule, not which zones happen to be switched on
  in production.
- **`TestGarden_GroupCadenceGate`** gets the same treatment, for a quieter reason: with the lawn
  zones disabled, its two "lawn stays gated" assertions were passing **vacuously** — they would have
  held even if cadence gating were completely broken. It was green, and meaningless.
- **New `TestGarden_DisabledZoneStaysOutOfPlan`** asserts the shipped default directly: with every
  zone far over trigger, the two disabled lawn zones stay out of the plan and the enabled beds zone
  does not. It also fails loudly if the defaults change, pointing at the two tests above.

Net effect: the next flip of that flag fails a garden test whose subject is that flag, instead of
breaking an unrelated grouping test and stopping all merges.

## Verification

```
=== RUN   TestGarden_LawnFiresTogetherBedsIndependent
--- PASS: TestGarden_LawnFiresTogetherBedsIndependent (0.00s)
=== RUN   TestGarden_GroupCadenceGate
--- PASS: TestGarden_GroupCadenceGate (0.00s)
=== RUN   TestGarden_DisabledZoneStaysOutOfPlan
--- PASS: TestGarden_DisabledZoneStaysOutOfPlan (0.00s)
```

`make test` (foreground, canonical): **47 ok, 0 failures** — the documented `main` baseline, restored.

No production code changes: `garden.js` is untouched, so there is no device impact and no degraded
mode to describe.

## Merge order

This should land **before** #442, which cannot go green until `main` is green.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- test(garden): stop asserting the lawn zones' shipped enabled state in a grouping test ([ac71cd5](https://github.com/asnowfix/home-automation/commit/ac71cd5fae542ac5065c7d211950dd47db203810))
<!-- END-AUTO-GENERATED-COMMITS -->