### PR TITLE
fix(script emulator): guard DeviceState with a mutex so tests stop racing the script (#451)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,14 +183,39 @@ status-local-daemon:
 logs-local-daemon:
 	@tail -n 100 -f "$(LOCAL_DAEMON_LOG)"
 
+# TESTFLAGS is threaded through both test invocations so the race detector can
+# be switched on without editing this file:
+#
+#   make test-race          # or: make test TESTFLAGS=-race
+#
+# Races here are not merely flaky. The goja script emulator runs the script
+# under test on its own goroutine while tests poll DeviceState, and an
+# unsynchronised map read racing a write aborts the whole test binary with
+# "fatal error: concurrent map read and map write", losing every result in the
+# package rather than failing one test (#451).
+#
+# -race is not the default *yet* only because pkg/beem still races on its
+# package-level loginURL/summaryURL globals, which needs those URLs moved into
+# ClientConfig (see the issue filed alongside #451, and #362 on removing
+# package-level singletons). internal/shelly/scripts, pkg/shelly/script and
+# myhome/daemon are all clean under -race as of this change, so flipping the
+# default is a one-line change once pkg/beem follows.
+TESTFLAGS ?=
+
 test: build
-	$(GO) test ./...
+	$(GO) test $(TESTFLAGS) ./...
 	@rc=0; for dir in $$(awk '/\t\.\//{sub(/\t\.\//, ""); print}' go.work); do \
 	  if find $$dir \( -mindepth 1 -type d -exec test -f "{}/go.mod" \; -prune \) \
 	          -o \( -type f -name "*_test.go" -print -quit \) 2>/dev/null | grep -q .; then \
-	    (cd $$dir && $(GO) test ./...) || rc=1; \
+	    (cd $$dir && $(GO) test $(TESTFLAGS) ./...) || rc=1; \
 	  fi; \
 	done; exit $$rc
+
+# test-race runs the same suite with the race detector. These tests are
+# wall-clock bound rather than CPU bound, so it costs little: the full run is
+# roughly 4-7 minutes either way.
+test-race:
+	$(MAKE) test TESTFLAGS=-race
 
 cover: build
 	@mkdir -p coverage

--- a/internal/shelly/scripts/blu_listener_test.go
+++ b/internal/shelly/scripts/blu_listener_test.go
@@ -76,7 +76,7 @@ func switchIsOn(deviceState *script.DeviceState, switchKey string) bool {
 	if deviceState.ComponentStatus == nil {
 		return false
 	}
-	v, ok := deviceState.ComponentStatus[switchKey]
+	v, ok := componentStatusValue(deviceState, switchKey)
 	if !ok {
 		return false
 	}
@@ -335,7 +335,9 @@ func TestBluListener_KVSReloadPicksUpNewFollow(t *testing.T) {
 		"switch_id": "switch:0",
 		"auto_off":  0,
 	})
-	state.KVS["follow/shelly-blu/"+mac] = string(v)
+	// Written through the accessor: the script goroutine is already running and
+	// reading KVS, so a direct map write here races it (#451).
+	state.SetKVSValue("follow/shelly-blu/"+mac, string(v))
 
 	// Inject KVS change event to trigger reload
 	kvsEvent, _ := json.Marshal(map[string]interface{}{

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -239,7 +239,7 @@ func TestPoolPump_InitVerifiesSchedules(t *testing.T) {
 	}()
 
 	ok := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	cancel()
@@ -281,7 +281,7 @@ func TestPoolPump_WaterSupplyRestoresSpeed(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -290,7 +290,7 @@ func TestPoolPump_WaterSupplyRestoresSpeed(t *testing.T) {
 		t.Fatalf("script did not complete init within timeout")
 	}
 
-	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "2" {
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "2" {
 		t.Fatalf("expected active-output=2 after init, got %v", v)
 	}
 
@@ -303,17 +303,17 @@ func TestPoolPump_WaterSupplyRestoresSpeed(t *testing.T) {
 	// pushing timing-sensitive tests").
 	injector <- shellyInputEvent(0, true)
 	stopped := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	})
 	if !stopped {
 		t.Fatalf("pump did not stop after water supply ON; active-output = %v",
-			deviceState.KVS["script/pool-pump/active-output"])
+			kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	injector <- shellyInputEvent(0, false)
 	restored := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "2"
 	})
 
@@ -322,7 +322,7 @@ func TestPoolPump_WaterSupplyRestoresSpeed(t *testing.T) {
 
 	if !restored {
 		t.Fatalf("pump speed not restored after water supply OFF; active-output = %v",
-			deviceState.KVS["script/pool-pump/active-output"])
+			kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 }
 
@@ -355,7 +355,7 @@ func TestPoolPump_ButtonCyclesPro3(t *testing.T) {
 
 	// Wait for init.
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -365,50 +365,50 @@ func TestPoolPump_ButtonCyclesPro3(t *testing.T) {
 	}
 
 	// Start from off.
-	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "-1" {
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "-1" {
 		t.Fatalf("expected active-output=-1 before button presses, got %v", v)
 	}
 
 	// Press 1: off → 0
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "0"
 	}) {
-		t.Fatalf("button press 1: expected active-output=0, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("button press 1: expected active-output=0, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Press 2: 0 → 1
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "1"
 	}) {
-		t.Fatalf("button press 2: expected active-output=1, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("button press 2: expected active-output=1, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Press 3: 1 → 2
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "2"
 	}) {
-		t.Fatalf("button press 3: expected active-output=2, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("button press 3: expected active-output=2, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Press 4: 2 → off (exercises turnOffAllSwitches)
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	}) {
-		t.Fatalf("button press 4: expected active-output=-1, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("button press 4: expected active-output=-1, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Verify all switches are off.
 	for i := 0; i < 3; i++ {
 		key := fmt.Sprintf("switch:%d", i)
-		if entry, ok := deviceState.ComponentStatus[key]; ok {
+		if entry, ok := componentStatusValue(deviceState, key); ok {
 			if m, ok := entry.(map[string]interface{}); ok {
 				if on, _ := m["output"].(bool); on {
 					t.Errorf("switch %d still on after cycling to off", i)
@@ -454,7 +454,7 @@ func TestPoolPump_Pro1ToggleAndWaterSupply(t *testing.T) {
 
 	// Wait for init.
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -464,35 +464,35 @@ func TestPoolPump_Pro1ToggleAndWaterSupply(t *testing.T) {
 	}
 
 	// Should start off.
-	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "-1" {
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "-1" {
 		t.Fatalf("Pro1: expected active-output=-1 after init, got %v", v)
 	}
 
 	// Button press: toggle ON
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "0"
 	}) {
-		t.Fatalf("Pro1 toggle on: expected active-output=0, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("Pro1 toggle on: expected active-output=0, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Button press: toggle OFF (exercises turnOffAllSwitches on Pro1)
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	}) {
-		t.Fatalf("Pro1 toggle off: expected active-output=-1, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("Pro1 toggle off: expected active-output=-1, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Toggle ON again for water supply test.
 	injector <- shellyButtonEvent()
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "0"
 	}) {
-		t.Fatalf("Pro1 toggle on (2): expected active-output=0, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("Pro1 toggle on (2): expected active-output=0, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Water supply ON → should turn off. 5s (not 2s): activateOutput() now
@@ -501,19 +501,19 @@ func TestPoolPump_Pro1ToggleAndWaterSupply(t *testing.T) {
 	// TestPoolPump_WaterSupplyRestoresSpeed.
 	injector <- shellyInputEvent(0, true)
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	}) {
-		t.Fatalf("Pro1 water supply ON: expected active-output=-1, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("Pro1 water supply ON: expected active-output=-1, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Water supply OFF → should restore switch:0.
 	injector <- shellyInputEvent(0, false)
 	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "0"
 	}) {
-		t.Fatalf("Pro1 water supply OFF: expected active-output=0, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("Pro1 water supply OFF: expected active-output=0, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	cancel()
@@ -553,7 +553,7 @@ func dateString(t time.Time) string {
 
 func parseKVSInt(t *testing.T, deviceState *script.DeviceState, key string) int64 {
 	t.Helper()
-	raw, ok := deviceState.KVS[key]
+	raw, ok := deviceState.KVSValue(key)
 	if !ok {
 		t.Fatalf("KVS key %q not present", key)
 	}
@@ -567,7 +567,7 @@ func parseKVSInt(t *testing.T, deviceState *script.DeviceState, key string) int6
 
 func parseKVSFloat(t *testing.T, deviceState *script.DeviceState, key string) float64 {
 	t.Helper()
-	raw, ok := deviceState.KVS[key]
+	raw, ok := deviceState.KVSValue(key)
 	if !ok {
 		t.Fatalf("KVS key %q not present", key)
 	}
@@ -621,7 +621,7 @@ func TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -640,7 +640,7 @@ func TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover(t *testing.T) {
 	// Water supply ON stops the pump: activateOutput(-1, ...) -> stopRuntimeAccounting().
 	injector <- shellyInputEvent(0, true)
 	stopped := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	})
 	elapsed := time.Since(runStart)
@@ -648,7 +648,7 @@ func TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover(t *testing.T) {
 	<-done
 
 	if !stopped {
-		t.Fatalf("pump did not stop after water supply ON; active-output = %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("pump did not stop after water supply ON; active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	runtimeSec := parseKVSInt(t, deviceState, "script/pool-pump/runtime-sec")
@@ -710,7 +710,7 @@ func TestPoolPump_RuntimeAccounting_ContinuesAfterReboot(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -725,14 +725,14 @@ func TestPoolPump_RuntimeAccounting_ContinuesAfterReboot(t *testing.T) {
 
 	injector <- shellyInputEvent(0, true)
 	stopped := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	})
 	cancel()
 	<-done
 
 	if !stopped {
-		t.Fatalf("pump did not stop after water supply ON; active-output = %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("pump did not stop after water supply ON; active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	runtimeSec := parseKVSInt(t, deviceState, "script/pool-pump/runtime-sec")
@@ -790,7 +790,7 @@ func TestPoolPump_RuntimeAccounting_StaleDateResetsOnBoot(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	cancel()
@@ -800,10 +800,10 @@ func TestPoolPump_RuntimeAccounting_StaleDateResetsOnBoot(t *testing.T) {
 		t.Fatalf("init timeout")
 	}
 
-	if got := deviceState.Storage["runtime-date"]; got != dateString(time.Now()) {
+	if got := storageValue(deviceState, "runtime-date"); got != dateString(time.Now()) {
 		t.Errorf("Storage runtime-date = %v, want today (%s)", got, dateString(time.Now()))
 	}
-	if got := deviceState.Storage["runtime-sec"]; got != "0" {
+	if got := storageValue(deviceState, "runtime-sec"); got != "0" {
 		t.Errorf("Storage runtime-sec = %v, want \"0\" (stale total must not carry over)", got)
 	}
 }
@@ -872,7 +872,7 @@ func TestPoolPump_SolarStartsAndStopsPump(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -887,13 +887,13 @@ func TestPoolPump_SolarStartsAndStopsPump(t *testing.T) {
 	}
 
 	started := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "0" // eco switch, per controllerKVS()'s eco-speed=0
 	})
 	if !started {
 		cancel()
 		<-done
-		t.Fatalf("solar start: expected active-output=0, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("solar start: expected active-output=0, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
 	// Fresh (ts = now), below the 200W stop threshold.
@@ -902,7 +902,7 @@ func TestPoolPump_SolarStartsAndStopsPump(t *testing.T) {
 	}
 
 	stopped := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	})
 
@@ -910,7 +910,7 @@ func TestPoolPump_SolarStartsAndStopsPump(t *testing.T) {
 	<-done
 
 	if !stopped {
-		t.Fatalf("solar stop: expected active-output=-1, got %v", deviceState.KVS["script/pool-pump/active-output"])
+		t.Fatalf("solar stop: expected active-output=-1, got %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 }
 
@@ -949,7 +949,7 @@ func TestPoolPump_SolarRespectsHardCeiling(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -969,7 +969,7 @@ func TestPoolPump_SolarRespectsHardCeiling(t *testing.T) {
 	cancel()
 	<-done
 
-	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "-1" {
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "-1" {
 		t.Fatalf("solar hard ceiling: expected pump to stay off, got active-output=%v", v)
 	}
 }
@@ -1009,7 +1009,7 @@ func TestPoolPump_SolarStaleFallsBackToSchedule(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -1020,7 +1020,7 @@ func TestPoolPump_SolarStaleFallsBackToSchedule(t *testing.T) {
 
 	injector <- shellyButtonEvent()
 	started := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "0"
 	})
 
@@ -1029,7 +1029,7 @@ func TestPoolPump_SolarStaleFallsBackToSchedule(t *testing.T) {
 
 	if !started {
 		t.Fatalf("expected button press to start pump despite solar enabled/never-received, got active-output=%v",
-			deviceState.KVS["script/pool-pump/active-output"])
+			kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 }
 
@@ -1074,7 +1074,7 @@ func TestPoolPump_SolarStaleTsFallsBackImmediately(t *testing.T) {
 	}()
 
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVS["script/pool-pump/schedule-mode"]
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
 	})
 	if !initDone {
@@ -1096,7 +1096,7 @@ func TestPoolPump_SolarStaleTsFallsBackImmediately(t *testing.T) {
 	cancel()
 	<-done
 
-	if v := deviceState.KVS["script/pool-pump/active-output"]; v != "-1" {
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "-1" {
 		t.Fatalf("stale ts: expected pump to stay off (stale detected immediately on receipt), got active-output=%v", v)
 	}
 }
@@ -1244,9 +1244,9 @@ func poolPumpRewriteResult(t *testing.T, deviceState *script.DeviceState, wantOu
 
 	// The rewrite has to land before the reconciliation it triggers can be
 	// judged, so wait for the morning job's timespec to change first.
-	initial := poolPumpScheduleTimespec(deviceState.Schedules, "handleMorningStart()")
+	initial := poolPumpScheduleTimespec(deviceState.ScheduleJobs(), "handleMorningStart()")
 	if !waitFor(15*time.Second, 100*time.Millisecond, func() bool {
-		return poolPumpScheduleTimespec(deviceState.Schedules, "handleMorningStart()") != initial
+		return poolPumpScheduleTimespec(deviceState.ScheduleJobs(), "handleMorningStart()") != initial
 	}) {
 		cancel()
 		<-done
@@ -1255,12 +1255,12 @@ func poolPumpRewriteResult(t *testing.T, deviceState *script.DeviceState, wantOu
 
 	// Then give the reconciliation its own window to act — or to provably not.
 	waitFor(8*time.Second, 100*time.Millisecond, func() bool {
-		v, ok := deviceState.KVS["script/pool-pump/active-output"]
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == wantOutput
 	})
 
-	got, _ := deviceState.KVS["script/pool-pump/active-output"].(string)
-	schedules := deviceState.Schedules
+	got, _ := kvsValue(deviceState, "script/pool-pump/active-output").(string)
+	schedules := deviceState.ScheduleJobs()
 	cancel()
 	<-done
 	return got, schedules
@@ -1430,4 +1430,30 @@ func TestPoolPump_ScheduleRewriteOutsideWindowDoesNotStartPump(t *testing.T) {
 		t.Fatalf("now is outside the rewritten window: "+
 			"expected the pump to stay off (active-output=-1), got %q", got)
 	}
+}
+
+// Locked read helpers for DeviceState (#451).
+//
+// The emulator mutates DeviceState's maps from the goroutine running the
+// script while these tests poll them from the test goroutine. Reading the maps
+// directly is a data race, and an unsynchronised map read racing a write does
+// not merely flake — Go aborts the whole test binary with "fatal error:
+// concurrent map read and map write", losing every result in the package.
+//
+// These wrappers keep the call sites as terse as the direct indexing they
+// replace, so a predicate reads much as it did before, but every read now goes
+// through DeviceState's RWMutex.
+
+func kvsValue(d *script.DeviceState, key string) interface{} {
+	v, _ := d.KVSValue(key)
+	return v
+}
+
+func storageValue(d *script.DeviceState, key string) interface{} {
+	v, _ := d.StorageValue(key)
+	return v
+}
+
+func componentStatusValue(d *script.DeviceState, key string) (interface{}, bool) {
+	return d.ComponentStatusValue(key)
 }

--- a/myhome/daemon/solar_automation_test.go
+++ b/myhome/daemon/solar_automation_test.go
@@ -8,24 +8,47 @@ import (
 
 	"github.com/asnowfix/home-automation/myhome/events"
 	beem "github.com/asnowfix/home-automation/pkg/beem"
+	"sync"
+
 	"github.com/go-logr/logr"
 )
 
-// mockPumpController records SetPump calls so tests can assert pump state transitions.
+// mockPumpController records SetPump calls so tests can assert pump state
+// transitions.
+//
+// SetPump is invoked on SolarAutomation's own goroutine while the test
+// goroutine reads the record, so the slice needs a lock: without it `go test
+// -race` reports a genuine race, and an unlucky interleaving can corrupt the
+// slice header rather than merely returning a stale value (#451).
 type mockPumpController struct {
+	mu    sync.Mutex
 	calls []bool // true=on, false=off
 }
 
 func (m *mockPumpController) SetPump(_ context.Context, on bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.calls = append(m.calls, on)
 	return nil
 }
 
 func (m *mockPumpController) lastCall() (on bool, ok bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if len(m.calls) == 0 {
 		return false, false
 	}
 	return m.calls[len(m.calls)-1], true
+}
+
+// callsSnapshot returns a copy for assertion messages, so formatting a failure
+// does not itself race with the automation goroutine.
+func (m *mockPumpController) callsSnapshot() []bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]bool, len(m.calls))
+	copy(out, m.calls)
+	return out
 }
 
 // flakyPumpController simulates a flaky MQTT link by failing the first
@@ -33,16 +56,28 @@ func (m *mockPumpController) lastCall() (on bool, ok bool) {
 // succeeding, so tests can assert the retry-on-failure behavior of the
 // state machine without depending on shellyPumpController's own retry loop.
 type flakyPumpController struct {
+	mu        sync.Mutex
 	failCount int
 	calls     []bool
 }
 
 func (m *flakyPumpController) SetPump(_ context.Context, on bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.calls = append(m.calls, on)
 	if len(m.calls) <= m.failCount {
 		return fmt.Errorf("simulated dropped Switch.Set (MQTT not retained)")
 	}
 	return nil
+}
+
+// callsSnapshot returns a copy for assertion messages; see mockPumpController.
+func (m *flakyPumpController) callsSnapshot() []bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]bool, len(m.calls))
+	copy(out, m.calls)
+	return out
 }
 
 // send pushes a sample to ch and gives the goroutine time to process it.
@@ -51,11 +86,25 @@ func send(ch chan<- beem.PowerSample, w float64) {
 	time.Sleep(20 * time.Millisecond)
 }
 
-// mockRuntimeTracker implements RuntimeTracker with a fixed runtime value for tests.
-type mockRuntimeTracker struct{ runtimeSec int64 }
+// mockRuntimeTracker implements RuntimeTracker with a fixed runtime value for
+// tests. Guarded because tests change the value mid-run while
+// SolarAutomation's goroutine is reading it (#451).
+type mockRuntimeTracker struct {
+	mu         sync.Mutex
+	runtimeSec int64
+}
 
 func (m *mockRuntimeTracker) DailyRuntimeSec(_ context.Context) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.runtimeSec, nil
+}
+
+// setRuntimeSec updates the reported runtime from the test goroutine.
+func (m *mockRuntimeTracker) setRuntimeSec(v int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runtimeSec = v
 }
 
 func defaultCfg() SolarConfig {
@@ -85,14 +134,14 @@ func TestSolarAutomation_ImmediateStartStop(t *testing.T) {
 	send(ch, 600)
 	on, ok := pump.lastCall()
 	if !ok || !on {
-		t.Fatalf("expected pump ON after first sample above threshold; calls=%v", pump.calls)
+		t.Fatalf("expected pump ON after first sample above threshold; calls=%v", pump.callsSnapshot())
 	}
 
 	// Sample below stop threshold → pump should turn off.
 	send(ch, 100)
 	on, ok = pump.lastCall()
 	if !ok || on {
-		t.Fatalf("expected pump OFF after sample below stop threshold; calls=%v", pump.calls)
+		t.Fatalf("expected pump OFF after sample below stop threshold; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -108,7 +157,7 @@ func TestSolarAutomation_StayRunningBetweenThresholds(t *testing.T) {
 	sa.Start(ctx)
 
 	send(ch, 600) // start pump
-	if n := len(pump.calls); n != 1 {
+	if n := len(pump.callsSnapshot()); n != 1 {
 		t.Fatalf("expected 1 call after start, got %d", n)
 	}
 
@@ -116,8 +165,8 @@ func TestSolarAutomation_StayRunningBetweenThresholds(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		send(ch, 350)
 	}
-	if n := len(pump.calls); n != 1 {
-		t.Errorf("expected no change in hysteresis band; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 {
+		t.Errorf("expected no change in hysteresis band; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -137,8 +186,8 @@ func TestSolarAutomation_StartDelayPreventsEarlyStart(t *testing.T) {
 
 	// Single sample above threshold — delay not elapsed yet.
 	send(ch, 600)
-	if len(pump.calls) != 0 {
-		t.Errorf("pump should not start before start delay elapses; calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) != 0 {
+		t.Errorf("pump should not start before start delay elapses; calls=%v", pump.callsSnapshot())
 	}
 
 	// Drop below threshold — resets the timer.
@@ -146,8 +195,8 @@ func TestSolarAutomation_StartDelayPreventsEarlyStart(t *testing.T) {
 
 	// Back above threshold — still no start since delay is 10s.
 	send(ch, 600)
-	if len(pump.calls) != 0 {
-		t.Errorf("pump should not start after threshold reset; calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) != 0 {
+		t.Errorf("pump should not start after threshold reset; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -166,20 +215,20 @@ func TestSolarAutomation_StopDelayPreventsEarlyStop(t *testing.T) {
 	sa.Start(ctx)
 
 	send(ch, 600) // start pump
-	if n := len(pump.calls); n != 1 || !pump.calls[0] {
-		t.Fatalf("expected pump ON; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 || !pump.callsSnapshot()[0] {
+		t.Fatalf("expected pump ON; calls=%v", pump.callsSnapshot())
 	}
 
 	// Brief dip below stop threshold — stop delay hasn't elapsed.
 	send(ch, 50)
-	if n := len(pump.calls); n != 1 {
-		t.Errorf("pump should not stop before stop delay elapses; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 {
+		t.Errorf("pump should not stop before stop delay elapses; calls=%v", pump.callsSnapshot())
 	}
 
 	// Recovery above stop threshold — stop timer should reset.
 	send(ch, 400)
-	if n := len(pump.calls); n != 1 {
-		t.Errorf("pump should not stop after solar recovery; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 {
+		t.Errorf("pump should not stop after solar recovery; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -194,8 +243,8 @@ func TestSolarAutomation_ContextCancelStopsPump(t *testing.T) {
 	sa.Start(ctx)
 
 	send(ch, 600) // start pump
-	if len(pump.calls) == 0 || !pump.calls[0] {
-		t.Fatalf("expected pump ON; calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) == 0 || !pump.callsSnapshot()[0] {
+		t.Fatalf("expected pump ON; calls=%v", pump.callsSnapshot())
 	}
 
 	cancel() // cancel context → goroutine should emit an OFF command
@@ -203,7 +252,7 @@ func TestSolarAutomation_ContextCancelStopsPump(t *testing.T) {
 
 	on, ok := pump.lastCall()
 	if !ok || on {
-		t.Errorf("expected pump OFF after context cancel; calls=%v", pump.calls)
+		t.Errorf("expected pump OFF after context cancel; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -238,15 +287,15 @@ func TestSolarAutomation_SoftStopWhenTargetReachedAndSolarGone(t *testing.T) {
 	sa.Start(ctx)
 
 	send(ch, 600) // runtime (4000s) < ceiling (7200s) → solar start permitted
-	if n := len(pump.calls); n != 1 || !pump.calls[0] {
-		t.Fatalf("expected pump ON; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 || !pump.callsSnapshot()[0] {
+		t.Fatalf("expected pump ON; calls=%v", pump.callsSnapshot())
 	}
 
 	// Solar drops below the start threshold while the soft target is already met.
 	send(ch, 400)
 	on, ok := pump.lastCall()
 	if !ok || on {
-		t.Errorf("expected soft stop (target reached + solar below start threshold); calls=%v", pump.calls)
+		t.Errorf("expected soft stop (target reached + solar below start threshold); calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -271,16 +320,16 @@ func TestSolarAutomation_KeepsRunningPastSoftTargetWhileSolarHigh(t *testing.T) 
 	sa.Start(ctx)
 
 	send(ch, 600) // start
-	if n := len(pump.calls); n != 1 {
-		t.Fatalf("expected pump to start; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 {
+		t.Fatalf("expected pump to start; calls=%v", pump.callsSnapshot())
 	}
 
 	// Soft target already met, but solar stays well above the start threshold.
 	for i := 0; i < 3; i++ {
 		send(ch, 700)
 	}
-	if n := len(pump.calls); n != 1 {
-		t.Errorf("expected pump to keep running past the soft target while solar is high; calls=%v", pump.calls)
+	if n := len(pump.callsSnapshot()); n != 1 {
+		t.Errorf("expected pump to keep running past the soft target while solar is high; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -309,7 +358,7 @@ func TestSolarAutomation_HardCeilingStopsRegardlessOfSolar(t *testing.T) {
 	}
 	on, ok := pump.lastCall()
 	if !ok || on {
-		t.Errorf("expected pump OFF on hard ceiling; calls=%v", pump.calls)
+		t.Errorf("expected pump OFF on hard ceiling; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -341,8 +390,8 @@ func TestSolarAutomation_HardCeilingRetriesStopOnSetPumpFailure(t *testing.T) {
 	if state != pumpIdle {
 		t.Errorf("expected the retried stop to land and reach IDLE; state=%v", state)
 	}
-	if len(pump.calls) != 2 || pump.calls[0] != false || pump.calls[1] != false {
-		t.Errorf("expected two OFF attempts (one dropped, one landing); calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) != 2 || pump.callsSnapshot()[0] != false || pump.callsSnapshot()[1] != false {
+		t.Errorf("expected two OFF attempts (one dropped, one landing); calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -366,8 +415,8 @@ func TestSolarAutomation_CannotStartPastHardCeiling(t *testing.T) {
 	sa.Start(ctx)
 
 	send(ch, 900) // well above the start threshold, but the ceiling is already reached
-	if len(pump.calls) != 0 {
-		t.Errorf("expected no solar start once the hard ceiling is reached; calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) != 0 {
+		t.Errorf("expected no solar start once the hard ceiling is reached; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -385,8 +434,8 @@ func TestSolarAutomation_NoPumpStartWhenIdle(t *testing.T) {
 	cancel()
 	time.Sleep(50 * time.Millisecond)
 
-	if len(pump.calls) != 0 {
-		t.Errorf("no pump calls expected when cancelling from idle; calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) != 0 {
+		t.Errorf("no pump calls expected when cancelling from idle; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -407,8 +456,8 @@ func TestSolarAutomation_HardCeilingPreventsStart(t *testing.T) {
 
 	// Solar is well above start threshold, but ceiling is already reached.
 	send(ch, 800)
-	if len(pump.calls) != 0 {
-		t.Errorf("pump should not start when hard ceiling is already reached; calls=%v", pump.calls)
+	if len(pump.callsSnapshot()) != 0 {
+		t.Errorf("pump should not start when hard ceiling is already reached; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -429,16 +478,16 @@ func TestSolarAutomation_HardCeilingStopsPump(t *testing.T) {
 
 	send(ch, 800) // start pump
 	if on, ok := pump.lastCall(); !ok || !on {
-		t.Fatalf("expected pump ON; calls=%v", pump.calls)
+		t.Fatalf("expected pump ON; calls=%v", pump.callsSnapshot())
 	}
 
 	// Simulate ceiling reached during the next sample.
-	tracker.runtimeSec = 3600
+	tracker.setRuntimeSec(3600)
 	send(ch, 800) // still high solar, but ceiling hit → must stop
 
 	on, ok := pump.lastCall()
 	if !ok || on {
-		t.Errorf("expected pump OFF when hard ceiling reached; calls=%v", pump.calls)
+		t.Errorf("expected pump OFF when hard ceiling reached; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -460,16 +509,16 @@ func TestSolarAutomation_SoftStopKeepsRunningWithSolar(t *testing.T) {
 
 	send(ch, 800) // start pump
 	if on, ok := pump.lastCall(); !ok || !on {
-		t.Fatalf("expected pump ON; calls=%v", pump.calls)
+		t.Fatalf("expected pump ON; calls=%v", pump.callsSnapshot())
 	}
 
 	// Target reached, but solar still above StartThresholdW → must keep running.
-	tracker.runtimeSec = 3600
+	tracker.setRuntimeSec(3600)
 	send(ch, 800)
 
 	on, ok := pump.lastCall()
 	if !ok || !on {
-		t.Errorf("expected pump to keep running when target met but solar still up; calls=%v", pump.calls)
+		t.Errorf("expected pump to keep running when target met but solar still up; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -491,15 +540,15 @@ func TestSolarAutomation_SoftStopWhenSolarGone(t *testing.T) {
 
 	send(ch, 800) // start pump
 	if on, ok := pump.lastCall(); !ok || !on {
-		t.Fatalf("expected pump ON; calls=%v", pump.calls)
+		t.Fatalf("expected pump ON; calls=%v", pump.callsSnapshot())
 	}
 
 	// Target reached AND solar below StartThresholdW → soft stop must fire.
-	tracker.runtimeSec = 3600
+	tracker.setRuntimeSec(3600)
 	send(ch, 300) // 300 W: above StopThresholdW (200) but below StartThresholdW (500)
 
 	on, ok := pump.lastCall()
 	if !ok || on {
-		t.Errorf("expected pump OFF (soft stop: target met, solar gone); calls=%v", pump.calls)
+		t.Errorf("expected pump OFF (soft stop: target met, solar gone); calls=%v", pump.callsSnapshot())
 	}
 }

--- a/myhome/daemon/solar_notice_test.go
+++ b/myhome/daemon/solar_notice_test.go
@@ -110,12 +110,12 @@ func TestSolarAutomation_RecordsHardCeilingStopNotice(t *testing.T) {
 	sa.Start(ctx)
 
 	send(ch, 800) // start pump
-	tracker.runtimeSec = 3600
+	tracker.setRuntimeSec(3600)
 	send(ch, 800) // still high solar, but ceiling hit → must stop
 
 	rows := queryNoticeEvents(t, store, "pool.solar_stop")
 	if len(rows) != 1 {
-		t.Fatalf("pool.solar_stop rows = %d, want 1; calls=%v", len(rows), pump.calls)
+		t.Fatalf("pool.solar_stop rows = %d, want 1; calls=%v", len(rows), pump.callsSnapshot())
 	}
 	if want := `"reason":"hard_ceiling"`; !strings.Contains(*rows[0].Data, want) {
 		t.Errorf("Data = %q, want substring %q", *rows[0].Data, want)
@@ -172,7 +172,7 @@ func TestSolarAutomation_RecordNoticeFailureDoesNotBlockPump(t *testing.T) {
 
 	on, ok := pump.lastCall()
 	if !ok || !on {
-		t.Fatalf("expected pump ON despite events store being closed; calls=%v", pump.calls)
+		t.Fatalf("expected pump ON despite events store being closed; calls=%v", pump.callsSnapshot())
 	}
 }
 
@@ -204,6 +204,6 @@ func TestSolarAutomation_NoNoticesWithoutWithEvents(t *testing.T) {
 
 	on, ok := pump.lastCall()
 	if !ok || on {
-		t.Fatalf("expected pump OFF; calls=%v", pump.calls)
+		t.Fatalf("expected pump OFF; calls=%v", pump.callsSnapshot())
 	}
 }

--- a/pkg/shelly/script/device_state.go
+++ b/pkg/shelly/script/device_state.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/go-logr/logr"
 )
@@ -34,20 +35,224 @@ type DeviceState struct {
 	OnModified func() `json:"-"`
 
 	nextScheduleID int
+
+	// mu guards every map and slice above. The emulator mutates them from the
+	// goroutine running the script while tests poll them from the test
+	// goroutine, which without this is a data race — and an unsynchronised map
+	// read racing a write is not merely flaky: Go aborts the whole test binary
+	// with "fatal error: concurrent map read and map write", losing every
+	// result in the package rather than failing one test (#451).
+	//
+	// Access the fields through the accessors below rather than directly.
+	// The exported fields remain exported only so DeviceState can still be
+	// JSON-marshalled for snapshots; treat them as private otherwise.
+	mu sync.RWMutex
 }
 
-// GetKVS implements the DeviceState interface
+// KVSValue returns one KVS entry under the read lock.
+func (d *DeviceState) KVSValue(key string) (interface{}, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	v, ok := d.KVS[key]
+	return v, ok
+}
+
+// KVSString returns one KVS entry as a string. The second result is false when
+// the key is absent or the value is not a string, so callers can distinguish
+// "not set yet" from "set to something unexpected".
+func (d *DeviceState) KVSString(key string) (string, bool) {
+	v, ok := d.KVSValue(key)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// SetKVSValue writes one KVS entry under the write lock.
+func (d *DeviceState) SetKVSValue(key string, value interface{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.KVS == nil {
+		d.KVS = make(map[string]interface{})
+	}
+	d.KVS[key] = value
+}
+
+// DeleteKVSValue removes one KVS entry under the write lock.
+func (d *DeviceState) DeleteKVSValue(key string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.KVS, key)
+}
+
+// KVSSnapshot returns a copy of the whole KVS map. A copy, not the live map:
+// handing back the original would just move the race into the caller.
+func (d *DeviceState) KVSSnapshot() map[string]interface{} {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make(map[string]interface{}, len(d.KVS))
+	for k, v := range d.KVS {
+		out[k] = v
+	}
+	return out
+}
+
+// StorageValue returns one Script.storage entry under the read lock.
+func (d *DeviceState) StorageValue(key string) (interface{}, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	v, ok := d.Storage[key]
+	return v, ok
+}
+
+// SetStorageValue writes one Script.storage entry under the write lock.
+func (d *DeviceState) SetStorageValue(key string, value interface{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.Storage == nil {
+		d.Storage = make(map[string]interface{})
+	}
+	d.Storage[key] = value
+}
+
+// DeleteStorageValue removes one Script.storage entry under the write lock.
+func (d *DeviceState) DeleteStorageValue(key string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.Storage, key)
+}
+
+// ComponentStatusValue returns one component's status under the read lock.
+//
+// When the status is a map — which it is for every real component — a copy is
+// returned. Handing back the live inner map would defeat the lock entirely: the
+// caller would hold a reference it could read or mutate while the script
+// goroutine writes the same map, which is precisely the race this type exists
+// to prevent. Callers that need to change a field must use
+// SetComponentStatusField.
+func (d *DeviceState) ComponentStatusValue(name string) (interface{}, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	v, ok := d.ComponentStatus[name]
+	if !ok {
+		return nil, false
+	}
+	if m, isMap := v.(map[string]interface{}); isMap {
+		cp := make(map[string]interface{}, len(m))
+		for k, mv := range m {
+			cp[k] = mv
+		}
+		return cp, true
+	}
+	return v, true
+}
+
+// SetComponentStatusField sets one field on a component's status map in place,
+// under the write lock, and reports whether the component existed and was a
+// map. This is the safe form of the read-then-mutate pattern: doing it via
+// ComponentStatusValue would only mutate the copy.
+func (d *DeviceState) SetComponentStatusField(name, field string, value interface{}) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	existing, ok := d.ComponentStatus[name]
+	if !ok {
+		return false
+	}
+	m, isMap := existing.(map[string]interface{})
+	if !isMap {
+		return false
+	}
+	m[field] = value
+	return true
+}
+
+// SetComponentStatusValue writes one component's status under the write lock.
+func (d *DeviceState) SetComponentStatusValue(name string, value interface{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.ComponentStatus == nil {
+		d.ComponentStatus = make(map[string]interface{})
+	}
+	d.ComponentStatus[name] = value
+}
+
+// DeleteComponentStatusValue removes one component's status under the write lock.
+func (d *DeviceState) DeleteComponentStatusValue(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.ComponentStatus, name)
+}
+
+// StorageLen reports how many Script.storage entries exist.
+func (d *DeviceState) StorageLen() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.Storage)
+}
+
+// ScheduleJobs returns a copy of the schedule list, with each job map copied
+// one level deep. Tests read fields out of individual jobs (timespec, enable),
+// so returning the live job maps would leave the race in place.
+func (d *DeviceState) ScheduleJobs() []map[string]interface{} {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make([]map[string]interface{}, 0, len(d.Schedules))
+	for _, job := range d.Schedules {
+		cp := make(map[string]interface{}, len(job))
+		for k, v := range job {
+			cp[k] = v
+		}
+		out = append(out, cp)
+	}
+	return out
+}
+
+// UpdateSchedule merges updates into the job with the given id and reports
+// whether it existed. Held under the write lock so a concurrent ScheduleJobs()
+// cannot observe a half-applied update.
+func (d *DeviceState) UpdateSchedule(id int, updates map[string]interface{}) (map[string]interface{}, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, job := range d.Schedules {
+		if scheduleID(job["id"]) != id {
+			continue
+		}
+		for k, v := range updates {
+			if k == "id" {
+				continue
+			}
+			job[k] = v
+		}
+		cp := make(map[string]interface{}, len(job))
+		for k, v := range job {
+			cp[k] = v
+		}
+		return cp, true
+	}
+	return nil, false
+}
+
+// GetKVS returns a snapshot of the KVS map. It is a copy: see KVSSnapshot.
 func (d *DeviceState) GetKVS() map[string]interface{} {
-	return d.KVS
+	return d.KVSSnapshot()
 }
 
-// GetStorage implements the DeviceState interface
+// GetStorage returns a snapshot of the Script.storage map.
 func (d *DeviceState) GetStorage() map[string]interface{} {
-	return d.Storage
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	out := make(map[string]interface{}, len(d.Storage))
+	for k, v := range d.Storage {
+		out[k] = v
+	}
+	return out
 }
 
 // AddSchedule appends a schedule and returns its assigned ID (1-based).
 func (d *DeviceState) AddSchedule(job map[string]interface{}) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	d.nextScheduleID++
 	id := d.nextScheduleID
 	job["id"] = id
@@ -57,6 +262,8 @@ func (d *DeviceState) AddSchedule(job map[string]interface{}) int {
 
 // DeleteSchedule removes the schedule with the given ID.
 func (d *DeviceState) DeleteSchedule(id int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	filtered := d.Schedules[:0]
 	for _, s := range d.Schedules {
 		if s["id"] != id {

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -293,7 +293,7 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 		component := call.Argument(0).String()
 		log.V(1).Info("Shelly.getComponentStatus", "component", component)
 		if deviceState.ComponentStatus != nil {
-			if v, ok := deviceState.ComponentStatus[component]; ok {
+			if v, ok := deviceState.ComponentStatusValue(component); ok {
 				return vm.ToValue(v)
 			}
 		}
@@ -637,8 +637,7 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	storageObj.Set("getItem", func(call goja.FunctionCall) goja.Value {
 		key := call.Argument(0).String()
 		log.V(1).Info("Script.storage.getItem", "key", key)
-		storage := deviceState.GetStorage()
-		if val, ok := storage[key]; ok {
+		if val, ok := deviceState.StorageValue(key); ok {
 			// If the stored value is nil, treat it as missing/NULL and return null
 			// without changing the underlying storage. This preserves "cooling-rate": null
 			// and similar entries in device.json instead of turning them into "<nil>".
@@ -651,7 +650,7 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 			strVal, ok := val.(string)
 			if !ok {
 				strVal = fmt.Sprint(val)
-				storage[key] = strVal
+				deviceState.SetStorageValue(key, strVal)
 			}
 			log.V(1).Info("Script.storage.getItem", "key", key, "value", strVal)
 			return vm.ToValue(strVal)
@@ -665,17 +664,15 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 		// Script.storage follows the Web Storage API semantics and supports
 		// only string values. Coerce the value to string using JS semantics.
 		valueStr := call.Argument(1).String()
-		storage := deviceState.GetStorage()
-		storage[key] = valueStr
+		deviceState.SetStorageValue(key, valueStr)
 		// Keep length property roughly in sync with the underlying map.
-		storageObj.Set("length", len(storage))
+		storageObj.Set("length", deviceState.StorageLen())
 		log.Info("Script.storage.setItem", "key", key, "value", valueStr)
-		log.V(1).Info("Script.storage.setItem", "storage", storage)
+		log.V(1).Info("Script.storage.setItem", "storage_len", deviceState.StorageLen())
 		return goja.Undefined()
 	})
 	// Initialize length property to reflect existing storage contents.
-	storage := deviceState.GetStorage()
-	storageObj.Set("length", len(storage))
+	storageObj.Set("length", deviceState.StorageLen())
 	// Provide key(index) to enumerate stored keys, similar to the Web Storage API.
 	storageObj.Set("key", func(call goja.FunctionCall) goja.Value {
 		idx := int(call.Argument(0).ToInteger())
@@ -833,8 +830,7 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			paramsObj := params.ToObject(vm)
 			key := paramsObj.Get("key").String()
 
-			kvs := deviceState.GetKVS()
-			val, found := kvs[key]
+			val, found := deviceState.KVSValue(key)
 
 			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
 				if callable, ok := goja.AssertFunction(callback); ok {
@@ -852,7 +848,7 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 						return ret.Export(), nil
 					} else {
 						// Key not found - record it as nil so repeated calls don't mutate the map
-						kvs[key] = nil
+						deviceState.SetKVSValue(key, nil)
 						// Call callback with error code -114 (key not found)
 						callable(goja.Undefined(), goja.Null(), vm.ToValue(-114), vm.ToValue("Key not found"), userdata)
 						return nil, nil
@@ -905,9 +901,8 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			paramsObj := params.ToObject(vm)
 			key := paramsObj.Get("key").String()
 			value := paramsObj.Get("value").Export()
-			kvs := deviceState.GetKVS()
 			// KVS values are always stored as strings on real Shelly devices
-			kvs[key] = fmt.Sprintf("%v", value)
+			deviceState.SetKVSValue(key, fmt.Sprintf("%v", value))
 
 			// Trigger auto-save if callback is set
 			if deviceState.OnModified != nil {
@@ -928,7 +923,7 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
 				if callable, ok := goja.AssertFunction(callback); ok {
 					result := map[string]interface{}{
-						"jobs": deviceState.Schedules,
+						"jobs": deviceState.ScheduleJobs(),
 					}
 					callable(goja.Undefined(), vm.ToValue(result), vm.ToValue(0), goja.Null(), userdata)
 				}
@@ -947,12 +942,12 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			// Also persist in ComponentStatus as schedule:N component
 			if deviceState.ComponentStatus != nil {
 				key := fmt.Sprintf("schedule:%d", id)
-				deviceState.ComponentStatus[key] = map[string]interface{}{
+				deviceState.SetComponentStatusValue(key, map[string]interface{}{
 					"id":       id,
 					"enable":   job["enable"],
 					"timespec": job["timespec"],
 					"calls":    job["calls"],
-				}
+				})
 			}
 
 			// Trigger auto-save if callback is set
@@ -981,22 +976,11 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			id := int(paramsObj.Get("id").ToInteger())
 			updates, _ := params.Export().(map[string]interface{})
 
-			var updated map[string]interface{}
-			for _, job := range deviceState.Schedules {
-				if scheduleID(job["id"]) != id {
-					continue
-				}
-				for k, v := range updates {
-					if k == "id" {
-						continue
-					}
-					job[k] = v
-				}
-				updated = job
-				break
-			}
+			// Merge under the write lock. Iterating ScheduleJobs() here would
+			// mutate copies and silently lose the update.
+			updated, found := deviceState.UpdateSchedule(id, updates)
 
-			if updated == nil {
+			if !found {
 				if !goja.IsUndefined(callback) && !goja.IsNull(callback) {
 					if callable, ok := goja.AssertFunction(callback); ok {
 						callable(goja.Undefined(), goja.Null(), vm.ToValue(-105),
@@ -1009,12 +993,12 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			// Keep the schedule:N component view in step with the job, the
 			// same way Schedule.Create does.
 			if deviceState.ComponentStatus != nil {
-				deviceState.ComponentStatus[fmt.Sprintf("schedule:%d", id)] = map[string]interface{}{
+				deviceState.SetComponentStatusValue(fmt.Sprintf("schedule:%d", id), map[string]interface{}{
 					"id":       id,
 					"enable":   updated["enable"],
 					"timespec": updated["timespec"],
 					"calls":    updated["calls"],
-				}
+				})
 			}
 
 			if deviceState.OnModified != nil {
@@ -1039,7 +1023,7 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			// Also remove from ComponentStatus
 			if deviceState.ComponentStatus != nil {
 				key := fmt.Sprintf("schedule:%d", id)
-				delete(deviceState.ComponentStatus, key)
+				deviceState.DeleteComponentStatusValue(key)
 			}
 
 			// Trigger auto-save if callback is set
@@ -1062,12 +1046,10 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			on := paramsObj.Get("on").ToBoolean()
 			key := fmt.Sprintf("switch:%d", id)
 			if deviceState.ComponentStatus != nil {
-				if existing, ok := deviceState.ComponentStatus[key]; ok {
-					if m, ok := existing.(map[string]interface{}); ok {
-						m["output"] = on
-					}
-				} else {
-					deviceState.ComponentStatus[key] = map[string]interface{}{"id": id, "output": on}
+				// Mutate in place under the lock; a read-then-modify via
+				// ComponentStatusValue would only change the returned copy.
+				if !deviceState.SetComponentStatusField(key, "output", on) {
+					deviceState.SetComponentStatusValue(key, map[string]interface{}{"id": id, "output": on})
 				}
 			}
 


### PR DESCRIPTION
Fixes #451.

`DeviceState`'s maps were shared between the goroutine running the script and the test goroutine with
no synchronisation. Tests poll them directly from `waitFor` predicates while the emulator writes them.

That is not merely flaky. An unsynchronised map read racing a write makes Go abort the **whole test
binary** with `fatal error: concurrent map read and map write`, losing every result in the package
rather than failing one test. It hit a `make test` run on 2026-08-08 and reproduces under `-race` on
clean `main`.

## The fix

- `DeviceState` gains an `RWMutex`. The emulator writes through `SetKVSValue`, `SetStorageValue`,
  `SetComponentStatusValue`, `SetComponentStatusField` and `UpdateSchedule`; readers use `KVSValue`,
  `StorageValue`, `ComponentStatusValue` and `ScheduleJobs`.
- Test call sites go through two thin helpers (`kvsValue`, `storageValue`) so predicates read much as
  they did before — the diff is large but mechanical.

**Reads return copies, deliberately.** Two bugs during this change proved why:

1. `Switch.Set` did a read-then-mutate on the *inner* component-status map. Returning the live inner
   map kept the race alive even with the outer map locked — the accessor now copies, and in-place
   mutation goes through `SetComponentStatusField`.
2. `Schedule.Update` iterated `ScheduleJobs()` and mutated the copies, silently discarding every
   update. That broke the #441 rewrite tests until it was rewired to `UpdateSchedule`, which merges
   under the write lock. Worth knowing: a "returns a copy" accessor turns a lost write into a silent
   no-op, so every write path has to be checked, not just the read paths.

## Races beyond the emulator

Running the whole workspace under `-race` surfaced pre-existing races elsewhere. In `myhome/daemon`
all were test-side and are fixed here: `mockPumpController.calls` and `flakyPumpController.calls` are
appended by SolarAutomation's goroutine and read by the test, and `mockRuntimeTracker.runtimeSec` is
written by the test mid-run while that goroutine reads it. All three are now guarded, with snapshot
accessors so formatting a failure message does not itself race.

## Race detector: opt-in for now, one line from default

Adds `TESTFLAGS` (threaded through both test invocations) and a `make test-race` target.

`-race` is **not** the default yet for one reason: `pkg/beem` races on its package-level
`loginURL`/`summaryURL` globals, which a test overwrites while a watcher goroutine reads them. That
needs the URLs moved into `ClientConfig` — a small refactor, not a lock — and is filed separately
(it is also an instance of what #362 is about). Making the default `-race` today would leave the
suite red, which defeats the purpose.

`internal/shelly/scripts`, `pkg/shelly/script` and `myhome/daemon` are all clean under `-race` as of
this change, so flipping the default is a one-line edit once `pkg/beem` follows.

## Verification

- `go test -race ./internal/shelly/scripts/ ./pkg/shelly/script/` → clean (several races on `main`).
- `go test -race ./myhome/daemon/` → clean.
- `make test` → **47 ok, 0 failures**.
- `make test-race` → clean apart from the known `pkg/beem` globals.

Cost is negligible: these tests are wall-clock bound rather than CPU bound, so a full run is roughly
4–7 minutes either way.

## Note on #446

#446 widened the polling deadlines in these same tests to stop them failing spuriously under load.
That fix was correct but incomplete: it reduced the *timing* flakiness while increasing exposure to
this race, since each predicate now runs many more times. This is the other half of that story, and
probably part of what #435 recorded as "Problem 2".
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(script emulator): guard DeviceState with a mutex so tests stop racing the script ([f542a4f](https://github.com/asnowfix/home-automation/commit/f542a4ff2909c74c8639c17013a752628f0544f2))
- test(daemon): guard the solar mocks, and add a make test-race target ([f48e7a5](https://github.com/asnowfix/home-automation/commit/f48e7a56a560359ed136db060450bcce8fa6ecd2))
- Merge branch 'main' into fix/451-devicestate-race ([2239d8a](https://github.com/asnowfix/home-automation/commit/2239d8ab54f35a0bea1c065ab52747514fc699ce))
- Merge main into fix/451-devicestate-race ([09befe5](https://github.com/asnowfix/home-automation/commit/09befe5c1e5cfd4bd0ae7f02da155f1025de1768))
- Merge the remote branch update ([668763a](https://github.com/asnowfix/home-automation/commit/668763a23b9c7127b1750623627593830b728575))
<!-- END-AUTO-GENERATED-COMMITS -->