### PR TITLE
fix(script upload): distinguish a failed upload from an unconfirmed one (#428)

### DIFF
--- a/internal/myhome/shelly/script/localdir_test.go
+++ b/internal/myhome/shelly/script/localdir_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/asnowfix/home-automation/internal/shelly/scripts"
@@ -192,5 +193,36 @@ func TestLoadScript_NoLocalScriptsDisablesEvenWhenFilePresent(t *testing.T) {
 	}
 	if string(code) != string(want) {
 		t.Errorf("code does not match embedded content")
+	}
+}
+
+// TestLoadScript_RejectsAbsolutePath is the regression test for the
+// "related observation" in issue #428: `script upload` given an absolute
+// path (e.g. `$(pwd)/pool-pump.js`) must be rejected with a clear,
+// actionable message, not one that misleadingly claims the file is missing
+// when it plainly exists on disk. validateFlatScriptName rejects any name
+// that is not its own basename — including absolute paths — before any
+// filesystem access is attempted, so the error is always the flat-name
+// complaint, never an fs.ErrNotExist-flavoured "file does not exist".
+func TestLoadScript_RejectsAbsolutePath(t *testing.T) {
+	log := testr.New(t)
+	dir := t.TempDir()
+
+	// The file genuinely exists at this absolute path — proves the
+	// rejection is about the name shape, not a failed lookup.
+	absPath := filepath.Join(dir, embeddedScriptName)
+	if err := os.WriteFile(absPath, []byte("// present on disk\n"), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	_, _, err := LoadScript(log, "", absPath)
+	if err == nil {
+		t.Fatal("expected an error for an absolute path, got nil")
+	}
+	if strings.Contains(err.Error(), "does not exist") || strings.Contains(err.Error(), "no such file") {
+		t.Errorf("error message misleadingly suggests the file is missing (it exists at %s): %v", absPath, err)
+	}
+	if !strings.Contains(err.Error(), "flat file name") {
+		t.Errorf("expected the flat-file-name error, got: %v", err)
 	}
 }

--- a/internal/myhome/shelly/script/ops.go
+++ b/internal/myhome/shelly/script/ops.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
 	"github.com/asnowfix/home-automation/pkg/shelly/script"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
 	"path/filepath"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -33,9 +35,146 @@ func UploadNamedScript(ctx context.Context, log logr.Logger, via types.Channel, 
 	return id, nil
 }
 
-// UploadWithVersion uploads a script and tracks its version in KVS
-// This is MyHome-specific business logic that combines script upload with version tracking
+// UploadStatus classifies the outcome of UploadWithVersionDetailed for
+// reporting and exit-code purposes — see issue #428.
+type UploadStatus int
+
+const (
+	// StatusUploaded means the script's code is on the device and the
+	// post-upload confirmation (enabling it, starting it) succeeded.
+	StatusUploaded UploadStatus = iota
+	// StatusIndeterminate means the script's code is confirmed on the
+	// device (every PutCode chunk was acknowledged), but a follow-up
+	// confirmation step (Script.SetConfig or Script.Start) did not
+	// complete — commonly because the device is still busy right after
+	// the upload. This is NOT an upload failure: re-uploading is
+	// unnecessary and wastes the operator's time. The caller should
+	// re-check status rather than re-upload.
+	StatusIndeterminate
+	// StatusFailed means the code transfer itself did not complete: the
+	// device does not reliably have the new script.
+	StatusFailed
+)
+
+func (s UploadStatus) String() string {
+	switch s {
+	case StatusUploaded:
+		return "uploaded"
+	case StatusIndeterminate:
+		return "indeterminate"
+	case StatusFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// classifyUpload turns the two possible failure points of an upload
+// attempt — the chunked code transfer itself (chunkErr) and the best-effort
+// post-upload confirmation (confirmErr, from enabling/starting the script)
+// — into a status and an operator-facing message.
+//
+// It deliberately does not inspect what kind of error confirmErr is
+// (context.DeadlineExceeded, a transport error, anything else): once
+// chunkErr is nil the code is verified present on the device, so ANY
+// confirmErr at that point is a confirmation gap, not evidence the upload
+// failed. Only a non-nil chunkErr means the upload itself did not complete.
+//
+// Kept as a pure function, like shouldUpload above, so the decision is
+// directly unit-testable without a device or a live MQTT broker.
+func classifyUpload(chunkErr, confirmErr error) (UploadStatus, string) {
+	if chunkErr != nil {
+		return StatusFailed, fmt.Sprintf("upload failed: %v", chunkErr)
+	}
+	if confirmErr != nil {
+		return StatusIndeterminate, fmt.Sprintf(
+			"script code was uploaded and confirmed on the device, but could not confirm it started/enabled: %v (re-run the status check rather than re-uploading)",
+			confirmErr,
+		)
+	}
+	return StatusUploaded, "script uploaded and confirmed running"
+}
+
+// startAttempts/startRetryDelay bound the retry of the post-upload
+// confirmation step (Script.Start). The device is often still busy for a
+// few seconds right after PutCode/SetConfig — persisting the script and/or
+// running its init — and does not answer RPCs in that window; see issue
+// #428. A short bounded retry turns most of these into confirmed successes
+// instead of an indeterminate result.
+//
+// Package-level vars, not consts, so tests can shrink the delay to keep the
+// suite fast; production code never changes them. Any test that does must
+// restore the original value in t.Cleanup.
+var (
+	startAttempts   = 3
+	startRetryDelay = 2 * time.Second
+)
+
+// retryBounded calls op up to attempts times, waiting delay between
+// attempts (subject to ctx cancellation), and returns nil on the first
+// success or the last error once attempts are exhausted. op receives the
+// 1-based attempt number for logging.
+//
+// Kept side-effect-free apart from calling op and waiting, so the
+// attempt-count/backoff behavior is unit-testable without a device.
+func retryBounded(ctx context.Context, attempts int, delay time.Duration, op func(attempt int) error) error {
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		err = op(attempt)
+		if err == nil {
+			return nil
+		}
+		if attempt < attempts {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+	}
+	return err
+}
+
+// startWithRetry attempts to start the script up to startAttempts times,
+// pausing startRetryDelay between attempts (bounded, cancellable via ctx).
+// It returns the last error, or nil on the first success.
+func startWithRetry(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, name string) error {
+	return retryBounded(ctx, startAttempts, startRetryDelay, func(attempt int) error {
+		_, err := script.StartStopDelete(ctx, via, device, name, script.Start)
+		if err != nil {
+			log.Info("Script.Start did not confirm, will retry if attempts remain",
+				"name", name, "device", device.Name(), "attempt", attempt, "maxAttempts", startAttempts, "error", err.Error())
+		}
+		return err
+	})
+}
+
+// UploadWithVersion uploads a script and tracks its version in KVS.
+// This is MyHome-specific business logic that combines script upload with
+// version tracking. It keeps the original two-value contract for existing
+// callers that only need a pass/fail signal: a post-upload confirmation gap
+// (code confirmed delivered, but enabling/starting it did not confirm) is
+// intentionally NOT surfaced as an error here, since re-uploading in
+// response would be wasted work — see issue #428. Callers that want to
+// report the distinction (e.g. the `script upload` CLI command) should call
+// UploadWithVersionDetailed instead.
 func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, name string, code []byte, minify bool, force bool) (uint32, error) {
+	id, status, err := UploadWithVersionDetailed(ctx, log, via, device, name, code, minify, force)
+	if err != nil {
+		return 0, err
+	}
+	if status == StatusIndeterminate {
+		log.Info("Upload confirmation incomplete, but code delivery was confirmed; not reporting as an error", "name", name, "device", device.Name())
+	}
+	return id, nil
+}
+
+// UploadWithVersionDetailed does the work of UploadWithVersion but also
+// reports an UploadStatus, letting the caller distinguish a fully confirmed
+// upload from one where the code was delivered but a follow-up
+// confirmation step (enabling/starting the script) did not respond. See
+// issue #428.
+func UploadWithVersionDetailed(ctx context.Context, log logr.Logger, via types.Channel, device types.Device, name string, code []byte, minify bool, force bool) (uint32, UploadStatus, error) {
 	// Calculate version hash
 	h := sha1.New()
 	h.Write(code)
@@ -75,29 +214,42 @@ func UploadWithVersion(ctx context.Context, log logr.Logger, via types.Channel, 
 		// Upload the script using the generic pkg/shelly/script package
 		id, err = script.Upload(ctx, via, device, name, code, minify)
 		if err != nil {
-			return 0, err
-		}
-
-		// Create/update KVS entry with script version
-		_, err = kvs.SetKeyValue(ctx, log, via, device, kvsKey, version)
-		if err != nil {
-			log.Error(err, "Unable to set KVS entry for script version", "key", kvsKey, "version", version, "device", device.Name())
-			// Don't fail the upload if KVS fails, just log the error
+			// A *script.PostUploadConfigError means every PutCode chunk
+			// was acknowledged (the code is on the device) but the
+			// follow-up SetConfig call did not confirm — a confirmation
+			// gap, not an upload failure. Anything else means the chunk
+			// transfer itself did not complete: genuinely failed.
+			var confErr *script.PostUploadConfigError
+			if errors.As(err, &confErr) {
+				id = confErr.Id
+				log.Info("Script code confirmed on device, but enabling it did not confirm; will still try to start it", "name", name, "device", device.Name(), "error", confErr.Error())
+			} else {
+				status, message := classifyUpload(err, nil)
+				log.Error(err, message, "name", name, "device", device.Name())
+				return 0, status, err
+			}
 		} else {
-			log.Info("Set KVS entry for script version", "key", kvsKey, "version", version, "device", device.Name())
+			// Create/update KVS entry with script version
+			_, err = kvs.SetKeyValue(ctx, log, via, device, kvsKey, version)
+			if err != nil {
+				log.Error(err, "Unable to set KVS entry for script version", "key", kvsKey, "version", version, "device", device.Name())
+				// Don't fail the upload if KVS fails, just log the error
+			} else {
+				log.Info("Set KVS entry for script version", "key", kvsKey, "version", version, "device", device.Name())
+			}
 		}
 	} else {
 		log.Info(reason, "name", name, "version", version)
 	}
 
-	// Now start the script
-	_, err = script.StartStopDelete(ctx, via, device, name, script.Start)
-	if err != nil {
-		log.Error(err, "Unable to start script", "name", name, "device", device.Name())
-		return 0, err
-	}
+	// Now start the script, with a bounded retry: the device is often still
+	// busy for a few seconds right after upload, and a bare timeout on the
+	// first attempt is not evidence the upload failed (issue #428).
+	confirmErr := startWithRetry(ctx, log, via, device, name)
+	status, message := classifyUpload(nil, confirmErr)
+	log.Info(message, "name", name, "device", device.Name())
 
-	return id, nil
+	return id, status, nil
 }
 
 // shouldUpload decides whether the script's code must be sent to the device,

--- a/internal/myhome/shelly/script/ops_test.go
+++ b/internal/myhome/shelly/script/ops_test.go
@@ -1,6 +1,19 @@
 package script
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/asnowfix/home-automation/pkg/shelly/kvs"
+	pkgscript "github.com/asnowfix/home-automation/pkg/shelly/script"
+	"github.com/asnowfix/home-automation/pkg/shelly/types"
+
+	"github.com/go-logr/logr/testr"
+)
 
 // TestShouldUpload covers the decision that #449 got wrong: a version marker
 // matching the code is not proof the device still has the script.
@@ -69,4 +82,373 @@ func TestShouldUpload(t *testing.T) {
 			}
 		})
 	}
