### PR TITLE
fix(script emulator): make the timer handler's stopped flag atomic

### DIFF
--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/asnowfix/home-automation/pkg/shelly/mqtt"
@@ -1233,8 +1234,12 @@ type timerHandler struct {
 	timer     *time.Timer
 	startTime time.Time
 	nextFire  time.Time
-	stopped   bool
-	ch        chan []byte // cached channel, created once in Wait()
+	// stopped is written by Close() on the owning goroutine and read by the
+	// goroutines Wait() spawns, so it must be atomic: as a plain bool it is a
+	// data race that -race reports (enabled by default since #454) and that can
+	// in principle miss a stop entirely.
+	stopped atomic.Bool
+	ch      chan []byte // cached channel, created once in Wait()
 }
 
 func (th *timerHandler) Wait() <-chan []byte {
@@ -1251,7 +1256,7 @@ func (th *timerHandler) Wait() <-chan []byte {
 		th.nextFire = time.Now().Add(th.period)
 		go func() {
 			for range th.ticker.C {
-				if th.stopped {
+				if th.stopped.Load() {
 					break
 				}
 				th.nextFire = time.Now().Add(th.period)
@@ -1270,7 +1275,7 @@ func (th *timerHandler) Wait() <-chan []byte {
 		th.nextFire = time.Now().Add(period)
 		go func() {
 			<-th.timer.C
-			if !th.stopped {
+			if !th.stopped.Load() {
 				th.ch <- []byte{} // Signal to fire callback
 			}
 			close(th.ch)
@@ -1299,7 +1304,7 @@ func (th *timerHandler) Handle(ctx context.Context, vm *goja.Runtime, msg []byte
 }
 
 func (th *timerHandler) Stop() {
-	th.stopped = true
+	th.stopped.Store(true)
 	if th.ticker != nil {
 		th.ticker.Stop()
 	}


### PR DESCRIPTION
**2026-08-10 15:52 CEST** — `make test` on `main` is currently **red**: `TestTimerHandlerRecurring`
reports a data race.

```
Write at 0x... by goroutine 52:
  pkg/shelly/script/run.go:1302        (th.stopped = true)
  pkg/shelly/script/timer_test.go:137
Previous read at 0x... by goroutine 53:
  pkg/shelly/script/run.go:1254        (if th.stopped)
```

`timerHandler.stopped` is written by `Close()` on the owning goroutine and read by the goroutines
`Wait()` spawns, with no synchronisation.

## Not just a reporting problem

Without synchronisation the reading goroutine is not guaranteed to observe the store at all, so a
**stopped recurring timer can fire once more after `Close()`**. In the emulator that is a spurious
callback; the same shape on a device would run a callback against state the script believes it has
torn down.

## Fix

`stopped` becomes an `atomic.Bool`. Three call sites, no lock ordering to reason about.

## Verification

- Reproduces on **clean `origin/main`** — this is pre-existing, surfaced rather than caused by the
  race detector becoming the default in #454.
- `go test -race -count=5 -run TestTimerHandler ./pkg/shelly/script/` → clean.
- `make test`: **47 ok, 0 failures**.

## Context

Found while running the suite for #459. It is the same class as #451/#452 — state shared between a
handler goroutine and its owner — and the third such race the detector has turned up since it was
enabled, which is a reasonable argument that enabling it was worth the ~1.5 minutes it adds to a run.

Does **not** affect v0.12.0 or the pump: `pkg/shelly/script` is the test emulator, not device or
daemon code.
<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(script emulator): make the timer handler's stopped flag atomic ([748a0da](https://github.com/asnowfix/home-automation/commit/748a0da2d863dbd880a068c155878831041ae573))
<!-- END-AUTO-GENERATED-COMMITS -->