### PR TITLE
refactor(pool-pump): one controller, eco/day/max speeds, no election

### DIFF
--- a/internal/myhome/shelly/script/pool.go
+++ b/internal/myhome/shelly/script/pool.go
@@ -38,22 +38,19 @@ func NewPoolService(log logr.Logger, provider DeviceProvider) *PoolService {
 
 // SetupOptions contains configuration for pool setup
 type SetupOptions struct {
-	DeviceIDs            []string // All device IDs to set up
-	PreferredDeviceID    string   // Which device ID should run
-	PreferredSpeed       string   // "eco", "mid", "high", "max"
+	DeviceIDs            []string // Device IDs to set up
+	PreferredSpeed       string   // "eco", "day" or "max" ("max" is the only stage a Pro1 has)
 	NightRunDurationMs   int
-	GraceDelayMs         int
 	EcoSpeed             int
-	MidSpeed             int
-	HighSpeed            int
+	DaySpeed             int
+	MaxSpeed             int
 	TemperatureThreshold float64
 	PoolVolume           int
 	Turnover             int
 	MaxFlowRate          int
 	MaxRpm               int
 	EcoRpm               int
-	MidRpm               int
-	HighRpm              int
+	DayRpm               int
 	MaxTemp              float64
 
 	// Solar-driven hysteresis (#405)
@@ -70,12 +67,17 @@ type SetupOptions struct {
 	NoMinify    bool
 }
 
-// Setup configures the pool pump system on all specified devices
+// Setup configures the pool pump controller(s).
+//
+// One controller is wired to the pump at a time; several may be configured (a
+// Pro3 kept as a spare for a Pro1, say), but they never coordinate — each acts
+// solely on its own schedule. There is therefore no minimum device count and no
+// election.
 func (s *PoolService) Setup(ctx context.Context, opts SetupOptions) error {
-	s.log.Info("Setting up pool pump system", "devices", len(opts.DeviceIDs), "preferred", opts.PreferredDeviceID)
+	s.log.Info("Setting up pool pump", "devices", len(opts.DeviceIDs))
 
-	if len(opts.DeviceIDs) < 2 {
-		return fmt.Errorf("at least 2 devices required, got %d", len(opts.DeviceIDs))
+	if len(opts.DeviceIDs) < 1 {
+		return fmt.Errorf("at least 1 device required, got %d", len(opts.DeviceIDs))
 	}
 
 	// Resolve all device IDs
@@ -101,58 +103,39 @@ func (s *PoolService) Setup(ctx context.Context, opts SetupOptions) error {
 		}{InputID: id, ID: dev.Id(), SD: sd})
 	}
 
-	// Find Pro3 and Pro1 IDs for cross-device tracking
-	var pro3ID, pro1ID string
-	for _, info := range deviceInfos {
-		// Check switch count to determine device type
-		// We can't query the device here, so we rely on the user providing at least one Pro3
-		// The script will auto-detect device type at runtime
-		// For now, just use the first device as Pro3 and second as Pro1 if not specified
-		if pro3ID == "" {
-			pro3ID = info.ID
-		} else if pro1ID == "" {
-			pro1ID = info.ID
-		}
-	}
-
 	// Use MQTT channel for KVS operations
 	via := types.ChannelMqtt
 
 	// Setup each device with the same configuration
 	for _, info := range deviceInfos {
-		if err := s.setupDevice(ctx, via, info.SD, info.ID, pro3ID, pro1ID, opts); err != nil {
+		if err := s.setupDevice(ctx, via, info.SD, info.ID, opts); err != nil {
 			return fmt.Errorf("failed to setup device %s: %w", info.ID, err)
 		}
 	}
 
-	s.log.Info("Pool pump setup complete", "device_count", len(deviceInfos), "preferred", opts.PreferredDeviceID)
+	s.log.Info("Pool pump setup complete", "device_count", len(deviceInfos))
 	return nil
 }
 
-func (s *PoolService) setupDevice(ctx context.Context, via types.Channel, sd *shelly.Device, deviceID, pro3ID, pro1ID string, opts SetupOptions) error {
+func (s *PoolService) setupDevice(ctx context.Context, via types.Channel, sd *shelly.Device, deviceID string, opts SetupOptions) error {
 	s.log.Info("Setting up device", "device", sd.Name(), "id", deviceID)
 
 	// All devices get the same KVS configuration
 	kvsConfig := map[string]string{
 		PoolKVSKeys["enable_logging"]:        "true",
 		PoolKVSKeys["mqtt_topic_prefix"]:     "pool/pump",
-		PoolKVSKeys["preferred_device_id"]:   opts.PreferredDeviceID,
 		PoolKVSKeys["preferred_speed"]:       opts.PreferredSpeed,
-		PoolKVSKeys["pro3_device_id"]:        pro3ID,
-		PoolKVSKeys["pro1_device_id"]:        pro1ID,
 		PoolKVSKeys["eco_speed"]:             fmt.Sprintf("%d", opts.EcoSpeed),
-		PoolKVSKeys["mid_speed"]:             fmt.Sprintf("%d", opts.MidSpeed),
-		PoolKVSKeys["high_speed"]:            fmt.Sprintf("%d", opts.HighSpeed),
+		PoolKVSKeys["day_speed"]:             fmt.Sprintf("%d", opts.DaySpeed),
+		PoolKVSKeys["max_speed"]:             fmt.Sprintf("%d", opts.MaxSpeed),
 		PoolKVSKeys["night_run_duration_ms"]: fmt.Sprintf("%d", opts.NightRunDurationMs),
-		PoolKVSKeys["grace_delay_ms"]:        fmt.Sprintf("%d", opts.GraceDelayMs),
 		PoolKVSKeys["temperature_threshold"]: fmt.Sprintf("%.1f", opts.TemperatureThreshold),
 		PoolKVSKeys["pool_volume"]:           fmt.Sprintf("%d", opts.PoolVolume),
 		PoolKVSKeys["turnover"]:              fmt.Sprintf("%d", opts.Turnover),
 		PoolKVSKeys["max_flow_rate"]:         fmt.Sprintf("%d", opts.MaxFlowRate),
 		PoolKVSKeys["max_rpm"]:               fmt.Sprintf("%d", opts.MaxRpm),
 		PoolKVSKeys["eco_rpm"]:               fmt.Sprintf("%d", opts.EcoRpm),
-		PoolKVSKeys["mid_rpm"]:               fmt.Sprintf("%d", opts.MidRpm),
-		PoolKVSKeys["high_rpm"]:              fmt.Sprintf("%d", opts.HighRpm),
+		PoolKVSKeys["day_rpm"]:               fmt.Sprintf("%d", opts.DayRpm),
 		PoolKVSKeys["max_temp"]:              fmt.Sprintf("%.1f", opts.MaxTemp),
 
 		// Solar-driven hysteresis (#405)
@@ -695,36 +678,28 @@ func (s *PoolService) Stop(ctx context.Context, deviceID string) error {
 }
 
 // AddDevice adds a single device to the pool pump mesh
-func (s *PoolService) AddDevice(ctx context.Context, via types.Channel, sd *shelly.Device, deviceID, pro3ID, pro1ID string, allDeviceIDs []string, opts SetupOptions) error {
-	s.log.Info("Adding device to pool pump mesh", "device", sd.Name(), "id", deviceID)
+// AddDevice configures one pump controller. There is no mesh and no peer list:
+// exactly one controller is wired to the pump at a time and never coordinates
+// with another.
+func (s *PoolService) AddDevice(ctx context.Context, via types.Channel, sd *shelly.Device, deviceID string, opts SetupOptions) error {
+	s.log.Info("Configuring pool pump controller", "device", sd.Name(), "id", deviceID)
 
-	// Build peer device list for KVS (all devices except this one)
-	peerIDs := []string{}
-	for _, id := range allDeviceIDs {
-		if id != deviceID {
-			peerIDs = append(peerIDs, id)
-		}
-	}
-
-	// Use the unified setupDevice function
-	return s.setupDevice(ctx, via, sd, deviceID, pro3ID, pro1ID, opts)
+	return s.setupDevice(ctx, via, sd, deviceID, opts)
 }
 
 // SetPreferred sets the preferred device ID and speed on a device
-func (s *PoolService) SetPreferred(ctx context.Context, via types.Channel, sd *shelly.Device, preferredID, speed string) error {
-	s.log.Info("Setting preferred device", "device", sd.Name(), "preferred", preferredID, "speed", speed)
+// SetSpeed sets the speed a controller uses when it starts the pump.
+//
+// There is no longer a preferred *device* to set: exactly one controller is
+// wired at a time, so a device runs on its own schedule with no election.
+func (s *PoolService) SetSpeed(ctx context.Context, via types.Channel, sd *shelly.Device, speed string) error {
+	s.log.Info("Setting pump speed", "device", sd.Name(), "speed", speed)
 
-	// Set preferred device ID
-	if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, PoolKVSKeys["preferred_device_id"], preferredID); err != nil {
-		return fmt.Errorf("failed to set preferred_device_id: %w", err)
-	}
-
-	// Set preferred speed
 	if _, err := kvs.SetKeyValue(ctx, s.log, via, sd, PoolKVSKeys["preferred_speed"], speed); err != nil {
 		return fmt.Errorf("failed to set preferred_speed: %w", err)
 	}
 
-	s.log.Info("Preferred device set successfully", "device", sd.Name())
+	s.log.Info("Pump speed set", "device", sd.Name(), "speed", speed)
 	return nil
 }
 

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -959,24 +959,40 @@ function computeTurnoverToday(sec) {
   return Math.round(turnover * 100) / 100;
 }
 
+// The speed this device will actually run at.
+//
+// A Pro1 is on/off: its single stage is 'max'. Whatever speed the KVS carries —
+// a Pro3-era 'eco', say — the pump physically runs at max RPM, so the whole
+// script must agree on that. Resolving it only in mapSpeedToSwitch() would fix
+// the switching and leave the arithmetic lying: computeFlowRate() scales
+// maxFlowRate by rpm/maxRpm, so 'eco' on a Pro1 would model 2000/2900 = 69% of
+// the real flow, underestimate turnover per day by a third, and make
+// computeRunHours() demand a longer window than the pool needs.
+//
+// Normalising rather than refusing also means a device still configured from
+// the Pro3 era keeps filtering instead of stranding.
+function effectiveSpeed(speed) {
+  if (!speed || speed === 'off') return 'off';
+  if (STATE.deviceType === 'pro1') return 'max';
+  return speed;
+}
+
 function mapSpeedToSwitch(speed) {
   // Map a semantic speed to a physical switch ID.
   // speed: 'eco', 'day', 'max' (or 'off')
   // Returns switch ID, or -1 for off.
 
-  if (!speed || speed === 'off') {
+  var eff = effectiveSpeed(speed);
+  if (eff === 'off') {
     return -1;
   }
 
   if (STATE.deviceType === 'pro3') {
     // Pro3 drives three speed stages.
-    if (speed === 'eco') return CONFIG.ecoSpeed;
-    if (speed === 'day') return CONFIG.daySpeed;
-    if (speed === 'max') return CONFIG.maxSpeed;
+    if (eff === 'eco') return CONFIG.ecoSpeed;
+    if (eff === 'day') return CONFIG.daySpeed;
+    if (eff === 'max') return CONFIG.maxSpeed;
   } else if (STATE.deviceType === 'pro1') {
-    // Pro1 is on/off: its single stage is 'max', and any configured speed
-    // resolves to it. Rejecting 'eco' here would strand a device whose KVS
-    // still carries a Pro3-era speed, so map rather than refuse.
     return 0;
   }
 
@@ -1689,10 +1705,12 @@ function lpad2(n) {
   return n < 10 ? '0' + n : String(n);
 }
 
-// Flow rate (m3/h) at the currently configured preferred speed
+// Flow rate (m3/h) at the speed this device actually runs at — see
+// effectiveSpeed(): on a Pro1 that is always 'max', regardless of what the KVS
+// says, because the pump has one stage.
 function computeFlowRate() {
   var speedRpms = {eco: CONFIG.ecoRpm, day: CONFIG.dayRpm, max: CONFIG.maxRpm};
-  var rpm = speedRpms[CONFIG.preferredSpeed];
+  var rpm = speedRpms[effectiveSpeed(CONFIG.preferredSpeed)];
   if (!rpm) rpm = CONFIG.maxRpm;
   return CONFIG.maxFlowRate * (rpm / CONFIG.maxRpm);
 }
@@ -1984,8 +2002,11 @@ function doStart(speed, reason) {
     return;
   }
 
-  log('Starting pump at speed:', speed, '-> switch:', switchId);
-  Shelly.emitEvent("pool.pump_start", {speed: speed, switch_id: switchId, reason: reason || "start"});
+  // Report the speed actually run, not the one configured: on a Pro1 those
+  // differ, and the event feeds the daily-turnover accounting.
+  var eff = effectiveSpeed(speed);
+  log('Starting pump at speed:', eff, '-> switch:', switchId);
+  Shelly.emitEvent("pool.pump_start", {speed: eff, switch_id: switchId, reason: reason || "start"});
   activateOutput(switchId);
 }
 

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1,15 +1,17 @@
 // pool-pump.js
 // ------------
 //
-// Unified pool pump control — same script runs on all devices in the mesh.
-// Each device compares CONFIG.preferredDeviceId to its own ID to decide if it
-// should be the active pump controller.
+// Unified pool pump control. Exactly ONE controller is wired to the pump at a
+// time, and it never coordinates with, checks for, or commands another: having
+// one controller drive another is an electrical anti-pattern. The multi-output
+// design is kept because a Pro3 drives three speed stages, but only one device
+// is ever connected.
 //
 // Pro3 (3-switch variator):
 //   - Input 0: Water supply sensor (inverted: HIGH = water supply ON → turn off pumps)
 //   - Input 1: High-water sensor (MQTT notification)
-//   - Input 2: Max speed active from other device (MQTT notification)
-//   - Switch 0-2: Pump speed stages (eco/mid/high, configurable via KVS)
+//   - Input 2: Max speed active (MQTT notification)
+//   - Switch 0-2: Pump speed stages (eco/day/max, configurable via KVS)
 //   - Button: Cycles through speeds
 //
 // Pro1 (1-switch):
@@ -49,26 +51,7 @@ var CONFIG_SCHEMA = {
     type: "string",
     cliOnly: true
   },
-  // Which device ID should run (actual Shelly device ID). Script compares this to its own ID
-  preferredDeviceId: {
-    key: "preferred",
-    default: null,
-    type: "string",
-    required: true
-  },
-  // Pro3 device ID (for MQTT subscriptions - cross-device status tracking)
-  pro3DeviceId: {
-    key: "pro3-id",
-    default: null,
-    type: "string"
-  },
-  // Pro1 device ID (for MQTT subscriptions - cross-device status tracking)
-  pro1DeviceId: {
-    key: "pro1-id",
-    default: null,
-    type: "string"
-  },
-  // Speed: 'eco', 'mid', 'high', 'max'. Maps to switches based on device capabilities
+  // Speed: 'eco', 'day', 'max', 'max'. Maps to switches based on device capabilities
   preferredSpeed: {
     key: "speed",
     default: "eco",
@@ -80,15 +63,15 @@ var CONFIG_SCHEMA = {
     default: 2,
     type: "number"
   },
-  // Pro3 switch ID for mid speed (0, 1, or 2)
-  midSpeed: {
-    key: "mid-speed",
+  // Pro3 switch ID for day speed (0, 1, or 2)
+  daySpeed: {
+    key: "day-speed",
     default: 1,
     type: "number"
   },
-  // Pro3 switch ID for high speed (0, 1, or 2)
-  highSpeed: {
-    key: "high-speed",
+  // Pro3 switch ID for max speed (0, 1, or 2)
+  maxSpeed: {
+    key: "max-speed",
     default: 0,
     type: "number"
   },
@@ -98,12 +81,6 @@ var CONFIG_SCHEMA = {
     default: 3600000,
     type: "number",
     cliOnly: true
-  },
-  // Cross-device grace delay in ms (minimum 10000)
-  graceDelayMs: {
-    key: "grace-delay",
-    default: 10000,
-    type: "number"
   },
   // Temperature threshold (°C) for summer mode (day schedule)
   temperatureThreshold: {
@@ -141,16 +118,10 @@ var CONFIG_SCHEMA = {
     default: 2000,
     type: "number"
   },
-  // Variator RPM setting for mid speed
-  midRpm: {
-    key: "mid-rpm",
+  // Variator RPM setting for day speed
+  dayRpm: {
+    key: "day-rpm",
     default: 2600,
-    type: "number"
-  },
-  // Variator RPM setting for high speed
-  highRpm: {
-    key: "high-rpm",
-    default: 2900,
     type: "number"
   },
   // Temperature (°C) at which run time reaches one full turnover
@@ -234,8 +205,8 @@ function buildSwitchNames() {
   if (STATE.deviceType === "pro3") {
     var names = [];
     names.push({id: CONFIG.ecoSpeed, name: "pump-eco"});
-    names.push({id: CONFIG.midSpeed, name: "pump-mid"});
-    names.push({id: CONFIG.highSpeed, name: "pump-high"});
+    names.push({id: CONFIG.daySpeed, name: "pump-day"});
+    names.push({id: CONFIG.maxSpeed, name: "pump-max"});
     return names;
   } else if (STATE.deviceType === "pro1") {
     return [{id: 0, name: "pump-max"}];
@@ -282,15 +253,9 @@ function loadConfig(callback) {
           log("  -", missingRequired[i]);
         }
         log("Script cannot start without required configuration.");
-        log("Please run: ctl pool setup <pro3-device> --pro1 <pro1-device>");
+        log("Please run: ctl pool setup <device>");
         callback(false);
         return;
-      }
-
-      // Clamp grace delay to minimum safe value
-      if (CONFIG.graceDelayMs < 10000) {
-        log("WARNING: grace-delay below minimum (10000ms), clamping");
-        CONFIG.graceDelayMs = 10000;
       }
 
       // Enumerate available outputs and inputs
@@ -328,8 +293,6 @@ function loadConfig(callback) {
       // Cache my device ID
       var deviceInfo = Shelly.getDeviceInfo();
       if (deviceInfo && deviceInfo.id) {
-        STATE.myDeviceId = deviceInfo.id;
-        log("My device ID:", STATE.myDeviceId);
       } else {
         log("ERROR: Could not get device ID");
         callback(false);
@@ -453,7 +416,6 @@ function queueTask(task) {
 var STATE = {
   // Device configuration (auto-detected at startup)
   deviceType: null,           // "pro3" or "pro1"
-  myDeviceId: null,           // My Shelly device ID from Shelly.getDeviceInfo().id
   outputs: [],                // Array of available output IDs
   inputs: [],                 // Array of available input IDs
 
@@ -469,12 +431,6 @@ var STATE = {
   graceTimer: null,
   graceActive: false,
 
-  // Tracked pro1 switch:0 state (updated via MQTT status subscription, controller only)
-  pro1On: false,
-
-  // Tracked pro3 switch states (updated via MQTT status subscription, bootstrap only)
-  // Key: switch id (0,1,2), value: true/false
-  pro3SwitchStates: {},
   
   // MQTT connection
   mqttConnected: false,
@@ -735,55 +691,6 @@ function ensureForecastUrl(cb) {
 
   log('Forecast URL not found, detecting location...');
   Shelly.call('Shelly.DetectLocation', {}, onDeviceLocation, cb);
-}
-
-// === INTER-DEVICE SAFETY (Grace Delay Guards) ===
-// Uses STATE.graceTimer — a single one-shot timer that occupies one timer slot only while
-// a transition is in progress (never running during steady-state operation).
-
-function startGraceDelay(delayMs, callback) {
-  if (STATE.graceActive) {
-    log("Grace delay already active, queueing continuation");
-    queueTask(function() { startGraceDelay(delayMs, callback); });
-    return;
-  }
-  STATE.graceActive = true;
-  log("Grace delay started:", delayMs, "ms");
-  STATE.graceTimer = Timer.set(delayMs, false, function() {
-    STATE.graceTimer = null;
-    STATE.graceActive = false;
-    log("Grace delay complete");
-    if (callback) callback();
-  });
-}
-
-// Called when pro3 (controller) wants to activate one of its own outputs (pump variator).
-// If pro1 is currently on, turn it off first and wait graceDelayMs.
-function safeActivatePro3(targetOutputId, callback) {
-  if (STATE.deviceType !== "pro3") {
-    if (callback) callback();
-    return;
-  }
-
-  if (targetOutputId === -1) {
-    // Turning everything off — no guard needed
-    if (callback) callback();
-    return;
-  }
-
-  // Use MQTT-tracked pro1 state (kept current by subscribePro1Status).
-  if (!STATE.pro1On) {
-    if (callback) callback();
-    return;
-  }
-
-  log("pro1 is on — turning off before activating pro3 (grace:", CONFIG.graceDelayMs, "ms)");
-  turnOffPro1(function(err) {
-    if (err) {
-      log("WARNING: turnOffPro1 failed during safeActivatePro3:", err);
-    }
-    startGraceDelay(CONFIG.graceDelayMs, callback);
-  });
 }
 
 // === COMPONENT NAMING ===
@@ -1052,38 +959,24 @@ function computeTurnoverToday(sec) {
   return Math.round(turnover * 100) / 100;
 }
 
-// === DEVICE ACTIVATION DECISION ===
-function isMyTurnToRun() {
-  // Compare preferred device ID against my device ID
-  var preferredId = CONFIG.preferredDeviceId;
-  var myId = STATE.myDeviceId;
-
-  if (!preferredId || !myId) {
-    log("ERROR: Cannot determine activation - missing device ID");
-    return false;
-  }
-
-  var shouldRun = preferredId === myId;
-  log("Activation check: preferred=" + preferredId + ", me=" + myId + ", shouldRun=" + shouldRun);
-  return shouldRun;
-}
-
 function mapSpeedToSwitch(speed) {
-  // Map semantic speed to physical switch ID based on device type
-  // speed: 'eco', 'mid', 'high', 'max'
-  // Returns switch ID or -1 for off
+  // Map a semantic speed to a physical switch ID.
+  // speed: 'eco', 'day', 'max' (or 'off')
+  // Returns switch ID, or -1 for off.
 
   if (!speed || speed === 'off') {
     return -1;
   }
 
   if (STATE.deviceType === 'pro3') {
-    // Pro3: 3 switches
+    // Pro3 drives three speed stages.
     if (speed === 'eco') return CONFIG.ecoSpeed;
-    if (speed === 'mid') return CONFIG.midSpeed;
-    if (speed === 'high' || speed === 'max') return CONFIG.highSpeed;
+    if (speed === 'day') return CONFIG.daySpeed;
+    if (speed === 'max') return CONFIG.maxSpeed;
   } else if (STATE.deviceType === 'pro1') {
-    // Pro1: only 1 switch, all speeds map to switch:0
+    // Pro1 is on/off: its single stage is 'max', and any configured speed
+    // resolves to it. Rejecting 'eco' here would strand a device whose KVS
+    // still carries a Pro3-era speed, so map rather than refuse.
     return 0;
   }
 
@@ -1110,17 +1003,6 @@ function turnOffAllSwitchesNext(ids, index, callback) {
 
 function turnOffAllSwitches(callback) {
   turnOffAllSwitchesNext(STATE.outputs, 0, callback);
-}
-
-function turnOffPro1(callback) {
-  if (!CONFIG.pro1DeviceId) {
-    log("WARNING: pro1 device ID not configured");
-    if (callback) callback("no pro1 device ID");
-    return;
-  }
-  log("Sending turn-off command to pro1");
-  MQTT.publish(CONFIG.pro1DeviceId + "/command/switch:0", "off", 0, false);
-  if (callback) queueTask(function() { callback(null); });
 }
 
 function setOutput(outputId, on, callback) {
@@ -1243,7 +1125,7 @@ function activateOutput(outputId, callback) {
   }
 
   if (STATE.deviceType === "pro3") {
-    safeActivatePro3(outputId, function() {
+    (function(next) { next(); })(function() {
       // Turn off all outputs (one at a time via the task queue — see turnOffAllSwitches)
       turnOffAllSwitches(function() {
         if (outputId !== -1) {
@@ -1407,46 +1289,7 @@ function handleSwitchEvent(info) {
     STATE.activeOutput = activatedOutput;
     saveState();
 
-    // Inter-device safety: if pro1 is on (any source, including manual), turn it off.
-    // The grace delay is NOT applied here because pro3 turning on means variator is
-    // now active — pro1 must be off immediately; pro3 is already on.
-    // Note: cannot pre-intercept; this is the earliest reactive point.
-    if (STATE.pro1On) {
-      log("pro3 switch turned on but pro1 is on — sending turn-off to pro1");
-      turnOffPro1(function(err) {
-        if (err) {
-          log("WARNING: failed to turn off pro1 after pro3 switch on:", err);
-        }
-      });
-    }
-
   } else if (STATE.deviceType === "pro1" && info.state === true) {
-    // Inter-device safety: if any pro3 switch is on, immediately turn ourselves off
-    // and queue a re-activation after the grace delay.
-    var anyPro3On = false;
-    for (var k in STATE.pro3SwitchStates) {
-      if (STATE.pro3SwitchStates[k]) {
-        anyPro3On = true;
-        break;
-      }
-    }
-    if (anyPro3On) {
-      log("pro1 switch turned on but pro3 is on — turning off immediately, will retry after grace delay");
-      setOutput(0, false, function() {
-        STATE.activeOutput = -1;
-        saveState();
-        startGraceDelay(CONFIG.graceDelayMs, function() {
-          log("Grace delay complete — re-activating pro1");
-          setOutput(0, true, function() {
-            STATE.activeOutput = 0;
-
-            saveState();
-          });
-        });
-      });
-      return;
-    }
-
     STATE.activeOutput = 0;
     saveState();
 
@@ -1498,8 +1341,8 @@ function handleButtonEvent(info) {
 // Subscribes to the daemon's retained `myhome/energy/solar/available` topic
 // (see #403) and layers a start/stop hysteresis on top of the existing
 // forecast-driven schedule — never replacing it. Calls this script's own
-// doStart()/doStop() so the fuse, isMyTurnToRun(), and water-supply
-// protection remain in force for solar-triggered runs exactly as for
+// doStart()/doStop() so the fuse and water-supply protection remain in
+// force for solar-triggered runs exactly as for
 // scheduled/manual runs.
 //
 // Staleness is judged from the payload's own `ts` field (unix-epoch-seconds,
@@ -1626,72 +1469,6 @@ function checkSolarHysteresis() {
 
 // === MQTT SETUP ===
 
-// Parse a Shelly switch status payload and return the output boolean (or null on error)
-function parseSwitchStatus(message) {
-  var data = null;
-  try {
-    data = JSON.parse(message);
-  } catch (e) {
-    if (e && false) {}
-    return null;
-  }
-  if (!data || !("output" in data)) return null;
-  return data.output;
-}
-
-// --- Controller (pro3): track pro1 switch:0 ---
-function onPro1StatusMessage(topic, message) {
-  var on = parseSwitchStatus(message);
-  if (on === null) return;
-  if (STATE.pro1On !== on) {
-    log("pro1 switch:0 state updated via MQTT:", on);
-    STATE.pro1On = on;
-  }
-}
-
-function subscribePro1Status() {
-  // Subscribe to Pro1 status for cross-device protection
-  if (!CONFIG.pro1DeviceId) return;
-  var topic = CONFIG.pro1DeviceId + "/status/switch:0";
-  MQTT.subscribe(topic, onPro1StatusMessage);
-  log("Subscribed to pro1 status topic:", topic);
-  // Request current state immediately — status topics are NOT retained
-  MQTT.publish(CONFIG.pro1DeviceId + "/command/switch:0", "status_update", 0, false);
-  log("Requested pro1 switch:0 status_update");
-}
-
-// --- Bootstrap (pro1): track pro3 switch:0, switch:1, switch:2 ---
-function onPro3StatusMessage(topic, message) {
-  var on = parseSwitchStatus(message);
-  if (on === null) return;
-  // Extract switch id from topic suffix "…/status/switch:<id>"
-  var id = -1;
-  var parts = topic.split(":");
-  if (parts.length >= 2) {
-    var n = Number(parts[parts.length - 1]);
-    if (!isNaN(n)) id = n;
-  }
-  if (id < 0) return;
-  var prev = (id in STATE.pro3SwitchStates) ? STATE.pro3SwitchStates[id] : null;
-  if (prev !== on) {
-    log("pro3 switch:" + id + " state updated via MQTT:", on);
-    STATE.pro3SwitchStates[id] = on;
-  }
-}
-
-function subscribePro3Status() {
-  // Subscribe to Pro3 status for cross-device protection
-  if (!CONFIG.pro3DeviceId) return;
-  for (var i = 0; i < 3; i++) {
-    var topic = CONFIG.pro3DeviceId + "/status/switch:" + i;
-    MQTT.subscribe(topic, onPro3StatusMessage);
-    log("Subscribed to pro3 status topic:", topic);
-    // Request current state immediately — status topics are NOT retained
-    MQTT.publish(CONFIG.pro3DeviceId + "/command/switch:" + i, "status_update", 0, false);
-  }
-  log("Requested pro3 switch status_update for all 3 channels");
-}
-
 function setupMQTT() {
   var mqttStatus = Shelly.getComponentStatus("mqtt");
   if (mqttStatus && mqttStatus.connected) {
@@ -1700,8 +1477,6 @@ function setupMQTT() {
   } else {
     log("MQTT not connected");
   }
-  subscribePro1Status();
-  subscribePro3Status();
   subscribeSolarAvailable();
 }
 
@@ -1916,9 +1691,9 @@ function lpad2(n) {
 
 // Flow rate (m3/h) at the currently configured preferred speed
 function computeFlowRate() {
-  var speedRpms = {eco: CONFIG.ecoRpm, mid: CONFIG.midRpm, high: CONFIG.highRpm, max: CONFIG.highRpm};
+  var speedRpms = {eco: CONFIG.ecoRpm, day: CONFIG.dayRpm, max: CONFIG.maxRpm};
   var rpm = speedRpms[CONFIG.preferredSpeed];
-  if (!rpm) rpm = CONFIG.highRpm;
+  if (!rpm) rpm = CONFIG.maxRpm;
   return CONFIG.maxFlowRate * (rpm / CONFIG.maxRpm);
 }
 
@@ -2195,17 +1970,6 @@ function decideModeFromForecast() {
 function doStart(speed, reason) {
   log(reason || 'Start pump');
 
-  // Check if this device should run
-  if (!isMyTurnToRun()) {
-    log('Not my turn to run (preferred device: ' + CONFIG.preferredDeviceId + ', me: ' + STATE.myDeviceId + ')');
-    // Ensure I'm off if I'm not the preferred device
-    if (STATE.activeOutput !== -1) {
-      log('Turning off as I am not the preferred device');
-      activateOutput(-1);
-    }
-    return;
-  }
-
   var input0 = Shelly.getComponentStatus('input:0');
   if (input0 && input0.state) {
     log('Water supply protection active, ignoring start request');
@@ -2228,9 +1992,9 @@ function doStart(speed, reason) {
 function doStop(reason) {
   log(reason || 'Stop pump');
 
-  // Only stop if I'm currently the one running
-  if (!isMyTurnToRun() && STATE.activeOutput === -1) {
-    log('Not running and not preferred device, nothing to do');
+  // Nothing to stop if the pump is already off.
+  if (STATE.activeOutput === -1) {
+    log('Not running, nothing to do');
     return;
   }
 
@@ -2247,7 +2011,6 @@ function doStop(reason) {
 }
 
 // === SCHEDULE EVENT HANDLERS ===
-// Schedules only execute on the preferred device (determined by isMyTurnToRun check in doStart/doStop)
 function handleDailyCheck() {
   log('Daily check event');
 
@@ -2257,10 +2020,7 @@ function handleDailyCheck() {
     return;
   }
 
-  // Summer/winter mode check only runs on preferred device
-  if (isMyTurnToRun()) {
-    performDailyModeCheck();
-  }
+  performDailyModeCheck();
 }
 
 function handleMorningStart() {
@@ -2298,7 +2058,6 @@ function handleNightStop() {
 //
 // `reason` is optional so this can be handed straight to queueTask().
 function reconcileRunState(reason) {
-  if (!isMyTurnToRun()) return;
   var why = (reason || 'Schedule rewrite') + ': ';
 
   isWithinRunWindow(function(shouldRun) {
@@ -2379,8 +2138,6 @@ function continueInit() {
   // Device type and ID are already detected in loadConfig
   // Just log them here for confirmation
   log('Device type:', STATE.deviceType);
-  log('Device ID:', STATE.myDeviceId);
-  log('Preferred device:', CONFIG.preferredDeviceId);
 
   configureComponentNames();
   loadState();
@@ -2441,7 +2198,6 @@ function continueInit() {
     if (stepIndex >= initSteps.length) {
       log('✓ All initialization steps complete - script is now running');
       log('Current mode:', STATE.scheduleMode || 'winter');
-      log('Should I run?', isMyTurnToRun());
       queueTask(handleDailyCheck);
       return;
     }

--- a/internal/shelly/scripts/pool-pump.schema.json
+++ b/internal/shelly/scripts/pool-pump.schema.json
@@ -19,30 +19,8 @@
       "cliOnly": true
     },
     {
-      "name": "preferredDeviceId",
-      "description": "Which device ID should run (actual Shelly device ID). Script compares this to its own ID",
-      "key": "preferred",
-      "default": null,
-      "type": "string",
-      "required": true
-    },
-    {
-      "name": "pro3DeviceId",
-      "description": "Pro3 device ID (for MQTT subscriptions - cross-device status tracking)",
-      "key": "pro3-id",
-      "default": null,
-      "type": "string"
-    },
-    {
-      "name": "pro1DeviceId",
-      "description": "Pro1 device ID (for MQTT subscriptions - cross-device status tracking)",
-      "key": "pro1-id",
-      "default": null,
-      "type": "string"
-    },
-    {
       "name": "preferredSpeed",
-      "description": "Speed: 'eco', 'mid', 'high', 'max'. Maps to switches based on device capabilities",
+      "description": "Speed: 'eco', 'day', 'max', 'max'. Maps to switches based on device capabilities",
       "key": "speed",
       "default": "eco",
       "type": "string"
@@ -56,17 +34,17 @@
       "goConst": true
     },
     {
-      "name": "midSpeed",
-      "description": "Pro3 switch ID for mid speed (0, 1, or 2)",
-      "key": "mid-speed",
+      "name": "daySpeed",
+      "description": "Pro3 switch ID for day speed (0, 1, or 2)",
+      "key": "day-speed",
       "default": 1,
       "type": "number",
       "goConst": true
     },
     {
-      "name": "highSpeed",
-      "description": "Pro3 switch ID for high speed (0, 1, or 2)",
-      "key": "high-speed",
+      "name": "maxSpeed",
+      "description": "Pro3 switch ID for max speed (0, 1, or 2)",
+      "key": "max-speed",
       "default": 0,
       "type": "number",
       "goConst": true
@@ -83,18 +61,8 @@
       "goConstType": "time.Duration"
     },
     {
-      "name": "graceDelayMs",
-      "description": "Cross-device grace delay in ms (minimum 10000)",
-      "key": "grace-delay",
-      "default": 10000,
-      "type": "number",
-      "goConst": true,
-      "goConstName": "GraceDelay",
-      "goConstType": "time.Duration"
-    },
-    {
       "name": "temperatureThreshold",
-      "description": "Temperature threshold (°C) for summer mode (day schedule)",
+      "description": "Temperature threshold (\u00b0C) for summer mode (day schedule)",
       "key": "temp-threshold",
       "default": 20,
       "type": "number",
@@ -102,7 +70,7 @@
     },
     {
       "name": "poolVolume",
-      "description": "Pool volume in m³",
+      "description": "Pool volume in m\u00b3",
       "key": "pool-volume",
       "default": 46,
       "type": "number",
@@ -118,7 +86,7 @@
     },
     {
       "name": "maxFlowRate",
-      "description": "Pump max flow rate in m³/h at max RPM",
+      "description": "Pump max flow rate in m\u00b3/h at max RPM",
       "key": "max-flow-rate",
       "default": 31,
       "type": "number",
@@ -141,24 +109,16 @@
       "goConst": true
     },
     {
-      "name": "midRpm",
-      "description": "Variator RPM setting for mid speed",
-      "key": "mid-rpm",
+      "name": "dayRpm",
+      "description": "Variator RPM setting for day speed",
+      "key": "day-rpm",
       "default": 2600,
       "type": "number",
       "goConst": true
     },
     {
-      "name": "highRpm",
-      "description": "Variator RPM setting for high speed",
-      "key": "high-rpm",
-      "default": 2900,
-      "type": "number",
-      "goConst": true
-    },
-    {
       "name": "maxTemp",
-      "description": "Temperature (°C) at which run time reaches one full turnover",
+      "description": "Temperature (\u00b0C) at which run time reaches one full turnover",
       "key": "max-temp",
       "default": 35,
       "type": "number",

--- a/myhome/ctl/pool/setup.go
+++ b/myhome/ctl/pool/setup.go
@@ -101,39 +101,15 @@ Schedules are only created on Pro3 devices (detected by switch count).`,
 			return fmt.Errorf("failed to get shelly device: %w", err)
 		}
 
-		// Get all currently running pool-pump devices to determine peer IDs
+		// Controllers do not coordinate, so there are no peers to discover.
+		// An already-configured device is still worth reading for its speed, so
+		// adding a second controller inherits the setting rather than silently
+		// resetting it to the default.
 		existingDevices, _ := getPoolDevices(ctx)
 
-		// Build full device ID list: new device first, then existing peers
-		allIDs := []string{dev.Id()}
-		for _, existing := range existingDevices {
-			if existing.Id() != dev.Id() {
-				allIDs = append(allIDs, existing.Id())
-			}
-		}
-
-		// Simple heuristic: first = pro3, second = pro1
-		var pro3ID, pro1ID string
-		if len(allIDs) > 0 {
-			pro3ID = allIDs[0]
-		}
-		if len(allIDs) > 1 {
-			pro1ID = allIDs[1]
-		}
-
-		// Default preferred settings
-		currentPreferred := pro3ID
-		if currentPreferred == "" {
-			currentPreferred = dev.Id()
-		}
 		currentSpeed := "eco"
-
-		// If there are existing devices, read current preferred from one of them
 		via := types.ChannelMqtt
 		if len(existingDevices) > 0 {
-			if pref, err := getKVSValue(ctx, existingDevices[0], via, "script/pool-pump/preferred"); err == nil && pref != "" {
-				currentPreferred = pref
-			}
 			if speed, err := getKVSValue(ctx, existingDevices[0], via, "script/pool-pump/speed"); err == nil && speed != "" {
 				currentSpeed = speed
 			}
@@ -141,21 +117,18 @@ Schedules are only created on Pro3 devices (detected by switch count).`,
 
 		service := mhscript.NewPoolService(hlog.Logger, provider)
 		opts := mhscript.SetupOptions{
-			PreferredDeviceID:    currentPreferred,
 			PreferredSpeed:       currentSpeed,
 			NightRunDurationMs:   int(DefaultNightRunDuration.Milliseconds()),
-			GraceDelayMs:         int(DefaultGraceDelay.Milliseconds()),
 			EcoSpeed:             DefaultEcoSpeed,
-			MidSpeed:             DefaultMidSpeed,
-			HighSpeed:            DefaultHighSpeed,
+			DaySpeed:             DefaultDaySpeed,
+			MaxSpeed:             DefaultMaxSpeed,
 			TemperatureThreshold: DefaultTemperatureThreshold,
 			PoolVolume:           DefaultPoolVolume,
 			Turnover:             DefaultTurnover,
 			MaxFlowRate:          DefaultMaxFlowRate,
 			MaxRpm:               DefaultMaxRpm,
 			EcoRpm:               DefaultEcoRpm,
-			MidRpm:               DefaultMidRpm,
-			HighRpm:              DefaultHighRpm,
+			DayRpm:               DefaultDayRpm,
 			MaxTemp:              DefaultMaxTemp,
 
 			SolarEnabled:         DefaultSolarEnabled,
@@ -168,38 +141,35 @@ Schedules are only created on Pro3 devices (detected by switch count).`,
 			SolarStaleMs:         DefaultSolarStaleMs,
 		}
 
-		fmt.Printf("Adding device %s to pool pump mesh...\n", dev.Name())
-		if err := service.AddDevice(ctx, via, sd, dev.Id(), pro3ID, pro1ID, allIDs, opts); err != nil {
+		fmt.Printf("Configuring %s as a pool pump controller...\n", dev.Name())
+		if err := service.AddDevice(ctx, via, sd, dev.Id(), opts); err != nil {
 			return fmt.Errorf("failed to add device: %w", err)
 		}
 
-		fmt.Printf("✓ Device %s added to pool pump mesh\n", dev.Name())
-		fmt.Printf("  Total devices in mesh: %d\n", len(allIDs))
-		fmt.Printf("  Preferred: %s (speed: %s)\n", currentPreferred, currentSpeed)
+		fmt.Printf("✓ %s configured as a pool pump controller (speed: %s)\n", dev.Name(), currentSpeed)
 		return nil
 	},
 }
 
 var preferredCmd = &cobra.Command{
-	Use:   "preferred <device-id> <speed>",
-	Short: "Set the preferred device and speed on all devices",
-	Long: `Sets preferred_device_id and preferred_speed KVS values on ALL devices
-in the pool pump mesh. The specified device will activate at the given speed.
+	Use:   "speed <speed>",
+	Short: "Set the speed the pump controller starts at",
+	Long: `Sets the preferred_speed KVS value on every configured pool pump controller.
 
 Speed values:
-  eco  - Low speed
-  mid  - Medium speed (Pro3 only)
-  high - High speed (Pro3 only)
-  max  - Maximum speed`,
-	Args: cobra.ExactArgs(2),
+  eco - Low speed (Pro3 only)
+  day - Day speed (Pro3 only)
+  max - Maximum speed (the only stage a Pro1 has)
+
+A Pro1 is on/off, so any speed resolves to its single stage.`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
-		preferredID := args[0]
-		speed := args[1]
+		speed := args[0]
 
-		validSpeeds := map[string]bool{"eco": true, "mid": true, "high": true, "max": true}
+		validSpeeds := map[string]bool{"eco": true, "day": true, "max": true}
 		if !validSpeeds[speed] {
-			return fmt.Errorf("invalid speed: %s (must be eco, mid, high, or max)", speed)
+			return fmt.Errorf("invalid speed: %s (must be eco, day or max)", speed)
 		}
 
 		devices, err := getPoolDevices(ctx)
@@ -210,34 +180,21 @@ Speed values:
 			return fmt.Errorf("no devices running pool-pump.js. Run 'ctl pool add <device>' first")
 		}
 
-		// Verify preferred device is in the mesh
-		found := false
-		for _, sd := range devices {
-			if sd.Id() == preferredID || sd.Name() == preferredID {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("device %s is not in the pool pump mesh", preferredID)
-		}
-
 		provider := &poolProvider{}
 		service := mhscript.NewPoolService(hlog.Logger, provider)
 		via := types.ChannelMqtt
 
-		fmt.Printf("Setting preferred device to %s (speed: %s) on %d devices...\n",
-			preferredID, speed, len(devices))
+		fmt.Printf("Setting pump speed to %s on %d controller(s)...\n", speed, len(devices))
 
 		for _, sd := range devices {
-			if err := service.SetPreferred(ctx, via, sd, preferredID, speed); err != nil {
+			if err := service.SetSpeed(ctx, via, sd, speed); err != nil {
 				fmt.Printf("  ⚠ Failed to update %s: %v\n", sd.Name(), err)
 				continue
 			}
 			fmt.Printf("  ✓ Updated %s\n", sd.Name())
 		}
 
-		fmt.Printf("\n✓ Preferred device set to %s (speed: %s)\n", preferredID, speed)
+		fmt.Printf("\n✓ Pump speed set to %s\n", speed)
 		return nil
 	},
 }

--- a/tools/genconfigschema/regression_test.go
+++ b/tools/genconfigschema/regression_test.go
@@ -10,25 +10,20 @@ import (
 // proves the schema-driven generator reproduces every one of its 28 entries
 // byte-for-byte, so the refactor provably changes no runtime behaviour.
 var wantPoolKVSKeys = map[string]string{
-	"preferred_device_id":   "script/pool-pump/preferred",
 	"preferred_speed":       "script/pool-pump/speed",
-	"pro3_device_id":        "script/pool-pump/pro3-id",
-	"pro1_device_id":        "script/pool-pump/pro1-id",
 	"mqtt_topic_prefix":     "script/pool-pump/mqtt-topic",
 	"enable_logging":        "script/pool-pump/logging",
 	"eco_speed":             "script/pool-pump/eco-speed",
-	"mid_speed":             "script/pool-pump/mid-speed",
-	"high_speed":            "script/pool-pump/high-speed",
+	"day_speed":             "script/pool-pump/day-speed",
+	"max_speed":             "script/pool-pump/max-speed",
 	"night_run_duration_ms": "script/pool-pump/night-duration",
-	"grace_delay_ms":        "script/pool-pump/grace-delay",
 	"temperature_threshold": "script/pool-pump/temp-threshold",
 	"pool_volume":           "script/pool-pump/pool-volume",
 	"turnover":              "script/pool-pump/turnover",
 	"max_flow_rate":         "script/pool-pump/max-flow-rate",
 	"max_rpm":               "script/pool-pump/max-rpm",
 	"eco_rpm":               "script/pool-pump/eco-rpm",
-	"mid_rpm":               "script/pool-pump/mid-rpm",
-	"high_rpm":              "script/pool-pump/high-rpm",
+	"day_rpm":               "script/pool-pump/day-rpm",
 	"max_temp":              "script/pool-pump/max-temp",
 
 	"solar_enabled":           "script/pool-pump/solar-enabled",
@@ -46,18 +41,16 @@ var wantPoolKVSKeys = map[string]string{
 // keyed by the schema field name.
 var wantPoolDefaults = map[string]any{
 	"ecoSpeed":             2.0,
-	"midSpeed":             1.0,
-	"highSpeed":            0.0,
+	"daySpeed":             1.0,
+	"maxSpeed":            0.0,
 	"nightRunDurationMs":   3600000.0, // -> DefaultNightRunDuration (time.Duration, ms*time.Millisecond)
-	"graceDelayMs":         10000.0,   // -> DefaultGraceDelay
 	"temperatureThreshold": 20.0,
 	"poolVolume":           46.0,
 	"turnover":             5.0,
 	"maxFlowRate":          31.0,
 	"maxRpm":               2900.0,
 	"ecoRpm":               2000.0,
-	"midRpm":               2600.0,
-	"highRpm":              2900.0,
+	"dayRpm":               2600.0,
 	"maxTemp":              35.0,
 	"solarEnabled":         false,
 	"solarStartThresholdW": 500.0,
@@ -123,8 +116,8 @@ func TestRegression_PoolPumpSchemaMatchesToday(t *testing.T) {
 		t.Fatalf("LoadSchema: %v", err)
 	}
 
-	if len(schema.Fields) != 28 {
-		t.Fatalf("got %d fields, want 28", len(schema.Fields))
+	if len(schema.Fields) != 23 {
+		t.Fatalf("got %d fields, want 23", len(schema.Fields))
 	}
 
 	gotKVSKeys := map[string]string{}

--- a/tools/genconfigschema/schema_test.go
+++ b/tools/genconfigschema/schema_test.go
@@ -11,23 +11,18 @@ func TestCamelToSnake(t *testing.T) {
 	cases := map[string]string{
 		"enableLogging":        "enable_logging",
 		"mqttTopicPrefix":      "mqtt_topic_prefix",
-		"preferredDeviceId":    "preferred_device_id",
-		"pro3DeviceId":         "pro3_device_id",
-		"pro1DeviceId":         "pro1_device_id",
 		"preferredSpeed":       "preferred_speed",
 		"ecoSpeed":             "eco_speed",
-		"midSpeed":             "mid_speed",
-		"highSpeed":            "high_speed",
+		"daySpeed":             "day_speed",
+		"maxSpeed":            "max_speed",
 		"nightRunDurationMs":   "night_run_duration_ms",
-		"graceDelayMs":         "grace_delay_ms",
 		"temperatureThreshold": "temperature_threshold",
 		"poolVolume":           "pool_volume",
 		"turnover":             "turnover",
 		"maxFlowRate":          "max_flow_rate",
 		"maxRpm":               "max_rpm",
 		"ecoRpm":               "eco_rpm",
-		"midRpm":               "mid_rpm",
-		"highRpm":              "high_rpm",
+		"dayRpm":               "day_rpm",
 		"maxTemp":              "max_temp",
 		"solarEnabled":         "solar_enabled",
 		"solarStartThresholdW": "solar_start_threshold_w",
@@ -130,8 +125,8 @@ func TestLoadSchema_PoolPump(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSchema: %v", err)
 	}
-	if len(s.Fields) != 28 {
-		t.Errorf("pool-pump.schema.json: got %d fields, want 28", len(s.Fields))
+	if len(s.Fields) != 23 {
+		t.Errorf("pool-pump.schema.json: got %d fields, want 23", len(s.Fields))
 	}
 }
 


### PR DESCRIPTION
**2026-08-09 11:01 CEST** — Implements the design decision of 2026-08-09: only one controller is ever
wired to the pump, and it must not check for, coordinate with, or command another. One controller
driving another is an electrical anti-pattern.

The multi-output design stays, because a Pro3 drives three speed stages. A Pro1 is on/off, and its
single stage is `max`.

## What was removed from `pool-pump.js`

- `isMyTurnToRun()` and the preferred-device election
- `pro1On` / `pro3SwitchStates` peer tracking, and the two MQTT status subscriptions feeding them
- `turnOffPro1()` — commanding the other controller
- `safeActivatePro3()` — the "turn the other one off first" guard
- the grace-delay machinery (`startGraceDelay`, `STATE.graceTimer`) and its config key
- both cross-device branches of `handleSwitchEvent`
- `parseSwitchStatus()`, which only ever decoded peer status payloads

**336 lines out of the script.**

## This deletes the suspected cause of #450

One of those branches is the loop found on 2026-08-09: a Pro1 sees its own switch turn on, finds a
stale `pro3SwitchStates` entry, turns itself off, and re-activates after the grace delay — repeating
for as long as the stale state persists.

```js
if (anyPro3On) {
  setOutput(0, false, function() {          // off
    startGraceDelay(CONFIG.graceDelayMs, function() {
      setOutput(0, true, function() { ... });  // back on -> raises another switch event
    });
  });
}
```

It also **bypassed the anti-cycling fuse**: `fuseAllowOn()` is consulted only inside
`activateOutput()`, and this path calls `setOutput()` directly. So the one path that could cycle
indefinitely was the one the fuse could not see.

This PR removes the failure mode rather than guarding it. #450 should stay open until the pump has
run on this build, since the crash itself was never reproduced.

## Speeds are eco / day / max

Renamed consistently through the schema, the generated KVS keys, the JS and the CLI.

`high-rpm` **merges into** `max-rpm`: they were the same concept once "high" became "max", and
production carried the same value (2900) in both. `speedRpms` already aliased `max` to `highRpm`.

Config fields: **28 → 23**. `grace-delay`, `preferred`, `pro3-id` and `pro1-id` are gone.

Since #439, the JSON schema is the single source of truth, so all of this starts in
`pool-pump.schema.json` and regenerates into both the JS block and the Go constants. The
`genconfigschema` regression tests failed exactly as designed when the key set changed, and their
frozen expectations are updated here.

## CLI change (breaking)

`pool preferred <device-id> <speed>` → **`pool speed <speed>`**. There is no longer a device to
prefer. Valid speeds are `eco`, `day`, `max`; a Pro1 resolves any of them to its single stage rather
than refusing, so a device still carrying a Pro3-era `speed` is not stranded.

Say if you would rather keep `preferred` as a deprecated alias.

## Heap: measured on hardware

`mezzanine` (Pro1, fw 2.0.0), production KVS replicated, rebooted between arms, sampled until the
peak settled:

| script | `mem_peak` | free of ~23030 |
|---|---|---|
| `main` before #447 (2026-08-08) | 22778 | 252 |
| `main` + #447, solar off | 19194 | 3836 |
| `main` + #447, solar **on** | 19194 | 3836 |
| **this PR** | **16954** | **6076** |

**−2240 bytes** from this change, on top of #447's −3584. Script runs clean, no errors.

For #433 that is decisive: headroom goes from 252 bytes on Friday to **6076**, and enabling solar
costs no measurable peak (it is a config flag plus one MQTT subscription — the code is parsed either
way).

## Deployment note — needs a KVS migration

`filtration-hiver` currently carries `speed: eco` plus the now-dead `preferred`, `pro1-id`,
`pro3-id`, `grace-delay`, `mid-*` and `high-*` keys, and lacks `day-speed` / `max-speed` / `day-rpm`.
A Pro1 maps any speed to its single stage, so `speed: eco` is harmless, but the missing keys must be
written before this script runs there. The device is offline for hardware maintenance at time of
writing, which makes it a convenient moment.

## Verification

- `make test`: **47 ok, 0 failures**.
- Uploaded to `mezzanine` and run: clean init, no errors, peak as measured above.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- refactor(pool-pump): one controller, eco/day/max speeds, no election ([b709b09](https://github.com/asnowfix/home-automation/commit/b709b09848b6abc10f3b8549b13a9f18ed11ad83))
- fix(pool-pump): a Pro1 runs at max, so the flow model must say so ([22f45c7](https://github.com/asnowfix/home-automation/commit/22f45c71044aa546221cb222c64a819a6ed00355))
- Merge main into refactor/single-controller-pump ([83ed11a](https://github.com/asnowfix/home-automation/commit/83ed11a136bc1dceafb308ea6e5401e6bcb788f9))
- Merge main into refactor/single-controller-pump ([00237f6](https://github.com/asnowfix/home-automation/commit/00237f60ab806126d08421d36f9f08b8920f4f79))
- Merge main into refactor/single-controller-pump ([f8e5887](https://github.com/asnowfix/home-automation/commit/f8e5887a3e2af08b7c1b406a927cd7d078cbd3c6))
- Merge main into refactor/single-controller-pump ([3068cfc](https://github.com/asnowfix/home-automation/commit/3068cfc55b956a708206cf3bd07ee679c2bbfd45))
<!-- END-AUTO-GENERATED-COMMITS -->