### PR TITLE
docs: sub-agent and issue-hygiene conventions (#432)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1871,6 +1871,12 @@ For visibility without needing to run anything locally:
 3. **Monitor logs**: Debug output goes to stdout (not hlog)
 4. **Disable debug**: `go run . ctl shelly script debug device-name false`
 
+**Never reboot the device after enabling UDP debug.** `ctl shelly script debug <device> true`
+calls `Sys.SetConfig` and only reboots if the device itself reports `RestartRequired` — do not
+add a manual reboot around this command. Always disable debug again once you're done
+(`... false`); leaving UDP debug on permanently is not a valid workflow — it degrades device
+performance and causes crashes/reboots on its own within a fairly short time.
+
 ### Launch Configurations
 
 The project includes VS Code launch configurations in `.vscode/launch.json`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,10 +156,27 @@ emulator's per-call logging, is large enough to consume a sub-agent's context be
 the result.
 
 **Never end a turn in order to wait for a test run.** This is the #432 stall mode. Ending a turn
-terminates the sub-agent; the completion notification then has no live turn to land in, so an agent
-that signs off with "waiting for the test run, will resume when notified" is simply gone. Nothing
-re-invokes it. (A stalled agent can still be resumed by the coordinator with `SendMessage`, but
-that is a recovery, not the design.)
+terminates the sub-agent, and nothing re-invokes it when its background job finishes — so an agent
+that signs off with "waiting for the test run, will resume when notified" is simply gone.
+
+Measured directly on 2026-08-11 with a throwaway agent that backgrounded a 200-second job and then
+ended its turn:
+
+- the agent stopped after **9.8 s**, reported by the harness as `completed`;
+- its child kept running and finished normally **3.5 minutes later**;
+- the agent received **no** automatic notification of that completion — confirmed by asking the
+  agent itself after resuming it;
+- the agent's own completion notification fired **immediately**, while its child was still alive.
+
+Two consequences worth acting on:
+
+- **The child's work is not lost, only orphaned.** Before re-running anything for a stalled agent,
+  look for its output on disk — a completed `make test` costs ~6 minutes to repeat for nothing.
+- **A stalled agent can be resumed** by the coordinator with `SendMessage`, picking up its
+  transcript. That is a recovery, not the design; the agent must not plan around it.
+
+Do not treat "the agent's notification arrived" as meaning its background work has finished — the
+observed behaviour above shows the two are unrelated.
 
 The required pattern is: **background the run, then poll it to completion inside the same turn.**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,38 @@ When launching a sub-agent, give it exactly one of these and say which:
 Live-device measurements (`mem_peak`, RPC responses, event-DB queries) and negative results must be
 written down as they are obtained. Re-deriving them means re-touching real hardware.
 
-Related sub-agent rules: commit before running the full test suite (backgrounded `make test` is a
-known stall mode, #432), and sub-agents must not `git push` or open PRs — the coordinator does that
-from the sub-agent's worktree.
+Sub-agents must not `git push` or open PRs — the coordinator does that from the sub-agent's worktree.
+
+#### Running tests in a sub-agent
+
+**Commit first, then run tests.** A sub-agent that dies mid-run loses everything uncommitted, and its
+worktree may be auto-removed.
+
+**Never run the test suite in the foreground.** Go test output under `-race`, with the script
+emulator's per-call logging, is large enough to consume a sub-agent's context before it can act on
+the result.
+
+**Never end a turn in order to wait for a test run.** This is the #432 stall mode. Ending a turn
+terminates the sub-agent; the completion notification then has no live turn to land in, so an agent
+that signs off with "waiting for the test run, will resume when notified" is simply gone. Nothing
+re-invokes it. (A stalled agent can still be resumed by the coordinator with `SendMessage`, but
+that is a recovery, not the design.)
+
+The required pattern is: **background the run, then poll it to completion inside the same turn.**
+
+1. Start the suite with `run_in_background`, writing to a file.
+2. Loop: check the output file periodically until the run finishes or the timeout expires.
+3. Read results by **grepping the file** (`^(--- FAIL|FAIL|ok )`), never by inhaling it whole.
+4. **Report the wall-clock duration of the test run** in the final report, alongside pass/fail.
+
+The coordinator **must give an overall timeout at agent startup** — the agent stops polling and
+reports what it has when that budget is exhausted, rather than looping forever. Choose it from the
+measured suite duration with headroom: a full `make test` on `origin/main` took **5 min 47 s**
+(346.67 s wall clock) on 2026-08-11, so ~15 minutes is a reasonable default budget. These tests are
+known to slow down under CPU contention (#393), and several agents may share the machine.
+
+Duration reporting is not bookkeeping: it is how the suite's cost stays visible, so the budget above
+is re-derived from measurement rather than guessed.
 
 ### Go
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ go test ./internal/myhome/...                    # single package
 go test -v -run TestName ./path/to/package       # specific test
 go test -race ./...                              # with race detector
 
+# NOTE: pass a BARE FILENAME relative to the current directory. An absolute path fails with a
+# misleading "file does not exist" even when the file is plainly there.
 go run ./myhome ctl shelly script upload <device> <script.js> --no-minify
 go run ./myhome ctl shelly script update <device>
 go run ./myhome ctl shelly script debug <device> true
@@ -109,6 +111,21 @@ handing it to a coding agent with a cold context window: no "as discussed above,
 reader saw the same live-debugging session or chat history that motivated the issue. Cross-issue
 dependencies must be made explicit (e.g. "blocked by #123," "must land after #456") rather than
 implied by filing order or narrative context.
+
+**Close an issue only on empirical evidence, and put that evidence in the closing comment.** A fix
+that is present in the source is *not* verified — run the thing. For a data race, that means the
+race detector's output on the affected package; for a device bug, a live measurement; for a crash,
+a regression test that fails without the fix. An issue whose fix has been confirmed only by reading
+the diff stays **open**, with a note saying so.
+
+Grep alone is not evidence. Verifying a claim against `origin/main` while sitting on a feature
+branch — mixing `git grep <rev>` with working-tree greps — silently produces contradictory answers.
+Pick one and say which.
+
+**Keep the umbrella issue of a long campaign current.** For multi-week work, the top-level issue is
+the status board: post an update whenever a gate opens or closes, a measurement lands, or a release
+decision changes, using explicit state words (new / pending / implementing / verifying / discarded /
+closed-by-PR / blocked). Do not post when nothing changed.
 
 ### Sub-agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ other source of information than what the issue itself contains. It may, and sho
 external sources (docs URLs) and/or other issue(s) and/or PR(s), but must not assume the reader
 was present for the discussion that led to filing it.
 
+**Every issue filed in this repo must be self-contained** per the above definition — this applies
+whether a human or a coding agent is the one filing it. Before creating an issue, write it as if
+handing it to a coding agent with a cold context window: no "as discussed above," no assuming the
+reader saw the same live-debugging session or chat history that motivated the issue. Cross-issue
+dependencies must be made explicit (e.g. "blocked by #123," "must land after #456") rather than
+implied by filing order or narrative context.
+
 ### Go
 
 - **CLI output**: `fmt.Printf()` for user-facing messages; `hlog` for internal/debug logging. Never `log.Info()` in CLI commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,27 @@ reader saw the same live-debugging session or chat history that motivated the is
 dependencies must be made explicit (e.g. "blocked by #123," "must land after #456") rather than
 implied by filing order or narrative context.
 
+### Sub-agents
+
+**Every sub-agent must persist its progress outside its own context**, incrementally, as it works —
+not only in its final report. A sub-agent can die mid-task (API error, spend limit, stall) and its
+worktree may be auto-removed if it never committed, taking every finding with it.
+
+When launching a sub-agent, give it exactly one of these and say which:
+
+- **A progress file** at a path you define (e.g. `docs/<issue>-progress.md`, or a scratchpad path),
+  appended after each meaningful step: what was tried, what was measured, what was ruled out.
+- **Comments on the GitHub issue** it was given as its objective — preferred when the work is tied
+  to an issue, since the findings then survive for whoever picks it up next and satisfy the
+  self-contained-issue rule above.
+
+Live-device measurements (`mem_peak`, RPC responses, event-DB queries) and negative results must be
+written down as they are obtained. Re-deriving them means re-touching real hardware.
+
+Related sub-agent rules: commit before running the full test suite (backgrounded `make test` is a
+known stall mode, #432), and sub-agents must not `git push` or open PRs — the coordinator does that
+from the sub-agent's worktree.
+
 ### Go
 
 - **CLI output**: `fmt.Printf()` for user-facing messages; `hlog` for internal/debug logging. Never `log.Info()` in CLI commands.

--- a/docs/401-campaign-live-verification-status.md
+++ b/docs/401-campaign-live-verification-status.md
@@ -23,6 +23,8 @@ Sub-issues and their **current merge status**:
 | #405 | pool-pump.js solar-driven start/stop hysteresis | **Merged** — PR #419, commit `ae4c5da`, tag `campaign/401-solar-hysteresis` |
 | #406 | remove legacy `SolarAutomation` daemon code | **NOT STARTED — gated**, see below |
 | #407 | multi-consumer "solar router" | **Out of scope**, explicit follow-up, do not touch |
+| #421 | crash + missing restart catch-up found during live verification | **NOT STARTED** — new blocker for #406, see "Update 2026-08-03 evening" below |
+| #422 | standing real-device integration test campaign (spare Shelly Plus 1 `development`) | **NOT STARTED** — not a #406 blocker; #421's live re-verification is its first test case |
 
 **#406 is explicitly gated in the issue text**: it must not be started until #402/#403/#405 are
 verified working against the **real pool pump device**, not just CI green. That verification is
@@ -157,16 +159,73 @@ thing observed before this session was paused — it is NOT yet understood wheth
      `myhome/energy/solar/available` at all yet. Full live solar-hysteresis verification is
      therefore blocked on redeploying the daemon, not just the device script.
 
+## Update 2026-08-03 evening: live verification actually FAILED — script crash found, #406 still gated
+
+Resuming this session found `filtration-hiver` **crashed**, not just quiet: `Script.GetStatus` for
+id 2 (`pool-pump.js`) returned `running: false` with `error_msg: "Uncaught Error: Too many calls in
+progress"`, thrown from `storeValue("turnover-today", ...)` inside the task-queue dispatcher. The
+device had been running since 09:31:05 that morning; the script crashed at some point before the
+scheduled 18:14 evening-stop fired, so that schedule call was a no-op (script wasn't running to
+receive it) and the pump was found still on at ~19:34, over an hour late with no way to stop via
+schedule.
+
+Restarting the script (`Script.Stop` + `Script.Start`) brought it back, but it **crashed again
+within seconds** from a different call site (`saveState()`'s `storeValue(STATE_KEYS.activeOutput,
+...)` mirror) — same crash class, different trigger, confirming this is systemic rather than a
+one-off. The pump was manually confirmed off via `Switch.Set {id:0, on:false}` — though it turned
+out the crashed `handleEveningStop()` run had actually already turned it off correctly just before
+crashing on its own follow-up KVS write, so the manual call was a safety no-op, not what actually
+stopped the pump.
+
+**This is a new regression in the already-merged #402 accumulator (PR #410)**, filed as its own
+issue: **#421** — "fix(pool-pump): 'Too many calls in progress' crash kills script + no catch-up
+after restart". It covers two distinct bugs found together tonight:
+- **Bug A**: `queueTask`/`storeValue`'s fire-and-forget `Shelly.call` pattern has no notion of
+  calls-in-flight, so bursts of concurrent RPC calls (worst at boot, when `saveState()`,
+  `persistRuntimeState()`, and the `initSteps` sequence all queue/fire close together) can exceed the
+  real 5-concurrent-call device ceiling; an uncaught exception in one queued task kills the whole
+  script with no try/catch anywhere in `processTaskQueue`.
+- **Bug B**: `enforceOutputState()` on (re)start only mirrors the physical switch state — it never
+  checks whether *now* falls inside or outside today's schedule window, so a crash-recovery restart
+  between windows leaves a stale on/off state uncorrected until the next schedule tick (up to 24h
+  later).
+
+#421 also scopes in a **minimal slice of #250** (script emulator resource-limit enforcement, still
+open) as a prerequisite: the current emulator (`pkg/shelly/script/run.go`) has no concurrency
+ceiling or async delay at all, so the crash cannot be reproduced in a unit test without at least a
+per-VM in-flight-call counter + configurable delay in `DeviceTestMode`. Full test-first ordering is
+specified inside #421 — write the reproducing test before implementing either fix.
+
+Also discussed: the user has a spare Shelly Plus 1 named `development` available for safe
+integration testing of this crash/fix, without risking the real pump. Confirmed suitable with no
+script code changes needed — `pool-pump.js`'s device-type detection
+(`internal/shelly/scripts/pool-pump.js:321-331`) is purely by switch count, so a single-switch
+Plus 1 auto-detects the same code path as the Pro1. Only device-side config differs: point
+`script/pool-pump/preferred` at its own device ID, and use short-interval test `Schedule` jobs
+instead of daily ones. This is now filed as its own standing campaign issue, **#422** — "test:
+establish real-device integration test campaign using spare Shelly Plus 1 (development)" —
+covering the general process (device-availability precondition, a `docs/integration-tests.md`
+recording template) for repeatable real-hardware test cases going forward, not just this one crash.
+#421's own real-hardware re-verification step is registered as #422's first tracked test case
+(cross-linked from both issues). #422 is **not** a #406 blocker itself; #421 is.
+
+**#406 remains gated — more firmly than before.** The original gate was "not yet verified against
+real hardware"; tonight's session found the opposite of a clean verification (an active crash), so
+#421 must be fixed and re-verified live before #406 can be considered.
+
 ## Bottom line / what "done" looks like before #406 can start
 
-1. Confirm `filtration-hiver` is reachable again and running the new `pool-pump.js` cleanly
-   (id 2, started, no crash loop).
-2. Decide on and (if approved) execute a daemon redeploy to the NAS so `ctl pool status`,
+1. Fix **#421** (both bugs), with the reproducing test written and failing first, then passing after
+   the fix — per that issue's test plan.
+2. Confirm `filtration-hiver` (or the `development` Shelly Plus 1 first, as a safer dry run) is
+   reachable, running the new `pool-pump.js` cleanly (id 2, started, no crash loop) **including
+   surviving a normal boot and a mid-window restart without Bug A or Bug B recurring**.
+3. Decide on and (if approved) execute a daemon redeploy to the NAS so `ctl pool status`,
    `pool.turnover_today`, and the new `myhome/energy/solar/available` publisher are actually live
    — without this, solar hysteresis can never be observed end-to-end no matter what the device
    script does.
-3. With both device and daemon current, actually observe: pump status/turnover reads correctly via
+4. With both device and daemon current, actually observe: pump status/turnover reads correctly via
    `ctl pool status` (no parse error), and — if the user wants solar mode exercised — a real
    solar-triggered start/stop cycle, or at minimum clean startup with solar enabled and no crash.
-4. Only after the user explicitly confirms this looks right on real hardware, proceed to #406
+5. Only after the user explicitly confirms this looks right on real hardware, proceed to #406
    (delete `myhome/daemon/solar_automation.go` and related config/docs) as its own PR.

--- a/docs/401-campaign-live-verification-status.md
+++ b/docs/401-campaign-live-verification-status.md
@@ -1,0 +1,172 @@
+# Issue #401 campaign — status and live-device verification handover
+
+This file is a handover snapshot for whichever agent (or human) picks this up next. It assumes
+no memory of any prior conversation. Verify every claim below against current repo/device state
+before acting on it — this is a point-in-time snapshot, not live truth.
+
+## What #401 is
+
+Umbrella issue: "solar-driven pool pump redesign — daemon publishes availability, pump decides
+for itself" (https://github.com/asnowfix/home-automation/issues/401). Root problem: the pool pump
+didn't start on solar power because of a KVS-parsing bug, plus a structural issue where the daemon
+issued raw `Switch.Set` calls that bypassed the pump script's own safety logic. Fix: move all
+start/stop decision-making onto the device script itself; the daemon only publishes an
+availability topic.
+
+Sub-issues and their **current merge status**:
+
+| Issue | Title | Status |
+|---|---|---|
+| #402 | on-device runtime/turnover accumulator | **Merged** — PR #410, commit `40f8b54`, tag `campaign/401-pool-pump-runtime-accumulator` |
+| #403 | daemon aggregates solar sources → `myhome/energy/solar/available` | **Merged** — PR #412, commit `1f4cabe`, tag `campaign/401-solar-source-aggregator` |
+| #404 | minimal energy-claimers registry + RPC | **Merged** — PR #411, commit `4a24aba`, tag `campaign/401-energy-claimers-registry` |
+| #405 | pool-pump.js solar-driven start/stop hysteresis | **Merged** — PR #419, commit `ae4c5da`, tag `campaign/401-solar-hysteresis` |
+| #406 | remove legacy `SolarAutomation` daemon code | **NOT STARTED — gated**, see below |
+| #407 | multi-consumer "solar router" | **Out of scope**, explicit follow-up, do not touch |
+
+**#406 is explicitly gated in the issue text**: it must not be started until #402/#403/#405 are
+verified working against the **real pool pump device**, not just CI green. That verification is
+what this session was in the middle of when it got interrupted. Do not start #406 until that
+verification is actually done and the user has confirmed it.
+
+Side-fix also merged during this campcampaign, not itself a sub-issue: **PR #413** — pushing an
+annotated `campaign/401-*` tag onto `main` broke `git describe --tags` version derivation (picked
+the campaign tag instead of the nearest `vX.Y.Z` release tag), which broke the Debian package
+version format. Fixed by adding `--match 'v*'` to all 4 affected `git describe` call sites
+(`Makefile:242`, `Makefile:323`, `myhome/Makefile:10`, `.github/workflows/on-tag-main.yml:19`).
+Confirmed working (`v0.11.0-99-g4bc9172` etc.) — no further action needed on this.
+
+## Orchestration note (context, not actionable)
+
+Sub-issues #402–#405 were implemented via spawned sub-agents, reviewed, merged, and tagged from
+the main coordinating session directly (not through the originally-launched "orchestrator" agent,
+which stalled/failed repeatedly — ~8 times, mostly transient API disconnects and a couple of
+apparent interactive-git-editor hangs — and was eventually abandoned in favor of driving things
+directly). This is just background; it doesn't affect what's left to do.
+
+## What's in progress right now: real-device verification on `filtration-hiver`
+
+Device: `filtration-hiver`, id `shellypro1-ec62608c0230` (a Shelly Pro1). This is the device
+running `pool-pump.js`.
+
+**Environment facts, confirmed this session:**
+- MQTT broker is at `192.168.1.2:1883`. **Always pass `--mqtt-broker tcp://192.168.1.2:1883`
+  explicitly** — the user explicitly asked for this (auto-discovery / mDNS may not behave well
+  from this dev Mac). Do not rely on default discovery.
+- This dev Mac has an active VPN (`utun4`, gateway `10.5.0.2`) that wins the default route over
+  the real LAN (`en0`, `192.168.1.88`). This previously broke `internal/myhome/net.MainInterface()`
+  picking the wrong source IP for the UDP callback address used by
+  `myhome ctl shelly script debug <device> true` (device-level debug). See memory
+  `feedback_live_shelly_debug_workflow.md` for the exact symptom and manual fix
+  (`Sys.SetConfig` with the correct LAN IP) — this has NOT yet been re-checked in this session, do
+  it before relying on debug UDP output.
+- The MCP tool `shelly_list`/`shelly_call` (mcp__shelly__*) times out on `device.lookup` — it needs
+  a running myhome daemon instance to answer that RPC and none was reachable this way. Use the
+  locally-built `./myhome/myhome ctl ...` binary directly instead (it does lazy MQTT connect / can
+  talk to devices without a separate daemon process for most `ctl shelly`/`ctl pool` commands).
+- **There is a real, already-deployed, long-running `myhome` daemon somewhere on the network
+  (likely the NAS, `gruissan.local`, per memory `reference_nas_ssh.md` — arm64, `.deb` install,
+  `myhome.service` via systemd) that is still running PRE-#402 code.** Confirmed by: `ctl pool
+  status filtration-hiver` returned `PoolGetStatus` RPC content containing the exact legacy bug
+  description (`read active speed: parse KVS script/pool-pump/speed="eco": strconv.ParseFloat:
+  parsing "e": invalid syntax`), which only exists in the OLD `readPoolKVSFloat`-on-`speed`-key
+  code path (`myhome/daemon/solar_automation.go`), not the new `ComputeTurnover()` in
+  `myhome/daemon/pool_notices.go` (which reads pre-computed KVS keys and has no such parse). This
+  means **`ctl pool status` and the `pool.turnover_today` notice will keep showing the old bug
+  until that remote daemon is redeployed with the new merged binary** — this is separate from the
+  device-script work below and has NOT been done yet. Decide with the user whether/how to redeploy
+  it (likely: build an arm64 `.deb` from current `main`, ship it to the NAS, restart
+  `myhome.service`) — this is a production-service change, confirm before doing it.
+
+**Local build state (this worktree,
+`/Users/fix/Desktop/GIT/home-automation/.claude/worktrees/bugfix+pool-pump-not-starting`):**
+- Was on a stray branch (`issue-405-solar-hysteresis` at `992d62f`) at the start of this sub-task
+  for unclear reasons (possibly left over from earlier in this long session) — switched to `main`
+  and fast-forwarded to `ae4c5da` (HEAD at time of writing, includes #402/#403/#404/#405/#413).
+  Re-verify `git log --oneline -1` and `git status` before continuing — another agent may have
+  moved main further since.
+- `make generate && make build` succeeded cleanly from repo root of this worktree. Binary is at
+  `./myhome/myhome` (relative to worktree root). Embedded version string correctly showed
+  `v0.11.0-106-gae4c5da`, confirming PR #413's fix works end-to-end.
+
+**Script upload — DONE, with an important finding:**
+- `./myhome/myhome ctl shelly script update filtration-hiver pool-pump.js --no-minify --force
+  --mqtt-broker tcp://192.168.1.2:1883` **failed deterministically** (same result on two separate
+  attempts) at byte offset 53248 with device error `Missing or bad argument 'code'! (code:-103)`
+  on a `Script.PutCode` chunk call. The unminified script is 76614 bytes. Byte 53248 is chunk #26
+  of 38 (2048-byte chunks) — not a boundary/last-chunk artifact, and the content at that offset is
+  ordinary ASCII JS (part of the new solar-hysteresis code from #405), nothing structurally odd.
+  **Working hypothesis (not fully proven): the Shelly Pro1's script storage/heap is too small to
+  hold the raw unminified source now that #402+#405 added ~360 lines** — `--no-minify` is meant
+  for debugging readability per this repo's own convention (see root `CLAUDE.md`), not for
+  production size.
+- Retried **without** `--no-minify` (i.e. with minification): `./myhome/myhome ctl shelly script
+  update filtration-hiver pool-pump.js --force --mqtt-broker tcp://192.168.1.2:1883` —
+  **succeeded**: `✓ Successfully updated pool-pump.js (id: 2)`. So the minified script does fit and
+  upload cleanly. This is worth writing up as a real finding (possibly a follow-up issue: either
+  document the effective size ceiling somewhere, e.g. `docs/pool-pump.md`, or make `script
+  upload`/`update` warn/refuse before attempting an unminified upload known to be too large for a
+  device's declared JS RAM, rather than failing deep into a chunked upload with a confusing
+  "missing code argument" device error). **Not yet filed as an issue — consider doing so.**
+
+**Immediately after the successful minified upload, the device stopped responding to MQTT RPC
+calls** (`ctl pool status` reported "No devices running pool-pump.js" — likely a discovery-scan
+failure, not necessarily the specific device; a direct `ctl shelly call filtration-hiver
+Script.List --mqtt-broker tcp://192.168.1.2:1883` also timed out after 14s). **This was the last
+thing observed before this session was paused — it is NOT yet understood whether:**
+- the device is just briefly busy/recompiling the new script and needs more time before responding
+  again (plausible — Shelly script recompilation can take a few seconds to tens of seconds), or
+- the new script (or the act of re-creating/restarting it) crashed or is looping the device, or
+- something is wrong with MQTT connectivity/broker state unrelated to the device itself (less
+  likely given the earlier successful upload went through the same channel).
+
+**This is the very next thing to investigate.** Suggested next steps, in order:
+1. Wait a short interval (say 30–60s from whenever the successful upload happened) and retry a
+   simple, cheap call first — e.g. `./myhome/myhome ctl shelly call filtration-hiver
+   Shelly.GetDeviceInfo --mqtt-broker tcp://192.168.1.2:1883` (basic device-level reachability,
+   independent of scripts) before retrying `Script.List`.
+2. If the device responds to `Shelly.GetDeviceInfo` but still not to `Script.List`/script-specific
+   calls, that narrows it to a script-level problem (e.g. new solarEnabled=false path still
+   crashing on init, or the script failed to start after upload).
+3. If the device doesn't respond to anything, it may genuinely be rebooting/crash-looping — check
+   via the physical device or its own local status LED/web UI if accessible, or wait longer and
+   retry, before assuming anything is broken code-side. **Do not reboot the device manually /
+   proactively** — recall project convention (`feedback_live_shelly_debug_workflow.md`): follow
+   explicit literal steps, don't improvise extra reboots.
+4. Once basic reachability is confirmed, the actual verification plan (not yet started) is:
+   - `ctl shelly script debug filtration-hiver true --mqtt-broker tcp://192.168.1.2:1883`
+     (device-level UDP debug), backgrounded with output to a file, read that file directly (don't
+     pre-filter with grep/Monitor — see the live-debug-workflow memory for why). Check first
+     whether the VPN-vs-LAN-IP callback issue recurs (it broke this exact mechanism previously on
+     this same Mac).
+   - Confirm the script actually started (`Script.List`/`Script.GetStatus` id 2, running=true).
+   - Check KVS state for the new solar-* keys — they'll likely be **absent** (falling back to
+     script defaults, e.g. `solar-enabled` defaults to `false`) since KVS defaults are written by
+     `ctl pool setup`/`ctl pool add`, not by a script upload. Uploading the script alone does NOT
+     enable solar mode. Decide with the user whether to also run `ctl pool setup`/`add` with the
+     new `--solar-*` flags to actually exercise the hysteresis live, or whether to just confirm the
+     script boots cleanly with solar disabled (safe/no-op) as a first pass.
+   - Watch for the expected startup log lines (KVS reads with "using default" warnings for
+     unset solar-* keys, similar to the pattern already seen in the CI emulator logs during PR
+     review), and no crashes.
+   - Once solar-enabled is actually turned on (if the user wants that tested live), watch for
+     `Subscribed to myhome/energy/solar/available` and hysteresis log lines when a real/simulated
+     solar-available MQTT message arrives — this requires **#403's daemon-side aggregator to
+     actually be running somewhere and publishing**, which circles back to the stale-remote-daemon
+     problem above: the currently-deployed daemon predates #403 too, so it isn't publishing
+     `myhome/energy/solar/available` at all yet. Full live solar-hysteresis verification is
+     therefore blocked on redeploying the daemon, not just the device script.
+
+## Bottom line / what "done" looks like before #406 can start
+
+1. Confirm `filtration-hiver` is reachable again and running the new `pool-pump.js` cleanly
+   (id 2, started, no crash loop).
+2. Decide on and (if approved) execute a daemon redeploy to the NAS so `ctl pool status`,
+   `pool.turnover_today`, and the new `myhome/energy/solar/available` publisher are actually live
+   — without this, solar hysteresis can never be observed end-to-end no matter what the device
+   script does.
+3. With both device and daemon current, actually observe: pump status/turnover reads correctly via
+   `ctl pool status` (no parse error), and — if the user wants solar mode exercised — a real
+   solar-triggered start/stop cycle, or at minimum clean startup with solar enabled and no crash.
+4. Only after the user explicitly confirms this looks right on real hardware, proceed to #406
+   (delete `myhome/daemon/solar_automation.go` and related config/docs) as its own PR.

--- a/docs/401-campaign-live-verification-status.md
+++ b/docs/401-campaign-live-verification-status.md
@@ -1,19 +1,27 @@
 # Issue #401 campaign — status and live-device verification handover
 
-This file is a handover snapshot for whichever agent (or human) picks this up next. It assumes
-no memory of any prior conversation. Verify every claim below against current repo/device state
-before acting on it — this is a point-in-time snapshot, not live truth.
+This file is a handover snapshot for whichever agent (or human) picks this up next. It assumes no
+memory of any prior conversation. **Verify every claim below against current repo/device/issue
+state before acting on it** — this is a point-in-time snapshot (last updated 2026-08-03 evening),
+not live truth. Superseded sections from earlier snapshots have been removed rather than left to
+accumulate — if you need the full incident narrative (exact commands run, exact error output), it's
+preserved in this file's git history and in issue #421's body.
 
-## What #401 is
+## Objective
 
-Umbrella issue: "solar-driven pool pump redesign — daemon publishes availability, pump decides
-for itself" (https://github.com/asnowfix/home-automation/issues/401). Root problem: the pool pump
-didn't start on solar power because of a KVS-parsing bug, plus a structural issue where the daemon
-issued raw `Switch.Set` calls that bypassed the pump script's own safety logic. Fix: move all
-start/stop decision-making onto the device script itself; the daemon only publishes an
-availability topic.
+Umbrella issue **#401** — "solar-driven pool pump redesign — daemon publishes availability, pump
+decides for itself" (https://github.com/asnowfix/home-automation/issues/401). Root problem: the pool
+pump didn't start on solar power because of a KVS-parsing bug, plus a structural issue where the
+daemon issued raw `Switch.Set` calls that bypassed the pump script's own safety logic. Fix: move all
+start/stop decision-making onto the device script itself; the daemon only publishes an availability
+topic.
 
-Sub-issues and their **current merge status**:
+This doc's specific job is tracking **live-device verification** — #406 (deleting the legacy
+`SolarAutomation` daemon code) is explicitly gated in #401's own issue text on #402/#403/#405 being
+verified working against the **real pool pump device**, not just CI green. That verification is
+what this doc has been tracking across sessions, and it is **not yet complete**.
+
+## Status at a glance
 
 | Issue | Title | Status |
 |---|---|---|
@@ -21,211 +29,89 @@ Sub-issues and their **current merge status**:
 | #403 | daemon aggregates solar sources → `myhome/energy/solar/available` | **Merged** — PR #412, commit `1f4cabe`, tag `campaign/401-solar-source-aggregator` |
 | #404 | minimal energy-claimers registry + RPC | **Merged** — PR #411, commit `4a24aba`, tag `campaign/401-energy-claimers-registry` |
 | #405 | pool-pump.js solar-driven start/stop hysteresis | **Merged** — PR #419, commit `ae4c5da`, tag `campaign/401-solar-hysteresis` |
-| #406 | remove legacy `SolarAutomation` daemon code | **NOT STARTED — gated**, see below |
+| #406 | remove legacy `SolarAutomation` daemon code | **NOT STARTED — gated on #421**, see below |
 | #407 | multi-consumer "solar router" | **Out of scope**, explicit follow-up, do not touch |
-| #421 | crash + missing restart catch-up found during live verification | **NOT STARTED** — new blocker for #406, see "Update 2026-08-03 evening" below |
-| #422 | standing real-device integration test campaign (spare Shelly Plus 1 `development`) | **NOT STARTED** — not a #406 blocker; #421's live re-verification is its first test case |
+| #421 | crash ("Too many calls in progress") + missing restart catch-up, found during live verification | **NOT STARTED** — blocks #406 |
+| #422 | standing real-device integration test campaign (spare Shelly Plus 1 `development`) | **NOT STARTED** — not a #406 blocker; #421's live re-verification is its first tracked test case |
 
-**#406 is explicitly gated in the issue text**: it must not be started until #402/#403/#405 are
-verified working against the **real pool pump device**, not just CI green. That verification is
-what this session was in the middle of when it got interrupted. Do not start #406 until that
-verification is actually done and the user has confirmed it.
+Side-fix also merged during this campaign, not itself a sub-issue: **PR #413** — pushing an
+annotated `campaign/401-*` tag onto `main` broke `git describe --tags` version derivation. Fixed
+(4 call sites got `--match 'v*'`). Confirmed working — no further action needed.
 
-Side-fix also merged during this campcampaign, not itself a sub-issue: **PR #413** — pushing an
-annotated `campaign/401-*` tag onto `main` broke `git describe --tags` version derivation (picked
-the campaign tag instead of the nearest `vX.Y.Z` release tag), which broke the Debian package
-version format. Fixed by adding `--match 'v*'` to all 4 affected `git describe` call sites
-(`Makefile:242`, `Makefile:323`, `myhome/Makefile:10`, `.github/workflows/on-tag-main.yml:19`).
-Confirmed working (`v0.11.0-99-g4bc9172` etc.) — no further action needed on this.
+**Outstanding, not yet filed as an issue**: uploading `pool-pump.js` **unminified**
+(`--no-minify`) to `filtration-hiver` fails deterministically (`Missing or bad argument 'code'!`
+mid-chunk-upload) — working hypothesis is the Pro1's script storage is now too small for the raw
+source since #402+#405 added ~360 lines. Minified upload works fine. Worth filing as its own small
+issue (either document the effective size ceiling, e.g. in a new `docs/pool-pump.md`, or make
+`script upload`/`update` warn/refuse before a doomed unminified attempt instead of failing deep into
+a chunked upload with a confusing device error). Low priority relative to #421.
 
-## Orchestration note (context, not actionable)
+## Current live-device state (as of end of last session, 2026-08-03 evening)
 
-Sub-issues #402–#405 were implemented via spawned sub-agents, reviewed, merged, and tagged from
-the main coordinating session directly (not through the originally-launched "orchestrator" agent,
-which stalled/failed repeatedly — ~8 times, mostly transient API disconnects and a couple of
-apparent interactive-git-editor hangs — and was eventually abandoned in favor of driving things
-directly). This is just background; it doesn't affect what's left to do.
+Device: `filtration-hiver`, id `shellypro1-ec62608c0230` (Shelly Pro1), running `pool-pump.js`
+(script id 2). **Re-verify this on pickup — it may have changed** (another agent, a scheduled job,
+or the user may have touched it since):
 
-## What's in progress right now: real-device verification on `filtration-hiver`
+- **`pool-pump.js` is crashed (`running: false`)**, killed by the "Too many calls in progress" bug
+  described in #421, hit a second time right after a manual restart attempt during the last
+  session. It was deliberately **left crashed/not running** rather than restarted again, since a
+  third restart would very likely crash again within seconds (same systemic bug, two different call
+  sites already observed) — see #421 for the full root-cause analysis.
+- **The pump switch itself is confirmed OFF** (`Switch.GetStatus` → `output: false`), which is the
+  safe state. This was confirmed via a manual `Switch.Set {id:0, on:false}` call, though it turned
+  out to be a no-op — the crashed script's last `handleEveningStop()` run had already turned it off
+  correctly just before crashing on its own follow-up KVS write.
+- **Do not restart `pool-pump.js` on `filtration-hiver` and walk away** without watching it — assume
+  it will crash again shortly after boot until #421 is actually fixed. If you need the pump under
+  script control again before #421 lands, restart it and stay attentive (or better, test the fix on
+  the spare `development` device first, per #422).
 
-Device: `filtration-hiver`, id `shellypro1-ec62608c0230` (a Shelly Pro1). This is the device
-running `pool-pump.js`.
+## Environment facts (still valid, re-confirm if in doubt)
 
-**Environment facts, confirmed this session:**
 - MQTT broker is at `192.168.1.2:1883`. **Always pass `--mqtt-broker tcp://192.168.1.2:1883`
-  explicitly** — the user explicitly asked for this (auto-discovery / mDNS may not behave well
-  from this dev Mac). Do not rely on default discovery.
-- This dev Mac has an active VPN (`utun4`, gateway `10.5.0.2`) that wins the default route over
-  the real LAN (`en0`, `192.168.1.88`). This previously broke `internal/myhome/net.MainInterface()`
-  picking the wrong source IP for the UDP callback address used by
-  `myhome ctl shelly script debug <device> true` (device-level debug). See memory
-  `feedback_live_shelly_debug_workflow.md` for the exact symptom and manual fix
-  (`Sys.SetConfig` with the correct LAN IP) — this has NOT yet been re-checked in this session, do
-  it before relying on debug UDP output.
-- The MCP tool `shelly_list`/`shelly_call` (mcp__shelly__*) times out on `device.lookup` — it needs
-  a running myhome daemon instance to answer that RPC and none was reachable this way. Use the
-  locally-built `./myhome/myhome ctl ...` binary directly instead (it does lazy MQTT connect / can
-  talk to devices without a separate daemon process for most `ctl shelly`/`ctl pool` commands).
-- **There is a real, already-deployed, long-running `myhome` daemon somewhere on the network
-  (likely the NAS, `gruissan.local`, per memory `reference_nas_ssh.md` — arm64, `.deb` install,
-  `myhome.service` via systemd) that is still running PRE-#402 code.** Confirmed by: `ctl pool
-  status filtration-hiver` returned `PoolGetStatus` RPC content containing the exact legacy bug
-  description (`read active speed: parse KVS script/pool-pump/speed="eco": strconv.ParseFloat:
-  parsing "e": invalid syntax`), which only exists in the OLD `readPoolKVSFloat`-on-`speed`-key
-  code path (`myhome/daemon/solar_automation.go`), not the new `ComputeTurnover()` in
-  `myhome/daemon/pool_notices.go` (which reads pre-computed KVS keys and has no such parse). This
-  means **`ctl pool status` and the `pool.turnover_today` notice will keep showing the old bug
-  until that remote daemon is redeployed with the new merged binary** — this is separate from the
-  device-script work below and has NOT been done yet. Decide with the user whether/how to redeploy
-  it (likely: build an arm64 `.deb` from current `main`, ship it to the NAS, restart
-  `myhome.service`) — this is a production-service change, confirm before doing it.
+  explicitly** to `ctl shelly`/`ctl pool` commands — auto-discovery/mDNS may not behave well from
+  this dev Mac.
+- This dev Mac has an active VPN (`utun4`, gateway `10.5.0.2`) that wins the default route over the
+  real LAN (`en0`, `192.168.1.88`) — confirmed still true as of last session (`route -n get default`
+  → `10.5.0.2` via `utun4`). This breaks `internal/myhome/net.MainInterface()`'s pick of the LAN IP
+  for `ctl shelly script debug <device> true`'s UDP callback address. See memory
+  `feedback_live_shelly_debug_workflow.md` for the manual fix. **Do not reboot the device after
+  fixing the debug UDP address** — `ctl shelly script debug` only reboots if the device itself
+  reports `RestartRequired`; this is now documented in `AGENTS.md` ("Testing Shelly Scripts").
+- The MCP tool `shelly_list`/`shelly_call` (`mcp__shelly__*`) times out on `device.lookup` — it
+  needs a running local `myhome` daemon instance to resolve device names, and none is reachable this
+  way from this Mac. **Use the locally-built `./myhome/myhome ctl ...` binary directly instead**
+  (lazy MQTT connect, no separate daemon process needed for `ctl shelly`/`ctl pool` commands).
+- **There is a real, already-deployed, long-running `myhome` daemon somewhere on the network**
+  (likely the NAS, `gruissan.local` — arm64, `.deb` install, `myhome.service` via systemd) that is
+  **still running pre-#402 code**. Confirmed via the legacy KVS-parsing bug appearing in its RPC
+  responses. This means `ctl pool status` and the `pool.turnover_today` notice will keep showing the
+  old bug, and `myhome/energy/solar/available` is not being published at all, **until that remote
+  daemon is redeployed** with a build from current `main`. This is a production-service change —
+  confirm with the user before doing it (likely: build an arm64 `.deb`, ship to the NAS, restart
+  `myhome.service`).
+- Local build in this worktree
+  (`/Users/fix/Desktop/GIT/home-automation/.claude/worktrees/bugfix+pool-pump-not-starting`) was
+  last confirmed clean at commit `ae4c5da` (`make generate && make build` succeeded, embedded
+  version `v0.11.0-106-gae4c5da`). Branch has since moved to `docs/401-live-verification-handover`
+  at `1f89344` (this doc + related conventions/instructions commits) — **re-run
+  `git log --oneline -1` and rebuild before trusting the binary**, don't assume it's still current.
 
-**Local build state (this worktree,
-`/Users/fix/Desktop/GIT/home-automation/.claude/worktrees/bugfix+pool-pump-not-starting`):**
-- Was on a stray branch (`issue-405-solar-hysteresis` at `992d62f`) at the start of this sub-task
-  for unclear reasons (possibly left over from earlier in this long session) — switched to `main`
-  and fast-forwarded to `ae4c5da` (HEAD at time of writing, includes #402/#403/#404/#405/#413).
-  Re-verify `git log --oneline -1` and `git status` before continuing — another agent may have
-  moved main further since.
-- `make generate && make build` succeeded cleanly from repo root of this worktree. Binary is at
-  `./myhome/myhome` (relative to worktree root). Embedded version string correctly showed
-  `v0.11.0-106-gae4c5da`, confirming PR #413's fix works end-to-end.
+## What's next, in order
 
-**Script upload — DONE, with an important finding:**
-- `./myhome/myhome ctl shelly script update filtration-hiver pool-pump.js --no-minify --force
-  --mqtt-broker tcp://192.168.1.2:1883` **failed deterministically** (same result on two separate
-  attempts) at byte offset 53248 with device error `Missing or bad argument 'code'! (code:-103)`
-  on a `Script.PutCode` chunk call. The unminified script is 76614 bytes. Byte 53248 is chunk #26
-  of 38 (2048-byte chunks) — not a boundary/last-chunk artifact, and the content at that offset is
-  ordinary ASCII JS (part of the new solar-hysteresis code from #405), nothing structurally odd.
-  **Working hypothesis (not fully proven): the Shelly Pro1's script storage/heap is too small to
-  hold the raw unminified source now that #402+#405 added ~360 lines** — `--no-minify` is meant
-  for debugging readability per this repo's own convention (see root `CLAUDE.md`), not for
-  production size.
-- Retried **without** `--no-minify` (i.e. with minification): `./myhome/myhome ctl shelly script
-  update filtration-hiver pool-pump.js --force --mqtt-broker tcp://192.168.1.2:1883` —
-  **succeeded**: `✓ Successfully updated pool-pump.js (id: 2)`. So the minified script does fit and
-  upload cleanly. This is worth writing up as a real finding (possibly a follow-up issue: either
-  document the effective size ceiling somewhere, e.g. `docs/pool-pump.md`, or make `script
-  upload`/`update` warn/refuse before attempting an unminified upload known to be too large for a
-  device's declared JS RAM, rather than failing deep into a chunked upload with a confusing
-  "missing code argument" device error). **Not yet filed as an issue — consider doing so.**
-
-**Immediately after the successful minified upload, the device stopped responding to MQTT RPC
-calls** (`ctl pool status` reported "No devices running pool-pump.js" — likely a discovery-scan
-failure, not necessarily the specific device; a direct `ctl shelly call filtration-hiver
-Script.List --mqtt-broker tcp://192.168.1.2:1883` also timed out after 14s). **This was the last
-thing observed before this session was paused — it is NOT yet understood whether:**
-- the device is just briefly busy/recompiling the new script and needs more time before responding
-  again (plausible — Shelly script recompilation can take a few seconds to tens of seconds), or
-- the new script (or the act of re-creating/restarting it) crashed or is looping the device, or
-- something is wrong with MQTT connectivity/broker state unrelated to the device itself (less
-  likely given the earlier successful upload went through the same channel).
-
-**This is the very next thing to investigate.** Suggested next steps, in order:
-1. Wait a short interval (say 30–60s from whenever the successful upload happened) and retry a
-   simple, cheap call first — e.g. `./myhome/myhome ctl shelly call filtration-hiver
-   Shelly.GetDeviceInfo --mqtt-broker tcp://192.168.1.2:1883` (basic device-level reachability,
-   independent of scripts) before retrying `Script.List`.
-2. If the device responds to `Shelly.GetDeviceInfo` but still not to `Script.List`/script-specific
-   calls, that narrows it to a script-level problem (e.g. new solarEnabled=false path still
-   crashing on init, or the script failed to start after upload).
-3. If the device doesn't respond to anything, it may genuinely be rebooting/crash-looping — check
-   via the physical device or its own local status LED/web UI if accessible, or wait longer and
-   retry, before assuming anything is broken code-side. **Do not reboot the device manually /
-   proactively** — recall project convention (`feedback_live_shelly_debug_workflow.md`): follow
-   explicit literal steps, don't improvise extra reboots.
-4. Once basic reachability is confirmed, the actual verification plan (not yet started) is:
-   - `ctl shelly script debug filtration-hiver true --mqtt-broker tcp://192.168.1.2:1883`
-     (device-level UDP debug), backgrounded with output to a file, read that file directly (don't
-     pre-filter with grep/Monitor — see the live-debug-workflow memory for why). Check first
-     whether the VPN-vs-LAN-IP callback issue recurs (it broke this exact mechanism previously on
-     this same Mac).
-   - Confirm the script actually started (`Script.List`/`Script.GetStatus` id 2, running=true).
-   - Check KVS state for the new solar-* keys — they'll likely be **absent** (falling back to
-     script defaults, e.g. `solar-enabled` defaults to `false`) since KVS defaults are written by
-     `ctl pool setup`/`ctl pool add`, not by a script upload. Uploading the script alone does NOT
-     enable solar mode. Decide with the user whether to also run `ctl pool setup`/`add` with the
-     new `--solar-*` flags to actually exercise the hysteresis live, or whether to just confirm the
-     script boots cleanly with solar disabled (safe/no-op) as a first pass.
-   - Watch for the expected startup log lines (KVS reads with "using default" warnings for
-     unset solar-* keys, similar to the pattern already seen in the CI emulator logs during PR
-     review), and no crashes.
-   - Once solar-enabled is actually turned on (if the user wants that tested live), watch for
-     `Subscribed to myhome/energy/solar/available` and hysteresis log lines when a real/simulated
-     solar-available MQTT message arrives — this requires **#403's daemon-side aggregator to
-     actually be running somewhere and publishing**, which circles back to the stale-remote-daemon
-     problem above: the currently-deployed daemon predates #403 too, so it isn't publishing
-     `myhome/energy/solar/available` at all yet. Full live solar-hysteresis verification is
-     therefore blocked on redeploying the daemon, not just the device script.
-
-## Update 2026-08-03 evening: live verification actually FAILED — script crash found, #406 still gated
-
-Resuming this session found `filtration-hiver` **crashed**, not just quiet: `Script.GetStatus` for
-id 2 (`pool-pump.js`) returned `running: false` with `error_msg: "Uncaught Error: Too many calls in
-progress"`, thrown from `storeValue("turnover-today", ...)` inside the task-queue dispatcher. The
-device had been running since 09:31:05 that morning; the script crashed at some point before the
-scheduled 18:14 evening-stop fired, so that schedule call was a no-op (script wasn't running to
-receive it) and the pump was found still on at ~19:34, over an hour late with no way to stop via
-schedule.
-
-Restarting the script (`Script.Stop` + `Script.Start`) brought it back, but it **crashed again
-within seconds** from a different call site (`saveState()`'s `storeValue(STATE_KEYS.activeOutput,
-...)` mirror) — same crash class, different trigger, confirming this is systemic rather than a
-one-off. The pump was manually confirmed off via `Switch.Set {id:0, on:false}` — though it turned
-out the crashed `handleEveningStop()` run had actually already turned it off correctly just before
-crashing on its own follow-up KVS write, so the manual call was a safety no-op, not what actually
-stopped the pump.
-
-**This is a new regression in the already-merged #402 accumulator (PR #410)**, filed as its own
-issue: **#421** — "fix(pool-pump): 'Too many calls in progress' crash kills script + no catch-up
-after restart". It covers two distinct bugs found together tonight:
-- **Bug A**: `queueTask`/`storeValue`'s fire-and-forget `Shelly.call` pattern has no notion of
-  calls-in-flight, so bursts of concurrent RPC calls (worst at boot, when `saveState()`,
-  `persistRuntimeState()`, and the `initSteps` sequence all queue/fire close together) can exceed the
-  real 5-concurrent-call device ceiling; an uncaught exception in one queued task kills the whole
-  script with no try/catch anywhere in `processTaskQueue`.
-- **Bug B**: `enforceOutputState()` on (re)start only mirrors the physical switch state — it never
-  checks whether *now* falls inside or outside today's schedule window, so a crash-recovery restart
-  between windows leaves a stale on/off state uncorrected until the next schedule tick (up to 24h
-  later).
-
-#421 also scopes in a **minimal slice of #250** (script emulator resource-limit enforcement, still
-open) as a prerequisite: the current emulator (`pkg/shelly/script/run.go`) has no concurrency
-ceiling or async delay at all, so the crash cannot be reproduced in a unit test without at least a
-per-VM in-flight-call counter + configurable delay in `DeviceTestMode`. Full test-first ordering is
-specified inside #421 — write the reproducing test before implementing either fix.
-
-Also discussed: the user has a spare Shelly Plus 1 named `development` available for safe
-integration testing of this crash/fix, without risking the real pump. Confirmed suitable with no
-script code changes needed — `pool-pump.js`'s device-type detection
-(`internal/shelly/scripts/pool-pump.js:321-331`) is purely by switch count, so a single-switch
-Plus 1 auto-detects the same code path as the Pro1. Only device-side config differs: point
-`script/pool-pump/preferred` at its own device ID, and use short-interval test `Schedule` jobs
-instead of daily ones. This is now filed as its own standing campaign issue, **#422** — "test:
-establish real-device integration test campaign using spare Shelly Plus 1 (development)" —
-covering the general process (device-availability precondition, a `docs/integration-tests.md`
-recording template) for repeatable real-hardware test cases going forward, not just this one crash.
-#421's own real-hardware re-verification step is registered as #422's first tracked test case
-(cross-linked from both issues). #422 is **not** a #406 blocker itself; #421 is.
-
-**#406 remains gated — more firmly than before.** The original gate was "not yet verified against
-real hardware"; tonight's session found the opposite of a clean verification (an active crash), so
-#421 must be fixed and re-verified live before #406 can be considered.
-
-## Bottom line / what "done" looks like before #406 can start
-
-1. Fix **#421** (both bugs), with the reproducing test written and failing first, then passing after
-   the fix — per that issue's test plan.
-2. Confirm `filtration-hiver` (or the `development` Shelly Plus 1 first, as a safer dry run) is
-   reachable, running the new `pool-pump.js` cleanly (id 2, started, no crash loop) **including
-   surviving a normal boot and a mid-window restart without Bug A or Bug B recurring**.
-3. Decide on and (if approved) execute a daemon redeploy to the NAS so `ctl pool status`,
-   `pool.turnover_today`, and the new `myhome/energy/solar/available` publisher are actually live
-   — without this, solar hysteresis can never be observed end-to-end no matter what the device
-   script does.
+1. **Fix #421** (both the crash and the missing restart-catch-up), writing the reproducing unit
+   test *first* per that issue's test plan — this includes adding a minimal slice of #250 (script
+   emulator resource-limit enforcement) since the current emulator can't reproduce a
+   concurrent-call-ceiling crash at all yet.
+2. **Verify the #421 fix on real hardware** — prefer the spare Shelly Plus 1 `development` first
+   (safe dry run, per #422's test case #1) before touching `filtration-hiver` again. Confirm the
+   script survives a normal boot and a deliberate mid-window restart without either bug recurring.
+3. Once #421 is confirmed fixed on real hardware, decide with the user whether/how to **redeploy the
+   NAS daemon** to current `main` — required before `ctl pool status`, `pool.turnover_today`, or the
+   `myhome/energy/solar/available` publisher can be observed working live at all.
 4. With both device and daemon current, actually observe: pump status/turnover reads correctly via
    `ctl pool status` (no parse error), and — if the user wants solar mode exercised — a real
    solar-triggered start/stop cycle, or at minimum clean startup with solar enabled and no crash.
-5. Only after the user explicitly confirms this looks right on real hardware, proceed to #406
+5. Only after the user explicitly confirms this looks right on real hardware, proceed to **#406**
    (delete `myhome/daemon/solar_automation.go` and related config/docs) as its own PR.
+6. (Low priority, unblocked, can happen anytime) File the unminified-upload-size issue noted above.


### PR DESCRIPTION
## Why

Conventions that have been in use for days but exist **only on this branch** — `main` has none of them — plus three more learned today. Docs and agent-instruction changes only; **no code**, so nothing here can affect the running system.

## What lands

### 1. Sub-agents must persist progress outside their own context

A sub-agent can die mid-task (API error, spend limit, stall) and its worktree may be auto-removed if it never committed, taking every finding with it. Live-device measurements (`mem_peak`, RPC responses, event-DB queries) are the expensive case — re-deriving them means re-touching real hardware.

Rule: give each sub-agent exactly one of a **progress file** or **comments on its objective issue**, and say which. Issue comments are preferred when the work is tied to an issue.

### 2. Sub-agents poll a backgrounded test run instead of stalling (#432)

**The mechanism.** A sub-agent that backgrounds `make test` and then ends its turn to wait is gone: ending the turn terminates it, so the completion notification has no live turn to land in, and nothing re-invokes it. An agent signing off with *"waiting for the test run, will resume when notified"* has stated a belief the harness does not honour. This recurred on 2026-08-11.

**Foreground is not the fix** — `go test` output under `-race`, with the emulator's per-call logging, is large enough to consume a sub-agent's context before it can act on the result.

**Required pattern**: commit first → background the run → poll to completion *within the same turn* → grep the output file rather than reading it whole → report the run's wall-clock duration. The coordinator supplies an **overall timeout at agent startup**, so a stuck run ends in a report rather than an infinite loop.

Measured baseline recorded in the doc so the budget is derived, not guessed:

```
full `make test` on origin/main @ 84133f8
346.67 real   89.26 user   49.90 sys      → 5 min 47 s
```

Suggested ~15 min budget, since these tests slow under CPU contention (#393) and agents share the machine.

### 3. Close issues on empirical evidence

Four issues (#372, #373, #374, #421) were carried as open while already fixed; a fifth was nearly closed on a fix that had **no test behind it**. New rule: the closing comment must carry the run output — race-detector output, a live measurement, or a regression test that fails without the fix. An issue verified only by reading the diff **stays open**, with a note saying so.

Also: grep alone is not evidence. Mixing `git grep <rev>` against `origin/main` with working-tree greps while on a feature branch produced two contradictory readings in a single session. Say which tree you queried.

### 4. Keep a campaign's umbrella issue current

#401 went stale for two days across a release, a crash and a ten-PR merge series. The umbrella issue is the status board: update it when a gate moves, using explicit state words (new / pending / implementing / verifying / discarded / closed-by-PR / blocked), and stay silent when nothing changed.

### 5. Upload-path gotcha

`ctl shelly script upload` rejects an **absolute path** with a misleading `file does not exist` even when the file is plainly present. It needs a **bare filename relative to the current directory**. Noted inline next to the command in `CLAUDE.md`.

### 6. #401 live-verification handover doc

`docs/401-campaign-live-verification-status.md`.

## Diff

```
 AGENTS.md                                     |   6 ++
 CLAUDE.md                                     |  74 ++++++++++++++++
 docs/401-campaign-live-verification-status.md | 117 ++++++++++++++++++++++++++
```

Rebased onto `main` @ `4dfd40c`.

Refs #432.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- docs(401): live-device verification handover snapshot ([6f5854a](https://github.com/asnowfix/home-automation/commit/6f5854a82caa3b3241d693493e726a7af1c0677e))
- docs(401): record live-crash findings, file follow-up issues, tighten conventions ([81a2c2d](https://github.com/asnowfix/home-automation/commit/81a2c2deb67209573ad9275b3cafbd8f07229429))
- docs(401): rewrite handover as a clean restart point, not an incident log ([8c0f2ce](https://github.com/asnowfix/home-automation/commit/8c0f2ce11621d7511730c7b0279de59056248c09))
- docs: require sub-agents to persist progress to a file or issue comments ([5924ec8](https://github.com/asnowfix/home-automation/commit/5924ec814425775f5d9d7294e03d7654620166d5))
- docs: sub-agents poll a backgrounded test run instead of stalling (#432) ([81b301c](https://github.com/asnowfix/home-automation/commit/81b301cc62c74d2e78ddbd9e75136df34cf4b212))
- docs: close issues on evidence, keep campaign issues current, upload-path gotcha ([2071d6e](https://github.com/asnowfix/home-automation/commit/2071d6e7561bc7878839e93b42c18bcaf078c17f))
- docs: record the measured sub-agent lifecycle behind the #432 rule ([9dd2c62](https://github.com/asnowfix/home-automation/commit/9dd2c6259a8293b85a29bd8458608bc4bf0c6edd))
<!-- END-AUTO-GENERATED-COMMITS -->