### PR TITLE
fix(script upload): verify the script exists before trusting its version marker (#449)

### DIFF
--- a/internal/myhome/shelly/script/ops.go
+++ b/internal/myhome/shelly/script/ops.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"path/filepath"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 )
@@ -56,14 +56,21 @@ func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, 
 		log.Info("Got KVS entry for script version", "key", kvsKey, "version", kvsVersion)
 	}
 
-	// Upload if forced or version changed
+	// The version marker records what was last uploaded, but it can outlive the
+	// script itself: deleting a script from the device's web UI, with a raw
+	// Script.Delete RPC, or by factory reset leaves the marker behind (only
+	// DeleteWithVersion below removes it). Trusting the marker alone then skips
+	// the upload and starts a script that is absent or empty, while reporting
+	// success — see #449. So confirm the script is really on the device before
+	// letting a matching version suppress the upload.
+	present := scriptIsLoaded(ctx, log, via, device, basename)
+
+	// Upload if forced, the version changed, or the device does not actually
+	// have the script.
 	var id uint32
-	if force || version != kvsVersion {
-		if force {
-			log.Info("Force flag set, uploading script", "name", name, "version", version)
-		} else {
-			log.Info("Script version is different, uploading new one", "name", name, "version", version)
-		}
+	upload, reason := shouldUpload(force, version, kvsVersion, present)
+	if upload {
+		log.Info(reason, "name", name, "version", version, "key", kvsKey, "device", device.Name())
 
 		// Upload the script using the generic pkg/shelly/script package
 		id, err = script.Upload(ctx, via, device, name, code, minify)
@@ -80,7 +87,7 @@ func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, 
 			log.Info("Set KVS entry for script version", "key", kvsKey, "version", version, "device", device.Name())
 		}
 	} else {
-		log.Info("Script version is the same, skipping upload", "name", name, "version", version)
+		log.Info(reason, "name", name, "version", version)
 	}
 
 	// Now start the script
@@ -91,6 +98,49 @@ func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, 
 	}
 
 	return id, nil
