### PR TITLE
fix(events): count a day in local time, not UTC — daily runtime reads 0 between midnight and 02:00

### DIFF
--- a/myhome/daemon/pool_runtime_tracker_test.go
+++ b/myhome/daemon/pool_runtime_tracker_test.go
@@ -36,7 +36,7 @@ func TestPoolTracker_DailyRuntimeSec(t *testing.T) {
 	s := newTestEventsStorage(t)
 	tracker := NewPoolRuntimeTracker(logr.Discard(), s, "pool-device")
 
-	base := float64(time.Now().Truncate(24*time.Hour).Unix()) + 3600
+	base := localMidnightPlusHour(t)
 
 	insertSwitchEvent(t, s, "pool-device", "switch.on", base)
 	insertSwitchEvent(t, s, "pool-device", "switch.off", base+300) // 5 min
@@ -56,7 +56,7 @@ func TestPoolTracker_RemainingRuntimeSec(t *testing.T) {
 	s := newTestEventsStorage(t)
 	tracker := NewPoolRuntimeTracker(logr.Discard(), s, "pool-device")
 
-	base := float64(time.Now().Truncate(24*time.Hour).Unix()) + 3600
+	base := localMidnightPlusHour(t)
 	insertSwitchEvent(t, s, "pool-device", "switch.on", base)
 	insertSwitchEvent(t, s, "pool-device", "switch.off", base+3600) // 1 h
 
@@ -76,4 +76,19 @@ func TestPoolTracker_RemainingRuntimeSec(t *testing.T) {
 	if done != 0 {
 		t.Errorf("want 0 when target met, got %d", done)
 	}
+}
+
+// localMidnightPlusHour returns 01:00 local time today, as a Unix timestamp.
+//
+// Not time.Now().Truncate(24*time.Hour): Truncate works on absolute time since
+// the zero instant, so it aligns to UTC midnight, not local midnight. In a
+// UTC+2 zone that is 02:00 local — which means that between local midnight and
+// 02:00, "today" computed this way is still yesterday, the fixture events land
+// on the previous local day, and every test that counts "today's" runtime sees
+// zero. Deterministically broken for two hours every night rather than flaky.
+func localMidnightPlusHour(t *testing.T) float64 {
+	t.Helper()
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	return float64(midnight.Add(time.Hour).Unix())
 }

--- a/myhome/daemon/solar_automation_test.go
+++ b/myhome/daemon/solar_automation_test.go
@@ -212,7 +212,7 @@ func TestSolarAutomation_ContextCancelStopsPump(t *testing.T) {
 // exactly `seconds` for the rest of the test.
 func seedDailyRuntime(t *testing.T, s *events.Storage, deviceID string, seconds float64) {
 	t.Helper()
-	base := float64(time.Now().Truncate(24*time.Hour).Unix()) + 3600
+	base := localMidnightPlusHour(t)
 	insertSwitchEvent(t, s, deviceID, "switch.on", base)
 	insertSwitchEvent(t, s, deviceID, "switch.off", base+seconds)
 }

--- a/myhome/events/storage.go
+++ b/myhome/events/storage.go
@@ -240,7 +240,16 @@ func (s *Storage) LoadTodayStats(ctx context.Context, date string) ([]DailyStat,
 }
 
 // OnDurationSec returns the total seconds a component spent in the "on" state
-// on the given date (YYYY-MM-DD format).  Each off→on transition contributes
+// on the given date (YYYY-MM-DD format), interpreted in the **local** time
+// zone — the same zone callers use when they derive that date from
+// time.Now().Format("2006-01-02").
+//
+// The date filter therefore converts with 'localtime'. Without it SQLite's
+// date(ts,'unixepoch') yields the UTC date, which disagrees with the caller's
+// local date for the whole UTC offset every night: in CEST (UTC+2), between
+// local 00:00 and 02:00 the caller asks for today while the query still
+// matches yesterday, and daily runtime comes back as 0. "Today's filtration"
+// means the household's today, so both sides align on local days.  Each off→on transition contributes
 // (next_off.ts - on.ts) to the sum; if no off event follows the most recent on
 // (component is currently active), the open interval is measured to now.
 // Consecutive on events without an intervening off are deduplicated — only the
@@ -261,7 +270,7 @@ FROM events e1
 WHERE e1.device_id = ?
   AND e1.component = ?
   AND e1.event     = ?
-  AND date(e1.ts, 'unixepoch') = ?
+  AND date(e1.ts, 'unixepoch', 'localtime') = ?
   AND COALESCE(
       (SELECT e0.event FROM events e0
        WHERE e0.device_id = e1.device_id
@@ -273,11 +282,11 @@ WHERE e1.device_id = ?
   ) = ?`
 	var sec float64
 	err := s.db.QueryRowContext(ctx, q,
-		offEvent,                   // correlated subquery: min off.ts after this on
+		offEvent,                           // correlated subquery: min off.ts after this on
 		deviceID, component, onEvent, date, // outer WHERE
-		onEvent, offEvent,          // previous-event lookup: on OR off
-		offEvent,                   // COALESCE default: no prior event → treat as off
-		offEvent,                   // final equality: previous must be off
+		onEvent, offEvent, // previous-event lookup: on OR off
+		offEvent, // COALESCE default: no prior event → treat as off
+		offEvent, // final equality: previous must be off
 	).Scan(&sec)
 	if err != nil {
 		return 0, err

--- a/myhome/events/storage_test.go
+++ b/myhome/events/storage_test.go
@@ -23,18 +23,18 @@ func TestRecordAndQuery(t *testing.T) {
 	ctx := context.Background()
 
 	e1 := Event{
-		Ts:       1700000000.0,
-		DeviceID: "dev-1",
+		Ts:        1700000000.0,
+		DeviceID:  "dev-1",
 		Component: "switch:0",
-		Event:    "switch.on",
-		Severity: "info",
+		Event:     "switch.on",
+		Severity:  "info",
 	}
 	e2 := Event{
-		Ts:       1700000001.0,
-		DeviceID: "dev-2",
+		Ts:        1700000001.0,
+		DeviceID:  "dev-2",
 		Component: "switch:0",
-		Event:    "switch.off",
-		Severity: "info",
+		Event:     "switch.off",
+		Severity:  "info",
 	}
 
 	if err := s.Record(ctx, e1); err != nil {
@@ -76,7 +76,7 @@ func TestOnDurationSec(t *testing.T) {
 
 	today := time.Now().Format("2006-01-02")
 	// Use a base timestamp that falls on today's date.
-	base := float64(time.Now().Truncate(24*time.Hour).Unix()) + 3600 // 01:00 today
+	base := localMidnightPlusHour(t) // 01:00 local today
 
 	record := func(deviceID, component, event string, ts float64) {
 		t.Helper()
@@ -144,7 +144,7 @@ func TestOnDurationSec_WrongDay(t *testing.T) {
 
 	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
 	today := time.Now().Format("2006-01-02")
-	baseYesterday := float64(time.Now().Add(-24*time.Hour).Truncate(24*time.Hour).Unix()) + 3600
+	baseYesterday := localMidnightPlusHour(t) - 24*3600 // 01:00 local yesterday
 
 	if err := s.Record(ctx, Event{Ts: baseYesterday, DeviceID: "pump", Component: "switch:0", Event: "switch.on", Severity: "info"}); err != nil {
 		t.Fatal(err)
@@ -207,4 +207,19 @@ func TestPurge(t *testing.T) {
 	if remaining[0].DeviceID != "dev-fresh" {
 		t.Errorf("wrong remaining event: %s", remaining[0].DeviceID)
 	}
+}
+
+// localMidnightPlusHour returns 01:00 local time today, as a Unix timestamp.
+//
+// Not time.Now().Truncate(24*time.Hour): Truncate works on absolute time since
+// the zero instant, so it aligns to UTC midnight, not local midnight. In a
+// UTC+2 zone that is 02:00 local — which means that between local midnight and
+// 02:00, "today" computed this way is still yesterday, the fixture events land
+// on the previous local day, and every test that counts "today's" runtime sees
+// zero. Deterministically broken for two hours every night rather than flaky.
+func localMidnightPlusHour(t *testing.T) float64 {
+	t.Helper()
+	now := time.Now()
+	midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	return float64(midnight.Add(time.Hour).Unix())
 }


### PR DESCRIPTION
**2026-08-09 00:29 CEST** — A production bug that also broke three tests, found by running `make test`
just after midnight.

## The bug

`Storage.OnDurationSec` filters with:

```sql
AND date(e1.ts, 'unixepoch') = ?
```

SQLite's `date(ts,'unixepoch')` yields the **UTC** date. Every caller passes a **local** date, derived
from `time.Now().Format("2006-01-02")`.

The two disagree for the whole UTC offset, every night. In CEST (UTC+2), between local 00:00 and
02:00 the caller asks for *today* while the query still matches *yesterday*, so the sum is 0.

## Why it matters beyond tests

`PoolRuntimeTracker.DailyRuntimeSec` is built on this query, and it feeds the daily-target logic
behind the solar hysteresis and `ctl pool status`. For two hours every night the pump's accumulated
runtime reads as **zero** — so a daily-target check in that window would conclude the pump has not
run at all today.

Not hypothetical: it is the same window in which the pump's own night-run schedule (23:15 → 00:15)
lives.

## Fix

The query converts with `'localtime'`, so both sides agree on the household's day, and the doc
comment now states which zone the `date` argument is in.

The tests had the mirror-image bug and were consistent with the broken query: fixtures built
timestamps from `time.Now().Truncate(24*time.Hour)`, which aligns to **UTC** midnight rather than
local midnight. They now use a `localMidnightPlusHour` helper that explains why, in
`myhome/daemon` and `myhome/events`.

## Evidence

Run on clean `main` (`7afc692`) at **00:19 CEST**:

```
--- FAIL: TestPoolTracker_DailyRuntimeSec        want 600, got 0
--- FAIL: TestPoolTracker_RemainingRuntimeSec    want 3600, got 7200
                                                 want 0 when target met, got 1800
--- FAIL: TestSolarAutomation_SoftStopWhenTargetReachedAndSolarGone
```

The same tests pass during the day, which is why this has never been noticed: it is not flakiness,
it is **deterministically broken between 00:00 and 02:00 local time** (01:00–02:00 in CET) and
correct the rest of the day.

After the fix, at 00:28 CEST: `make test` → **47 ok, 0 failures**.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(events): count a day in local time, not UTC ([201bb84](https://github.com/asnowfix/home-automation/commit/201bb843f73df87f14a16bba21767d93eca1f039))
- Merge main into fix/utc-truncate-midnight-tests ([feb8f68](https://github.com/asnowfix/home-automation/commit/feb8f6836b5231087bb420fad83dd0676e231556))
<!-- END-AUTO-GENERATED-COMMITS -->