### PR TITLE
ci(coverage-delta): compare against the PR's actual base branch, and stop attributing baseline failures to the PR (#435)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,15 @@ jobs:
         run: ./scripts/check-coverage.sh "$(cat .coverage-min)"
 
   # Additive visibility only — never blocks merging. Computes the PR
-  # branch's aggregate coverage against main's so a reviewer can see at a
-  # glance whether a PR moved the needle, without running `make cover`
+  # branch's aggregate coverage against its base branch's (main, or a
+  # release branch like v0.11.x for a backport PR) so a reviewer can see at
+  # a glance whether a PR moved the needle, without running `make cover`
   # locally on both branches themselves.
+  #
+  # The baseline step is allowed to fail without failing this job (see
+  # `continue-on-error` below): a broken or flaky test on the base branch
+  # (e.g. #393) is not something the PR author can fix, and must not be
+  # reported as a coverage regression caused by the PR. See #435.
   coverage-delta:
     runs-on: ubuntu-latest
     needs: build
@@ -58,17 +64,31 @@ jobs:
         run: |
           make cover
           echo "PR_COVERAGE=$(go tool cover -func=coverage.txt | awk '/^total:/{print $3}' | tr -d '%')" >> "$GITHUB_ENV"
-      - name: Coverage on main
+      - name: Coverage on base branch (${{ github.base_ref }})
+        id: baseline
+        continue-on-error: true
         run: |
-          git worktree add /tmp/main-checkout origin/main
-          (cd /tmp/main-checkout && make cover)
-          echo "MAIN_COVERAGE=$(go tool cover -func=/tmp/main-checkout/coverage.txt | awk '/^total:/{print $3}' | tr -d '%')" >> "$GITHUB_ENV"
+          base_ref="${{ github.base_ref }}"
+          echo "BASE_REF=$base_ref" >> "$GITHUB_ENV"
+          git worktree add /tmp/base-checkout "origin/$base_ref"
+          (cd /tmp/base-checkout && make cover)
+          echo "BASE_COVERAGE=$(go tool cover -func=/tmp/base-checkout/coverage.txt | awk '/^total:/{print $3}' | tr -d '%')" >> "$GITHUB_ENV"
       - name: Post coverage delta
         run: |
-          delta=$(awk -v pr="$PR_COVERAGE" -v main="$MAIN_COVERAGE" 'BEGIN { printf "%+.1f", pr - main }')
+          if [ "${{ steps.baseline.outcome }}" != "success" ]; then
+            {
+              echo "## Coverage delta vs ${BASE_REF}"
+              echo "PR: ${PR_COVERAGE}% · baseline unavailable (\`make cover\` failed on \`${BASE_REF}\`) · delta: not computed"
+              echo ""
+              echo "_A failing baseline is not attributed to this PR — see the \"Coverage on base branch\" step log for the underlying failure._"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Baseline coverage computation failed on ${BASE_REF}; coverage delta not computed for this PR (baseline failure, not a PR defect)."
+            exit 0
+          fi
+          delta=$(awk -v pr="$PR_COVERAGE" -v base="$BASE_COVERAGE" 'BEGIN { printf "%+.1f", pr - base }')
           {
-            echo "## Coverage delta vs main"
-            echo "PR: ${PR_COVERAGE}% · main: ${MAIN_COVERAGE}% · delta: ${delta}pp"
+            echo "## Coverage delta vs ${BASE_REF}"
+            echo "PR: ${PR_COVERAGE}% · ${BASE_REF}: ${BASE_COVERAGE}% · delta: ${delta}pp"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Builds a temporary arm64 .deb for manual testing of this PR's changes —


### PR DESCRIPTION
## Two problems, both in `coverage-delta`

### 1. The baseline was hardcoded to `main`

```
git worktree add /tmp/main-checkout origin/main
```

This repo maintains release branches (`v0.11.x` and similar), so a backport PR was measured against `main` and its coverage delta was meaningless. Now resolved from `github.base_ref`, which is safe here because the job already gates on `if: github.event_name == 'pull_request'`. The resolved name flows through `$GITHUB_ENV` and into the summary, so it reads *"Coverage delta vs v0.11.x"* rather than a hardcoded "vs main".

### 2. A failing baseline was reported as the PR's fault

The job computes coverage **on the baseline first**. When a test flakes there, the job fails — and it fails on PRs that contain no Go code at all.

Observed on 2026-08-11 against PR #467, a **docs-only** change:

```
--- FAIL: TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover (18.41s)
FAIL	github.com/asnowfix/home-automation/internal/shelly/scripts	245.524s
make: *** [Makefile:221: cover] Error 1
```

The same test passes locally in **9.1 s** on an idle machine — a real-timer flake under runner contention, tracked in #393. Diagnosing it cost a full investigation on a PR that could not possibly have caused it.

The baseline step now carries `id: baseline` + `continue-on-error: true`. If it fails, the final step writes a "baseline unavailable" summary and a `::warning::` annotation, then exits 0 rather than computing a bogus delta. This makes the job's own stated contract — *"Additive visibility only — never blocks merging"* — actually hold when the base branch is broken or flaky.

## Scope

`.github/workflows/test.yml` only. **No Go code**, and nothing under `internal/shelly/scripts` (other work is in flight there). A repo-wide grep found no other hardcoded `origin/main` baseline; `auto-tag-patch.yml` already resolves its base branch dynamically.

## Verification

- YAML parses (`yaml.safe_load`); jobs still `build`, `coverage-delta`, `build-pr-deb`.
- Hand-traced three cases — PR→`main`, PR→`v0.11.x`, and a baseline-side failure — recorded on #435.
- `actionlint`/`act` were not available locally; no new tooling was installed.

**Not verified without a live CI run**, and worth watching on this PR itself: that `github.base_ref` populates as documented on the runner, and that `fetch-depth: 0` really fetches `refs/heads/v0.11.x` — only `origin/main` has ever been exercised by this job.

Closes #435.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- ci(coverage-delta): compare against the PR's actual base branch, not main ([a8d29ee](https://github.com/asnowfix/home-automation/commit/a8d29ee0928dbdb0713f129410ce32f62e87ac3a))
<!-- END-AUTO-GENERATED-COMMITS -->