+}
+
+// errTransport simulates a non-timeout transport error (e.g. connection
+// reset) returned by a follow-up RPC, distinct from context.DeadlineExceeded.
+var errTransport = errors.New("connection reset by peer")
+
+// TestClassifyUpload covers issue #428: a timeout or transport error on the
+// post-upload confirmation step (enabling/starting the script) must not be
+// reported as an upload failure once the chunked code transfer itself
+// succeeded. This is the pure decision function extracted so it is directly
+// testable without a device or a live MQTT broker.
+func TestClassifyUpload(t *testing.T) {
+	tests := []struct {
+		name       string
+		chunkErr   error
+		confirmErr error
+		wantStatus UploadStatus
+	}{
+		{
+			name:       "upload fails outright",
+			chunkErr:   errors.New("PutCode chunk 2/5: no response"),
+			confirmErr: nil, // never attempted; chunk transfer itself failed
+			wantStatus: StatusFailed,
+		},
+		{
+			name:       "upload succeeds and verification succeeds",
+			chunkErr:   nil,
+			confirmErr: nil,
+			wantStatus: StatusUploaded,
+		},
+		{
+			name:       "upload succeeds and verification times out",
+			chunkErr:   nil,
+			confirmErr: context.DeadlineExceeded,
+			wantStatus: StatusIndeterminate,
+		},
+		{
+			name:       "verification returns a transport error that is not a timeout",
+			chunkErr:   nil,
+			confirmErr: errTransport,
+			wantStatus: StatusIndeterminate,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			status, message := classifyUpload(tc.chunkErr, tc.confirmErr)
+			if status != tc.wantStatus {
+				t.Errorf("classifyUpload(chunkErr=%v, confirmErr=%v) = %v (%q), want %v",
+					tc.chunkErr, tc.confirmErr, status, message, tc.wantStatus)
+			}
+			if message == "" {
+				t.Error("expected a non-empty message for the operator")
+			}
+			// A genuine failure must never carry a "confirm your status,
+			// don't re-upload" message, and vice versa — the message and
+			// the exit-code-driving status must agree.
+			if status == StatusFailed && tc.chunkErr == nil {
+				t.Error("StatusFailed returned without a chunk error")
+			}
+			if status == StatusIndeterminate && tc.chunkErr != nil {
+				t.Error("StatusIndeterminate returned despite a chunk error")
+			}
+		})
+	}
+}
+
+// TestRetryBounded proves the retry helper used to confirm a script's start
+// is genuinely bounded (issue #428's "consider a bounded retry" direction)
+// and that it stops retrying at the first success.
+func TestRetryBounded(t *testing.T) {
+	t.Run("succeeds on first attempt: no wait, no retry", func(t *testing.T) {
+		calls := 0
+		err := retryBounded(context.Background(), 3, time.Hour, func(attempt int) error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected exactly 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("succeeds on a later attempt within the bound", func(t *testing.T) {
+		calls := 0
+		err := retryBounded(context.Background(), 3, time.Millisecond, func(attempt int) error {
+			calls++
+			if attempt < 3 {
+				return errTransport
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error after eventual success, got %v", err)
+		}
+		if calls != 3 {
+			t.Errorf("expected exactly 3 calls, got %d", calls)
+		}
+	})
+
+	t.Run("gives up after exhausting attempts and returns the last error", func(t *testing.T) {
+		calls := 0
+		wantErr := errors.New("attempt failure")
+		err := retryBounded(context.Background(), 3, time.Millisecond, func(attempt int) error {
+			calls++
+			return wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected %v, got %v", wantErr, err)
+		}
+		if calls != 3 {
+			t.Errorf("expected exactly 3 calls (bounded), got %d", calls)
+		}
+	})
+
+	t.Run("stops early on context cancellation between attempts", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		calls := 0
+		err := retryBounded(ctx, 5, 50*time.Millisecond, func(attempt int) error {
+			calls++
+			if attempt == 1 {
+				cancel()
+			}
+			return errTransport
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected exactly 1 call before cancellation was observed, got %d", calls)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// fakeUploadDevice — a minimal types.Device double that exercises
+// UploadWithVersionDetailed end-to-end (chunked upload, KVS version
+// tracking, and the post-upload Script.Start confirmation) without a real
+// device or MQTT broker. Modeled on pkg/shelly/script's fakeDevice.
+// ---------------------------------------------------------------------------
+
+type fakeUploadDevice struct {
+	id      string
+	scripts map[uint32]string // id -> name: scripts the device currently has
+	nextID  uint32
+	kv      map[string]string
+
+	// startErr, if set, is consulted on every Script.Start attempt (1-based);
+	// a non-nil return simulates the confirmation step failing (timeout,
+	// transport error, ...).
+	startErr   func(attempt int) error
+	startCalls int
+}
+
+var _ types.Device = (*fakeUploadDevice)(nil)
+
+func newFakeUploadDevice(id string) *fakeUploadDevice {
+	return &fakeUploadDevice{id: id, scripts: map[uint32]string{}, kv: map[string]string{}}
+}
+
+func (f *fakeUploadDevice) CallE(_ context.Context, _ types.Channel, method string, params any) (any, error) {
+	switch method {
+	case "Script.List":
+		list := make([]pkgscript.Status, 0, len(f.scripts))
+		for id, name := range f.scripts {
+			list = append(list, pkgscript.Status{Id: id, Name: name})
+		}
+		return &pkgscript.ListResponse{Scripts: list}, nil
+
+	case "Script.Create":
+		req := params.(*pkgscript.Configuration)
+		f.nextID++
+		f.scripts[f.nextID] = req.Name
+		return &pkgscript.Status{Id: f.nextID, Name: req.Name}, nil
+
+	case "Script.Stop":
+		return &pkgscript.Status{}, nil
+
+	case "Script.PutCode":
+		return &pkgscript.PutCodeResponse{}, nil
+
+	case "Script.SetConfig":
+		return &pkgscript.Status{}, nil
+
+	case "Script.Start":
+		f.startCalls++
+		if f.startErr != nil {
+			if err := f.startErr(f.startCalls); err != nil {
+				return nil, err
+			}
+		}
+		return &pkgscript.Status{}, nil
+
+	case "KVS.Get":
+		req := params.(*kvs.GetRequest)
+		v, ok := f.kv[req.Key]
+		if !ok {
+			return nil, fmt.Errorf("fakeUploadDevice: key %q not found", req.Key)
+		}
+		return &kvs.GetResponse{Value: v}, nil
+
+	case "KVS.Set":
+		req := params.(*kvs.KeyValue)
+		f.kv[req.Key] = req.Value
+		return &kvs.Status{}, nil
+
+	default:
+		return nil, fmt.Errorf("fakeUploadDevice: unexpected method %q", method)
+	}
+}
+
+func (f *fakeUploadDevice) String() string                                             { return "fake-upload-device" }
+func (f *fakeUploadDevice) Name() string                                               { return "fake-upload-device" }
+func (f *fakeUploadDevice) Host() string                                               { return "fake" }
+func (f *fakeUploadDevice) Manufacturer() string                                       { return "fake" }
+func (f *fakeUploadDevice) Id() string                                                 { return f.id }
+func (f *fakeUploadDevice) Mac() net.HardwareAddr                                      { return nil }
+func (f *fakeUploadDevice) ReplyTo() string                                            { return "" }
+func (f *fakeUploadDevice) To() chan<- []byte                                          { return nil }
+func (f *fakeUploadDevice) From() <-chan []byte                                        { return nil }
+func (f *fakeUploadDevice) StartDialog(_ context.Context) uint32                       { return 0 }
+func (f *fakeUploadDevice) StopDialog(_ context.Context, _ uint32)                     {}
+func (f *fakeUploadDevice) IsHttpReady() bool                                          { return false }
+func (f *fakeUploadDevice) IsMqttReady() bool                                          { return true }
+func (f *fakeUploadDevice) Channel(_ context.Context, via types.Channel) types.Channel { return via }
+func (f *fakeUploadDevice) UpdateName(_ string)                                        {}
+func (f *fakeUploadDevice) UpdateHost(_ string)                                        {}
+func (f *fakeUploadDevice) ClearHost()                                                 {}
+func (f *fakeUploadDevice) UpdateMac(_ string)                                         {}
+func (f *fakeUploadDevice) UpdateId(_ string)                                          {}
+func (f *fakeUploadDevice) IsModified() bool                                           { return false }
+func (f *fakeUploadDevice) ResetModified()                                             {}
+
+// withFastRetry shrinks startAttempts/startRetryDelay for the duration of a
+// test, restoring the production values in t.Cleanup (the package-level
+// vars are shared, untested code must never observe the shrunk values).
+func withFastRetry(t *testing.T, attempts int) {
+	t.Helper()
+	origAttempts, origDelay := startAttempts, startRetryDelay
+	startAttempts = attempts
+	startRetryDelay = time.Millisecond
+	t.Cleanup(func() {
+		startAttempts = origAttempts
+		startRetryDelay = origDelay
+	})
+}
+
+// TestUploadWithVersionDetailed_StartTimeoutIsIndeterminate is the
+// regression test for issue #428: every PutCode chunk was acknowledged
+// (confirmed by the fake device's Script.List reflecting the new script
+// afterwards) but Script.Start never confirms. Before the fix, this made
+// UploadWithVersion return a non-nil error and the CLI report "upload
+// failed" even though the code was on the device the whole time.
+func TestUploadWithVersionDetailed_StartTimeoutIsIndeterminate(t *testing.T) {
+	withFastRetry(t, 3)
+	log := testr.New(t)
+	dev := newFakeUploadDevice("device-428-timeout")
+	dev.startErr = func(attempt int) error { return context.DeadlineExceeded }
+
+	id, status, err := UploadWithVersionDetailed(context.Background(), log, types.ChannelDefault, dev, "pool-pump.js", []byte("// v1\n"), false, false)
+	if err != nil {
+		t.Fatalf("UploadWithVersionDetailed returned an error for a confirmed upload with only a Start timeout: %v", err)
+	}
+	if status != StatusIndeterminate {
+		t.Errorf("status = %v, want %v", status, StatusIndeterminate)
+	}
+	if id == 0 {
+		t.Error("expected a non-zero script id: the code transfer succeeded")
+	}
+	if dev.startCalls != 3 {
+		t.Errorf("expected the bounded retry to make exactly 3 Script.Start attempts, got %d", dev.startCalls)
+	}
+
+	// The literal bug report: UploadWithVersion (the two-value contract most
+	// callers use) must not turn this into an error either.
+	dev2 := newFakeUploadDevice("device-428-timeout-2")
+	dev2.startErr = func(attempt int) error { return context.DeadlineExceeded }
+	if _, err := UploadWithVersion(context.Background(), log, types.ChannelDefault, dev2, "pool-pump.js", []byte("// v1\n"), false, false); err != nil {
+		t.Fatalf("UploadWithVersion reported failure for a script that was actually uploaded: %v (this is exactly issue #428)", err)
+	}
+}
+
+// TestUploadWithVersionDetailed_StartSucceedsAfterRetry proves the bounded
+// retry itself does useful work: a Start that only confirms on the 2nd
+// attempt is reported as a fully confirmed upload, not indeterminate.
+func TestUploadWithVersionDetailed_StartSucceedsAfterRetry(t *testing.T) {
+	withFastRetry(t, 3)
+	log := testr.New(t)
+	dev := newFakeUploadDevice("device-428-retry-recovers")
+	dev.startErr = func(attempt int) error {
+		if attempt < 2 {
+			return context.DeadlineExceeded
+		}
+		return nil
+	}
+
+	id, status, err := UploadWithVersionDetailed(context.Background(), log, types.ChannelDefault, dev, "pool-pump.js", []byte("// v1\n"), false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != StatusUploaded {
+		t.Errorf("status = %v, want %v (retry should have recovered)", status, StatusUploaded)
+	}
+	if id == 0 {
+		t.Error("expected a non-zero script id")
+	}
+}
+
+// TestUploadWithVersionDetailed_AllConfirmed is the control case: nothing
+// times out, everything is confirmed.
+func TestUploadWithVersionDetailed_AllConfirmed(t *testing.T) {
+	log := testr.New(t)
+	dev := newFakeUploadDevice("device-428-happy-path")
+
+	id, status, err := UploadWithVersionDetailed(context.Background(), log, types.ChannelDefault, dev, "pool-pump.js", []byte("// v1\n"), false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != StatusUploaded {
+		t.Errorf("status = %v, want %v", status, StatusUploaded)
+	}
+	if id == 0 {
+		t.Error("expected a non-zero script id")
+	}
+	if dev.startCalls != 1 {
+		t.Errorf("expected exactly 1 Script.Start call when it succeeds immediately, got %d", dev.startCalls)
+	}
+}
+
+// TestUploadWithVersionDetailed_ChunkFailureIsGenuineFailure proves the
+// other half of the classification: when the code transfer itself does not
+// complete, this remains a real failure (non-nil error, StatusFailed) —
+// the fix must not swallow genuine failures.
+func TestUploadWithVersionDetailed_ChunkFailureIsGenuineFailure(t *testing.T) {
+	log := testr.New(t)
+	dev := newFakeUploadDevice("device-428-chunk-fails")
+	// Fail at the RPC dispatch layer itself: PutCode always errors, so no
+	// chunk is ever acknowledged.
+	dev.scripts = map[uint32]string{} // starts empty, forcing Script.Create
+
+	failing := &failingCallDevice{fakeUploadDevice: dev, failMethod: "Script.PutCode"}
+
+	id, status, err := UploadWithVersionDetailed(context.Background(), log, types.ChannelDefault, failing, "pool-pump.js", []byte("// v1\n"), false, false)
+	if err == nil {
+		t.Fatal("expected an error: the chunk transfer never completed")
+	}
+	if status != StatusFailed {
+		t.Errorf("status = %v, want %v", status, StatusFailed)
+	}
+	if id != 0 {
+		t.Errorf("id = %d, want 0 for a genuine failure", id)
+	}
+}
+
+// failingCallDevice wraps fakeUploadDevice and forces one RPC method to
+// always fail, regardless of the fake's own state — used to simulate a
+// chunk transfer that never completes.
+type failingCallDevice struct {
+	*fakeUploadDevice
+	failMethod string
+}
+
+func (f *failingCallDevice) CallE(ctx context.Context, via types.Channel, method string, params any) (any, error) {
+	if method == f.failMethod {
+		return nil, errTransport
+	}
+	return f.fakeUploadDevice.CallE(ctx, via, method, params)
 }

--- a/myhome/ctl/shelly/script/start-stop-delete.go
+++ b/myhome/ctl/shelly/script/start-stop-delete.go
@@ -69,11 +69,28 @@ func doUpload(ctx context.Context, log logr.Logger, via types.Channel, device de
 	}
 	fmt.Printf("  . Source: %s\n", source)
 
-	// Upload with version tracking
-	id, err := mhscript.UploadWithVersion(ctx, log, via, sd, scriptName, buf, !noMinify, forceUpload)
+	// Upload with version tracking. Use the *Detailed variant so a
+	// post-upload confirmation gap (code delivered, but enabling/starting
+	// it did not confirm — commonly a device still busy right after the
+	// upload) can be reported for what it is instead of as an upload
+	// failure. See issue #428.
+	id, status, err := mhscript.UploadWithVersionDetailed(ctx, log, via, sd, scriptName, buf, !noMinify, forceUpload)
 	if err != nil {
+		// The code transfer itself did not complete: this is a genuine
+		// failure, and the only case that should make the command exit
+		// non-zero.
 		fmt.Printf("✗ Failed to upload %s to %s: %v\n", scriptName, sd.Name(), err)
 		return nil, err
+	}
+	if status == mhscript.StatusIndeterminate {
+		// The code is confirmed on the device (every chunk was
+		// acknowledged), but a follow-up confirmation step did not
+		// respond in time even after retrying. This is not a failure —
+		// re-uploading would be wasted work — so the command exits 0.
+		// The operator's correct next step is to re-check status, not
+		// re-upload.
+		fmt.Printf("⚠ Uploaded %s to %s (id: %d), but could not confirm it started/enabled — the device may still be busy. Re-run `script status` rather than re-uploading.\n", scriptName, sd.Name(), id)
+		return id, nil
 	}
 	fmt.Printf("✓ Successfully uploaded %s to %s (id: %d)\n", scriptName, sd.Name(), id)
 	return id, nil

--- a/myhome/ctl/shelly/script/update.go
+++ b/myhome/ctl/shelly/script/update.go
@@ -102,14 +102,32 @@ func doUpdate(ctx context.Context, log logr.Logger, via types.Channel, device de
 		}
 		fmt.Printf("    . Source: %s\n", source)
 
-		id, err := mhscript.UploadWithVersion(ctx, log, via, sd, scriptName, buf, !updateNoMinify, updateForce)
+		id, status, err := mhscript.UploadWithVersionDetailed(ctx, log, via, sd, scriptName, buf, !updateNoMinify, updateForce)
 		if err != nil {
+			// The code transfer itself did not complete: a genuine
+			// failure. See issue #428.
 			fmt.Printf("  ✗ Failed to update %s: %v\n", scriptName, err)
 			updateResults = append(updateResults, UpdateResult{
 				ScriptName: scriptName,
 				ScriptId:   loadedScript.Id,
 				Status:     "error",
 				Message:    fmt.Sprintf("Update failed: %v", err),
+			})
+			continue
+		}
+
+		if status == mhscript.StatusIndeterminate {
+			// Code confirmed on the device; a follow-up confirmation step
+			// (enable/start) did not respond even after retrying. Not a
+			// failure — re-uploading would be wasted work — so this does
+			// not count against the device's overall result.
+			fmt.Printf("  ⚠ %s uploaded (id: %d) but could not confirm it started/enabled — re-run `script status` rather than re-uploading\n", scriptName, id)
+			updateResults = append(updateResults, UpdateResult{
+				ScriptName: scriptName,
+				ScriptId:   loadedScript.Id,
+				NewId:      id,
+				Status:     "indeterminate",
+				Message:    "Code uploaded and confirmed; could not confirm start/enable",
 			})
 			continue
 		}

--- a/pkg/shelly/script/main.go
+++ b/pkg/shelly/script/main.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/fs"
 	"github.com/asnowfix/home-automation/pkg/shelly/types"
+	"io/fs"
 	"reflect"
 	"strconv"
 
@@ -321,7 +321,28 @@ func Download(ctx context.Context, via types.Channel, device types.Device, name 
 	return res.Data, nil
 }
 
-// For MyHome-specific version tracking, use internal/myhome/shelly/script.UploadWithVersionAndStart instead
+// PostUploadConfigError reports that the chunked code transfer completed —
+// every PutCode chunk was sent and acknowledged, so the script's code is on
+// the device — but the follow-up Script.SetConfig call (which enables the
+// script for autostart) did not get a confirmed response. This is a
+// confirmation gap, not an upload failure: see issue #428, where a device
+// that goes briefly unresponsive right after the last chunk turned a
+// successful upload into a reported failure.
+//
+// Id is still populated so a caller can act on the script it just uploaded
+// (e.g. retry just the confirmation) instead of treating the id as unknown.
+type PostUploadConfigError struct {
+	Id  uint32
+	Err error
+}
+
+func (e *PostUploadConfigError) Error() string {
+	return fmt.Sprintf("script code uploaded (id %d) but enabling it did not confirm: %v", e.Id, e.Err)
+}
+
+func (e *PostUploadConfigError) Unwrap() error { return e.Err }
+
+// For MyHome-specific version tracking, use internal/myhome/shelly/script.UploadWithVersion instead
 func Upload(ctx context.Context, via types.Channel, device types.Device, name string, code []byte, minify bool) (uint32, error) {
 	var err error
 
@@ -335,7 +356,11 @@ func Upload(ctx context.Context, via types.Channel, device types.Device, name st
 
 	id, err := doUpload(ctx, via, device, name, code, minify)
 	if err != nil {
-		return 0, err
+		// Preserve id: a *PostUploadConfigError carries the id of a script
+		// whose code is confirmed on the device, so callers that check for it
+		// (see internal/myhome/shelly/script.UploadWithVersionDetailed) need
+		// it rather than a bare 0.
+		return id, err
 	}
 	return id, nil
 }
@@ -416,8 +441,11 @@ func doUpload(ctx context.Context, via types.Channel, device types.Device, name 
 		},
 	})
 	if err != nil {
-		log.Error(err, "Unable to configure script", "id", id, "name", name, "device", device.Name())
-		return 0, err
+		// Every chunk above was acknowledged, so the code is on the device;
+		// only this housekeeping call did not confirm. Report it as such
+		// (see PostUploadConfigError) instead of as an upload failure.
+		log.Error(err, "Script code uploaded but enabling it did not confirm", "id", id, "name", name, "device", device.Name())
+		return id, &PostUploadConfigError{Id: id, Err: err}
 	}
 	log.Info("Configured script", "name", name, "id", id, "out", out)
 


### PR DESCRIPTION
## Problem

`script upload` reported a **successful** upload as a failure whenever the post-upload confirmation RPC timed out. Over MQTT the device is often still busy for a few seconds right after `PutCode`/`SetConfig` — persisting the script, running its init — and simply does not answer. The operator then re-uploads unnecessarily, or believes the device is in a bad state when it is not.

The root of it: `Upload()` collapsed any post-chunk error to `(0, err)`, discarding the script id and making a confirmation gap indistinguishable from a genuine chunk-transfer failure.

## Change

**Three outcomes instead of two**, decided by a pure function (same pattern as the existing `shouldUpload`):

```go
func classifyUpload(chunkErr, confirmErr error) (UploadStatus, string)
```

| chunkErr | confirmErr | status |
|---|---|---|
| set | — | `StatusFailed` |
| nil | set | `StatusIndeterminate` |
| nil | nil | `StatusUploaded` |

Deliberately it does **not** inspect what kind of error `confirmErr` is. Once the chunk transfer is confirmed, any confirmation-step error is a confirmation gap, not evidence of failure — a timeout and a transport error are equally uninformative about whether the code landed.

Supporting changes:
- `pkg/shelly/script/main.go`: new `PostUploadConfigError{Id, Err}` preserves the script id through a post-chunk `Script.SetConfig` failure.
- Bounded, cancellable retry of `Script.Start` (3 attempts, 2 s apart) before settling on indeterminate — this turns most transient busy-device cases into confirmed successes.
- `UploadWithVersion` keeps its 2-value signature (~9 call sites in pool/heater/garden automation, none needed changes) and treats indeterminate as success. New `UploadWithVersionDetailed` returns `(id, UploadStatus, error)` for the `upload` and `update` CLI commands.

**Exit code**: only `StatusFailed` exits non-zero; `StatusIndeterminate` exits **0**. An operator scripting around this must never treat "unconfirmed" as "needs retry" — re-uploading is exactly the wasteful behaviour this bug caused. The distinction stays visible in the printed message and in `update`'s per-script `"indeterminate"` JSON status:

```
⚠ Uploaded ... but could not confirm it started/enabled ...
  Re-run 'script status' rather than re-uploading.
```

## Tests

`TestClassifyUpload` (all four cases), `TestRetryBounded`, and `TestUploadWithVersionDetailed_*` against a fake `types.Device` — including the literal regression (`Script.Start` always times out) through both the detailed and wrapper paths, plus a control that genuine chunk failures still fail.

Verified they do not compile against the pre-fix `ops.go` (fix stashed, rerun, `undefined: UploadStatus`).

```
go test -count=1 -run 'TestClassifyUpload|TestRetryBounded|TestUploadWithVersionDetailed|TestLoadScript_RejectsAbsolutePath' ./internal/myhome/shelly/script/...
ok  github.com/asnowfix/home-automation/internal/myhome/shelly/script  0.579s
```

Full `make test`: 47 ok, 0 FAIL, ~7m13s (slower than the 5m47s baseline — concurrent agent test runs on the same machine).

## Incidental: the absolute-path gotcha is already fixed

`CLAUDE.md` currently warns that `script upload` rejects an absolute path with a misleading `file does not exist`. That was observed with a **v0.12.0 binary predating #464**. On `main`, `doUpload` resolves through `LoadScript`, whose `validateFlatScriptName` rejects any non-basename with a clear `script name must be a flat file name, not a path` **before** touching the filesystem. `TestLoadScript_RejectsAbsolutePath` pins that. The `CLAUDE.md` wording should be corrected separately.

Closes #428.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(script upload): don't report a confirmed upload as a failure (#428) ([502bc3f](https://github.com/asnowfix/home-automation/commit/502bc3fb8a24a64ed19d5a1c46574b2c7c31d8b9))
<!-- END-AUTO-GENERATED-COMMITS -->