+}
+
+// shouldUpload decides whether the script's code must be sent to the device,
+// and returns the reason for the log line.
+//
+// The subtle case is the last one. A matching version marker is not on its own
+// evidence that the device still has the script: the marker lives in the
+// device's KVS and outlives any deletion that does not go through
+// DeleteWithVersion — the web UI, a raw Script.Delete RPC, another tool, a
+// factory reset. Skipping the upload then leaves UploadWithVersion starting a
+// script that is absent (an outright error) or, if something recreated it
+// empty, one that runs and does nothing while reporting success (#449).
+//
+// Kept as a pure function so this decision is testable without a device.
+func shouldUpload(force bool, wantVersion, kvsVersion string, present bool) (bool, string) {
+	switch {
+	case force:
+		return true, "Force flag set, uploading script"
+	case wantVersion != kvsVersion:
+		return true, "Script version is different, uploading new one"
+	case !present:
+		return true, "KVS records this version but the script is not on the device, uploading anyway"
+	default:
+		return false, "Script version is the same and the script is present, skipping upload"
+	}
+}
+
+// scriptIsLoaded reports whether the device currently has a script with this
+// name. A lookup failure is reported as "present" so a transient RPC error
+// cannot turn into a surprise re-upload: the version check then decides on its
+// own, exactly as it did before.
+func scriptIsLoaded(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, basename string) bool {
+	loaded, err := script.ListLoaded(ctx, via, device)
+	if err != nil {
+		log.Info("Unable to list loaded scripts, assuming the script is present", "name", basename, "device", device.Name())
+		return true
+	}
+	for _, l := range loaded {
+		if l.Name == basename {
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteWithVersion deletes a script and removes its version from KVS

--- a/internal/myhome/shelly/script/ops_test.go
+++ b/internal/myhome/shelly/script/ops_test.go
@@ -1,0 +1,72 @@
+package script
+
+import "testing"
+
+// TestShouldUpload covers the decision that #449 got wrong: a version marker
+// matching the code is not proof the device still has the script.
+func TestShouldUpload(t *testing.T) {
+	const version = "abc123"
+
+	tests := []struct {
+		name       string
+		force      bool
+		want       string
+		kvsVersion string
+		present    bool
+		wantUpload bool
+	}{
+		{
+			name:       "version differs, script present",
+			want:       version,
+			kvsVersion: "old",
+			present:    true,
+			wantUpload: true,
+		},
+		{
+			name:       "version matches and script is present: skip",
+			want:       version,
+			kvsVersion: version,
+			present:    true,
+			wantUpload: false,
+		},
+		{
+			// The #449 case. Before the fix this skipped the upload, then tried
+			// to start a script the device does not have — reporting either
+			// "script not found" or, when something had recreated it empty,
+			// success for a script that does nothing.
+			name:       "version matches but script is gone: upload anyway",
+			want:       version,
+			kvsVersion: version,
+			present:    false,
+			wantUpload: true,
+		},
+		{
+			name:       "force overrides a matching version",
+			force:      true,
+			want:       version,
+			kvsVersion: version,
+			present:    true,
+			wantUpload: true,
+		},
+		{
+			name:       "no marker recorded yet",
+			want:       version,
+			kvsVersion: "",
+			present:    false,
+			wantUpload: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := shouldUpload(tc.force, tc.want, tc.kvsVersion, tc.present)
+			if got != tc.wantUpload {
+				t.Errorf("shouldUpload(force=%v, want=%q, kvs=%q, present=%v) = %v (%q), want %v",
+					tc.force, tc.want, tc.kvsVersion, tc.present, got, reason, tc.wantUpload)
+			}
+			if reason == "" {
+				t.Error("expected a non-empty reason for the log line")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**2026-08-09 00:20 CEST** — Fixes #449.

`UploadWithVersion` skipped the code transfer whenever the KVS version marker matched the code being
uploaded, then started the script by name.

## The marker can outlive the script

The marker (`script/<name>` in device KVS) records what was last uploaded. `DeleteWithVersion`
removes it — so the CLI's `script delete` is clean — but **any deletion that does not go through it
leaves the marker behind**: the device's web UI, a raw `Script.Delete` RPC, another tool, a factory
reset.

After such a deletion the marker still claims the version is installed, so the upload is skipped and
the start either:

- fails outright with `script not found: name=pool-pump.js id=0`, or
- **starts an empty script while printing `✓ Successfully uploaded`**, if something has since
  recreated it.

`Script.GetStatus` reports `running: true` in the second case, so the usual verification does not
catch it. Only an implausibly small `mem_used` (28 bytes) or an empty `Script.GetCode` reveals it:

```
{"id":4,"running":true,"mem_used":28,"mem_peak":28,"mem_free":23002}
{"data":"","left":0}
```

## Fix

The upload now also happens when the device does not actually have the script. The decision moves
into `shouldUpload()`, a pure function, so the case is unit-testable without a device:

| force | version vs marker | on device | result |
|---|---|---|---|
| no | differs | yes | upload |
| no | matches | yes | skip |
| no | **matches** | **no** | **upload** ← the bug |
| yes | matches | yes | upload |

A failure to list scripts is treated as "present", so a transient RPC error cannot cause a surprise
re-upload; the version check then decides exactly as before.

## Correction to the issue as filed

#449 is titled "deleting a script leaves its KVS version marker". That is **wrong for the CLI path** —
`DeleteWithVersion` does delete it. My marker survived because I had deleted the script with a raw
`Script.Delete` RPC while measuring heap, bypassing that logic. The real defect is narrower but still
serious: the upload trusts the marker without checking the script exists, so *any* out-of-band
deletion produces the failure. The issue has been updated.

## Verification

- `go test -run TestShouldUpload ./internal/myhome/shelly/script/` → 5 subtests pass.
- `make test`: 45 ok, 2 pre-existing failures in `myhome/daemon` unrelated to this change —
  `TestPoolTracker_*` and one `TestSolarAutomation_*`, which fail identically on clean `main`
  (`7afc692`). They are a clock bug, not flakiness: the fixtures use
  `time.Now().Truncate(24*time.Hour)`, which aligns to **UTC** rather than local midnight, so between
  00:00 and 02:00 CEST the events land on the previous local day. Filed and fixed separately.

## Context

Found while measuring `pool-pump.js` heap for #433 on a spare Pro1. The empty upload cost one invalid
measurement arm before `Script.GetCode` showed the code was empty.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(script upload): verify the script exists before trusting its version marker ([3707d11](https://github.com/asnowfix/home-automation/commit/3707d11a789c805a0e617fe4e54c01246b877f19))
<!-- END-AUTO-GENERATED-COMMITS -->