### PR TITLE
fix(pool-pump): stop losing the day's runtime on every script restart (#469)

### DIFF
--- a/docs/pool-pump.md
+++ b/docs/pool-pump.md
@@ -330,6 +330,7 @@ All keys use prefix `script/pool-pump/` (≤ 32 chars total).
 | `active-output` | `-1` or switch ID currently active |
 | `schedule-mode` | `"summer"` or `"winter"` |
 | `runtime-sec` | Cumulative pump-on seconds today (see #402) |
+| `runtime-ts` | Epoch second `runtime-sec` applies to; KVS recovery path if `Script.storage` is lost, e.g. a script reinstall (see #469) |
 | `turnover-today` | Pool-volume turnovers achieved today (see #402) |
 
 ### Script.storage (script-private)
@@ -337,7 +338,7 @@ All keys use prefix `script/pool-pump/` (≤ 32 chars total).
 |-----|-------|
 | `forecast-url` | Open-Meteo URL built from GPS coordinates |
 | `my-device-id` | Cached device ID from `Shelly.getDeviceInfo().id` |
-| `runtime-date` / `runtime-sec` | Boot-safe mirror of today's runtime counter (see #402) |
+| `runtime` | Boot-safe mirror of today's runtime counter, as one JSON object `{sec, ts}` (see #402, #469). The day is derived from `ts` (epoch seconds), never from a stored date string — a pre-#469 device may still have the legacy `runtime-sec` / `runtime-date` scalar pair, migrated to `runtime` once on first boot after upgrade. |
 
 ---
 

--- a/internal/myhome/shelly/script/pool.go
+++ b/internal/myhome/shelly/script/pool.go
@@ -408,6 +408,7 @@ var knownPoolPumpStateKeys = []string{
 	"script/pool-pump/active-output",
 	"script/pool-pump/schedule-mode",
 	"script/pool-pump/runtime-sec",    // runtime_today_sec: cumulative pump-on seconds today (#402)
+	"script/pool-pump/runtime-ts",     // epoch second STATE.runtimeTodaySec applies to; KVS recovery path (#469)
 	"script/pool-pump/turnover-today", // turnover_today: today's achieved water-volume turnovers (#402)
 }
 

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -366,16 +366,25 @@ var STORAGE_KEYS = {
                                     // Script.storage.getItem() is synchronous; KVS.Get is
                                     // async-only, so Shelly.call without a callback always
                                     // returns null and schedule mode was lost on every reboot
-  runtimeSec:    "runtime-sec",     // cumulative pump-on seconds today (checkpointed while
-                                    // running, see flushRuntimeCheckpoint), synchronous so a
-                                    // reboot mid-run only loses runtime since the last flush
-  runtimeDate:   "runtime-date"     // "YYYY-M-D" date the above count applies to, for
-                                    // day-rollover detection (see ensureRuntimeDay)
+  runtime:       "runtime",         // #469: single JSON object {sec, ts} — cumulative pump-on
+                                    // seconds today plus the epoch second of the last update.
+                                    // Replaces the old loose-scalar pair below: a serialised
+                                    // object cannot be silently misparsed as a number, and the
+                                    // day a count belongs to is derived from ts, never stored
+                                    // or parsed as a date string.
+  runtimeSecLegacy:  "runtime-sec",  // pre-#469 format, read once for migration then unused
+  runtimeDateLegacy: "runtime-date"  // pre-#469 format, read once for migration then unused
 };
 
-// State keys for KVS persistence (fire-and-forget writes only; reads use Script.storage)
+// State keys for KVS persistence (fire-and-forget writes only; reads use Script.storage,
+// except runtimeSec/runtimeTs below, which loadRuntimeState() reads back asynchronously
+// as a recovery path when Script.storage itself yields nothing valid — see #469)
 var STATE_KEYS = {
-  activeOutput: "active-output"     // -1 (all off), 0, 1, 2 for pro3; 0 for pro1
+  activeOutput: "active-output",    // -1 (all off), 0, 1, 2 for pro3; 0 for pro1
+  runtimeSec:   "runtime-sec",      // mirrors STATE.runtimeTodaySec, rounded (also read by
+                                    // the Go daemon, see myhome/daemon/pool_notices.go)
+  runtimeTs:    "runtime-ts"        // epoch second STATE.runtimeTodaySec applies to; KVS
+                                    // survives script reinstalls and can be hand-repaired
 };
 
 // === IN-FLIGHT RPC TRACKING (#421 Bug A) ===
@@ -672,7 +681,9 @@ var STATE = {
 
   // Runtime/turnover tracking (on-device, for ctl pool status — see #402)
   runtimeTodaySec: 0,         // cumulative pump-on seconds today (completed intervals only)
-  runtimeDate: null,          // "YYYY-M-D" date runtimeTodaySec applies to
+  runtimeTs: null,            // epoch second (Date.now()/1000) runtimeTodaySec applies to —
+                              // #469: the calendar day is derived from this, never from a
+                              // stored date string (see reconcileRuntimeState)
   runStartTs: null,           // Date.now() when the current ON interval began; null when off
   runtimeFlushTimer: null,    // Timer handle for periodic checkpointing while running
 
@@ -701,7 +712,14 @@ function log() {
   print(SCRIPT_PREFIX, s);
 }
 
-// === SCRIPT.STORAGE HELPERS (for forecast URL) ===
+// === SCRIPT.STORAGE HELPERS ===
+// #469: loadStorageValue() used to guess a value's type (Number, then
+// JSON.parse, then raw string) and callers silently accepted whatever came
+// back. A restore that landed on the wrong type (e.g. a date string
+// misparsed as a number) became null/0 with no warning, and the daily pump
+// runtime accounting reset itself on every ordinary script restart. Callers
+// now say what type they expect via loadStorageNumber/String/Object, and
+// every fallback to a default is logged.
 function storeStorageValue(key, value) {
   var valueStr;
   if (typeof value === "undefined" || value === null) {
@@ -716,24 +734,46 @@ function storeStorageValue(key, value) {
   Script.storage.setItem(key, valueStr);
 }
 
-function loadStorageValue(key) {
+// Returns a number, or null (with a warning) if the key is absent or does
+// not hold a valid number.
+function loadStorageNumber(key) {
   var v = Script.storage.getItem(key);
-  if (v === null || v === undefined) return null;
-  if (v === "null" || v === "undefined") return null;
-  if (v === "true") return true;
-  if (v === "false") return false;
-  try {
-    var num = Number(v);
-    if (!isNaN(num)) return num;
-  } catch (e) {
-    // Espruino throws "String too big to convert to float" on long strings
-    if (e && false) {}
+  if (v === null || v === undefined || v === "null") return null;
+  var num = Number(v);
+  if (isNaN(num)) {
+    log("WARNING: Script.storage[" + key + "] expected a number, got:", v);
+    return null;
   }
+  return num;
+}
+
+// Returns the raw string, or null (with a warning) if the key is absent.
+// Script.storage follows Web Storage semantics — getItem() always returns
+// either a string or null, so no type-guessing is needed or attempted here.
+function loadStorageString(key) {
+  var v = Script.storage.getItem(key);
+  if (v === null || v === undefined || v === "null") return null;
+  if (typeof v !== "string") {
+    log("WARNING: Script.storage[" + key + "] expected a string, got:", v);
+    return null;
+  }
+  return v;
+}
+
+// Returns a parsed JSON object, or null (with a warning) if the key is
+// absent, not valid JSON, or parses to a non-object (e.g. a bare number).
+function loadStorageObject(key) {
+  var v = Script.storage.getItem(key);
+  if (v === null || v === undefined || v === "null") return null;
   try {
-    return JSON.parse(v);
+    var obj = JSON.parse(v);
+    if (obj !== null && typeof obj === "object") return obj;
+    log("WARNING: Script.storage[" + key + "] expected an object, got:", v);
+    return null;
   } catch (e) {
+    log("WARNING: Script.storage[" + key + "] failed to parse as JSON:", v);
     if (e && false) {}
-    return v;
+    return null;
   }
 }
 
@@ -753,23 +793,29 @@ function storeValue(key, value) {
   Shelly.call("KVS.Set", {key: CONFIG_KEY_PREFIX + key, value: valueStr});
 }
 
-function loadValue(key) {
-  var result = Shelly.call("KVS.Get", {key: CONFIG_KEY_PREFIX + key});
-  if (result && ("value" in result)) {
-    var v = result.value;
-    if (v === "null" || v === "undefined") return null;
-    if (v === "true") return true;
-    if (v === "false") return false;
-    var num = Number(v);
-    if (!isNaN(num)) return num;
-    try {
-      return JSON.parse(v);
-    } catch (e) {
-      if (e && false) {}
-      return v;
+// Async KVS read (KVS.Get has no synchronous form — Shelly.call without a
+// callback returns null on real firmware, see STORAGE_KEYS.scheduleMode
+// comment below). cb receives (value) — a number if the stored string
+// parses as one, else the raw string, or null if the key is missing/errored.
+function loadValueAsync(key, cb) {
+  Shelly.call("KVS.Get", {key: CONFIG_KEY_PREFIX + key}, function (result, error_code, error_message) {
+    if (error_code !== 0 || !result || !("value" in result)) {
+      if (error_message && false) {}
+      cb(null);
+      return;
     }
-  }
-  return null;
+    var v = result.value;
+    if (v === "null" || v === "undefined") {
+      cb(null);
+      return;
+    }
+    var num = Number(v);
+    if (!isNaN(num)) {
+      cb(num);
+      return;
+    }
+    cb(v);
+  });
 }
 
 // Fractional-day-free "YYYY-M-D" date string, used for day-rollover checks
@@ -777,6 +823,15 @@ function loadValue(key) {
 function todayDateString() {
   var now = new Date();
   return now.getFullYear() + '-' + (now.getMonth() + 1) + '-' + now.getDate();
+}
+
+// Comparable local-calendar-day number (e.g. 20260811) for a given epoch
+// second. Used instead of a formatted/parsed date string (#469) so day
+// comparisons never depend on round-tripping a string through
+// Script.storage — only the number ts itself is persisted.
+function localDayNumber(epochSec) {
+  var d = new Date(epochSec * 1000);
+  return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
 }
 
 // === WEATHER FORECAST FUNCTIONS (Memory-Optimized) ===
@@ -865,7 +920,7 @@ function onForecast(result, error_code, error_message, cb) {
 }
 
 function fetchAndCacheForecast(cb) {
-  var url = STATE.forecastUrl || loadStorageValue(STORAGE_KEYS.forecastUrl);
+  var url = STATE.forecastUrl || loadStorageString(STORAGE_KEYS.forecastUrl);
   if (!url) {
     log('Forecast URL not configured. Skipping.');
     if (typeof cb === 'function') queueTask(function() { cb(); });
@@ -905,7 +960,7 @@ function ensureForecastUrl(cb) {
     return;
   }
 
-  var storedUrl = loadStorageValue(STORAGE_KEYS.forecastUrl);
+  var storedUrl = loadStorageString(STORAGE_KEYS.forecastUrl);
   if (storedUrl && storedUrl.indexOf('daily=') !== -1) {
     STATE.forecastUrl = storedUrl;
     log('Loaded forecast URL from storage');
@@ -1022,34 +1077,61 @@ function applyComponentNames(callback) {
 }
 
 // === STATE PERSISTENCE ===
-function loadState() {
+// loadState(onDone) restores STATE from persisted storage and calls onDone()
+// when finished. It is synchronous in the common case (Script.storage has a
+// valid {sec, ts} object) and calls onDone() immediately, before returning.
+// It only goes truly asynchronous when Script.storage yields nothing usable
+// at all, in which case it falls back to an async KVS read before calling
+// onDone() (#469) — see loadRuntimeStateFromStorage/FromKVS below.
+function loadState(onDone) {
   log("Loading persisted state...");
 
-  // runtimeDate/runtimeTodaySec: Script.storage (synchronous), restored
-  // before enforceOutputState() decides whether to resume runtime accounting
-  // for a run already in progress. ensureRuntimeDay() resets the counter if
-  // the restored date is stale (previous day).
-  var savedRuntimeDate = loadStorageValue(STORAGE_KEYS.runtimeDate);
-  var savedRuntimeSec = loadStorageValue(STORAGE_KEYS.runtimeSec);
-  STATE.runtimeDate = (typeof savedRuntimeDate === "string") ? savedRuntimeDate : null;
-  STATE.runtimeTodaySec = (typeof savedRuntimeSec === "number") ? savedRuntimeSec : 0;
-  ensureRuntimeDay();
-  log("Restored runtime today:", STATE.runtimeTodaySec, "s for date:", STATE.runtimeDate);
+  // runtimeTodaySec/runtimeTs: restored before enforceOutputState() decides
+  // whether to resume runtime accounting for a run already in progress.
+  var fromStorage = loadRuntimeStateFromStorage();
+  if (fromStorage !== null) {
+    applyRuntimeState(reconcileRuntimeState(fromStorage.sec, fromStorage.ts, "Script.storage"));
+    finishLoadState(onDone);
+    return;
+  }
 
+  log("WARNING: Script.storage has no valid runtime state, falling back to KVS (#469)");
+  loadRuntimeStateFromKVS(function (kvsSec, kvsTs) {
+    applyRuntimeState(reconcileRuntimeState(kvsSec, kvsTs, "KVS"));
+    finishLoadState(onDone);
+  });
+}
+
+// Commits a reconciled {sec, ts} result to STATE and re-persists it in the
+// current (Script.storage) format immediately — this stabilizes a migrated
+// legacy value or a KVS-recovered value on disk without waiting for the next
+// checkpoint.
+function applyRuntimeState(state) {
+  STATE.runtimeTodaySec = state.sec;
+  STATE.runtimeTs = state.ts;
+  persistRuntimeState(STATE.runtimeTodaySec);
+  log("Restored runtime today:", STATE.runtimeTodaySec, "s, ts:", STATE.runtimeTs);
+}
+
+// Remainder of loadState() that does not depend on the runtime-restore path
+// taken above (sync vs. async KVS fallback).
+function finishLoadState(onDone) {
   // activeOutput: KVS fire-and-forget write; read is skipped here because
   // enforceOutputState() reads the actual hardware switch state right after
   // this call — hardware truth overrides any stale KVS value.
 
   // scheduleMode: use Script.storage (synchronous getItem/setItem) so that
   // the correct mode survives a reboot without needing an async callback chain.
-  var savedMode = loadStorageValue(STORAGE_KEYS.scheduleMode);
-  if (savedMode !== null && (savedMode === "summer" || savedMode === "winter")) {
+  var savedMode = loadStorageString(STORAGE_KEYS.scheduleMode);
+  if (savedMode === "summer" || savedMode === "winter") {
     STATE.scheduleMode = savedMode;
     log("Restored schedule mode:", STATE.scheduleMode);
   } else {
     STATE.scheduleMode = "winter";
     log("No saved schedule mode, defaulting to winter");
   }
+
+  if (typeof onDone === "function") onDone();
 }
 
 function saveState() {
@@ -1084,21 +1166,118 @@ function saveState() {
 // handleWaterSupply, the button handler, the anti-cycling fuse) is covered
 // with zero duplication.
 
-// Resets the daily counter when the persisted date has rolled over. If a run
-// is currently open (runStartTs set) across the rollover, its start marker is
-// pulled forward to "now" so only post-midnight time accrues to the new day —
-// otherwise the next flush/stop would re-credit the whole pre-midnight run
-// (since Date.now() - runStartTs would still span back into yesterday).
+// Restores {sec, ts} from Script.storage: prefers the current single-object
+// format, falling back once to the pre-#469 loose-scalar pair for a device
+// upgrading in place. Returns null if neither is present/valid, so the
+// caller (loadState) can fall back further to KVS.
+function loadRuntimeStateFromStorage() {
+  var obj = loadStorageObject(STORAGE_KEYS.runtime);
+  if (obj !== null) {
+    if (typeof obj.sec === "number" && typeof obj.ts === "number") {
+      return {sec: obj.sec, ts: obj.ts};
+    }
+    log("WARNING: Script.storage[" + STORAGE_KEYS.runtime + "] is malformed:", JSON.stringify(obj));
+  }
+  return migrateLegacyRuntimeState();
+}
+
+// One-time migration for devices that only have the pre-#469 loose-scalar
+// pair (runtime-sec + runtime-date). The date string is parsed here, and
+// only here — this is the one legacy compatibility path, not the ongoing
+// day-rollover logic, which never stores or parses a date string (#469).
+// applyRuntimeState() re-persists the result in the new object format
+// immediately, so this path is not taken again on the next restart.
+function migrateLegacyRuntimeState() {
+  var legacySec = loadStorageNumber(STORAGE_KEYS.runtimeSecLegacy);
+  if (legacySec === null) {
+    return null; // nothing to migrate; a genuinely fresh device
+  }
+  var legacyDateStr = loadStorageString(STORAGE_KEYS.runtimeDateLegacy);
+  var legacyTs = epochSecondsForDateString(legacyDateStr);
+  if (legacyTs === null) {
+    log("WARNING: legacy runtime-date missing/unparseable during migration ('" + legacyDateStr + "'), assuming today");
+    legacyTs = Math.floor(Date.now() / 1000);
+  }
+  log("Migrating legacy runtime state (#469): sec=" + legacySec + " date=" + legacyDateStr);
+  return {sec: legacySec, ts: legacyTs};
+}
+
+// Parses a legacy "YYYY-M-D" date string into the epoch second of local noon
+// on that day (noon avoids DST-transition edge cases at midnight). Returns
+// null if s is missing or not that shape. Migration-only — see above.
+function epochSecondsForDateString(s) {
+  if (typeof s !== "string") return null;
+  var parts = s.split('-');
+  if (parts.length !== 3) return null;
+  var y = Number(parts[0]);
+  var m = Number(parts[1]);
+  var d = Number(parts[2]);
+  if (isNaN(y) || isNaN(m) || isNaN(d)) return null;
+  var dt = new Date(y, m - 1, d, 12, 0, 0);
+  return Math.floor(dt.getTime() / 1000);
+}
+
+// Recovery path (#469): only reached when Script.storage yields nothing
+// usable for either format — e.g. a fresh Script.storage after a script
+// reinstall. KVS survives reinstalls. cb(sec, ts) receives numbers, or null
+// for whichever half is missing/invalid. KVS.Get is async-only (Shelly.call
+// without a callback returns null on real firmware — see the
+// STORAGE_KEYS.scheduleMode comment above), so this chains two sequential
+// calls rather than reading synchronously.
+function loadRuntimeStateFromKVS(cb) {
+  loadValueAsync(STATE_KEYS.runtimeSec, function (secVal) {
+    var sec = (typeof secVal === "number") ? secVal : null;
+    loadValueAsync(STATE_KEYS.runtimeTs, function (tsVal) {
+      var ts = (typeof tsVal === "number") ? tsVal : null;
+      cb(sec, ts);
+    });
+  });
+}
+
+// Decides the day's starting {sec, ts} from a restored (sec, ts) pair.
+// Zeroes the count ONLY when ts is valid and demonstrably belongs to an
+// earlier calendar day than today (a genuine rollover). Anything else —
+// missing state, a sec with no valid ts, a ts that fails to parse — carries
+// the count forward with a loud warning instead of resetting it: an
+// over-counted day wastes energy, but a zeroed day causes real
+// over-filtration, which is the harm #469 was filed over.
+function reconcileRuntimeState(sec, ts, sourceLabel) {
+  var nowSec = Math.floor(Date.now() / 1000);
+  if (sec === null) {
+    log("WARNING: no valid runtime state from " + sourceLabel + " — starting today's count at 0s rather than assuming a reset (#469)");
+    return {sec: 0, ts: nowSec};
+  }
+  if (ts === null) {
+    log("WARNING: runtime state from " + sourceLabel + " has a count but no valid timestamp, cannot verify which day it belongs to — carrying forward", sec, "s as today's total");
+    return {sec: sec, ts: nowSec};
+  }
+  var restoredDay = localDayNumber(ts);
+  var today = localDayNumber(nowSec);
+  if (restoredDay < today) {
+    log("Runtime day rollover:", restoredDay, "->", today);
+    return {sec: 0, ts: nowSec};
+  }
+  if (restoredDay > today) {
+    log("WARNING: runtime state from " + sourceLabel + " has a future timestamp (day " + restoredDay + " > today " + today + ") — carrying forward", sec, "s rather than trusting or discarding it");
+  }
+  return {sec: sec, ts: ts};
+}
+
+// Re-derives STATE.runtimeTs's day against "now" mid-run (called from
+// startRuntimeAccounting/flushRuntimeCheckpoint) and resets the counter on a
+// genuine rollover. If a run is currently open (runStartTs set) across the
+// rollover, its start marker is pulled forward to "now" so only
+// post-midnight time accrues to the new day — otherwise the next
+// flush/stop would re-credit the whole pre-midnight run (since
+// Date.now() - runStartTs would still span back into yesterday).
 function ensureRuntimeDay() {
-  var today = todayDateString();
-  if (STATE.runtimeDate !== today) {
-    log("Runtime day rollover:", STATE.runtimeDate, "->", today);
-    STATE.runtimeDate = today;
-    STATE.runtimeTodaySec = 0;
+  var reconciled = reconcileRuntimeState(STATE.runtimeTodaySec, STATE.runtimeTs, "in-memory state");
+  if (reconciled.sec !== STATE.runtimeTodaySec || reconciled.ts !== STATE.runtimeTs) {
+    STATE.runtimeTodaySec = reconciled.sec;
+    STATE.runtimeTs = reconciled.ts;
     if (STATE.runStartTs !== null) {
       STATE.runStartTs = Date.now();
     }
-    storeStorageValue(STORAGE_KEYS.runtimeDate, STATE.runtimeDate);
     persistRuntimeState(STATE.runtimeTodaySec);
   }
 }
@@ -1143,27 +1322,35 @@ function flushRuntimeCheckpoint() {
   persistRuntimeState(STATE.runtimeTodaySec + elapsedSec);
 }
 
-// Persists sec (defaults to STATE.runtimeTodaySec) to Script.storage (sync,
-// boot-safe) and mirrors it — plus today's computed turnover — to KVS for
-// Go-side visibility (myhome/daemon/pool_notices.go ComputeTurnover).
+// Persists sec (defaults to STATE.runtimeTodaySec) plus the current epoch
+// second to Script.storage as one object (sync, boot-safe — #469: a
+// serialised {sec, ts} object cannot be silently misparsed as a number the
+// way the old loose scalars could) and mirrors sec, ts, and today's computed
+// turnover to KVS for Go-side visibility (myhome/daemon/pool_notices.go
+// ComputeTurnover) and as a recovery path if Script.storage is ever lost
+// (e.g. a script reinstall — see loadRuntimeStateFromKVS).
 //
 // The Script.storage write is synchronous and always happens (cheap, no RPC).
-// The two KVS mirrors go through Shelly.call and are skipped during
+// The KVS mirrors go through Shelly.call and are skipped during
 // STATE.initializing — same guard as saveState() — and queued via
-// queueTask() rather than fired back-to-back: an un-queued pair here,
-// repeated every 60s by flushRuntimeCheckpoint() while the pump runs and
-// possibly overlapping saveState()'s own KVS writes, is exactly the
-// "Too many calls in progress" crash PR #394 fixed (5-concurrent-RPC limit).
-// A skipped mirror during init is harmless — the next checkpoint or stop
-// re-persists it.
+// queueTask() rather than fired back-to-back: un-queued calls here, repeated
+// every 60s by flushRuntimeCheckpoint() while the pump runs and possibly
+// overlapping saveState()'s own KVS writes, is exactly the "Too many calls
+// in progress" crash PR #394 fixed (5-concurrent-RPC limit). A skipped
+// mirror during init is harmless — the next checkpoint or stop re-persists it.
 function persistRuntimeState(overrideSec) {
   var sec = (typeof overrideSec === "number") ? overrideSec : STATE.runtimeTodaySec;
-  storeStorageValue(STORAGE_KEYS.runtimeSec, sec);
+  var ts = Math.floor(Date.now() / 1000);
+  STATE.runtimeTs = ts;
+  storeStorageValue(STORAGE_KEYS.runtime, {sec: sec, ts: ts});
   if (STATE.initializing) {
     return;
   }
   queueTask(function() {
-    storeValue("runtime-sec", Math.round(sec));
+    storeValue(STATE_KEYS.runtimeSec, Math.round(sec));
+  });
+  queueTask(function() {
+    storeValue(STATE_KEYS.runtimeTs, ts);
   });
   queueTask(function() {
     storeValue("turnover-today", computeTurnoverToday(sec));
@@ -2385,7 +2572,15 @@ function continueInit() {
   log('Device type:', STATE.deviceType);
 
   configureComponentNames();
-  loadState();
+  // loadState() is synchronous in the common case (Script.storage has valid
+  // data) and calls finishContinueInit() immediately, before returning here
+  // — so this is not a behavior change for a healthy device. It only goes
+  // truly async when Script.storage yields nothing usable and it falls back
+  // to an async KVS read (#469); the rest of init correctly waits for that.
+  loadState(finishContinueInit);
+}
+
+function finishContinueInit() {
   enforceOutputState();
   setupMQTT();
 

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -676,39 +676,22 @@ func TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover(t *testing.T) {
 // running). Asserts runtime-sec continues accumulating from the persisted
 // baseline instead of resetting to 0 — the crash/reboot resilience #402
 // point 6 exists for.
-func TestPoolPump_RuntimeAccounting_ContinuesAfterReboot(t *testing.T) {
-	buf := readPoolPumpScript(t)
-
-	mqtt.ResetClient()
-	mqtt.SetClient(mqtt.NewMockClient())
-	t.Cleanup(mqtt.ResetClient)
-
-	injector := make(chan []byte, 4)
-
-	cs := pro3ComponentStatus()
-	cs["switch:2"] = map[string]interface{}{"id": 2, "output": true} // pump left "on" across the simulated reboot
-
-	const baselineSec = 3600 // 1h of runtime accrued before the "reboot"
-
-	deviceState := &script.DeviceState{
-		KVS: controllerKVS(),
-		Storage: map[string]interface{}{
-			"runtime-sec":  fmt.Sprintf("%d", baselineSec),
-			"runtime-date": dateString(time.Now()),
-		},
-		ComponentStatus: cs,
-		Schedules:       poolPumpSchedules(),
-		EventInjector:   injector,
-	}
-
+// runPoolPumpPhase starts pool-pump.js against deviceState in the
+// background and returns once init has completed (schedule-mode written to
+// KVS), leaving the script running. Call the returned stop() to cancel the
+// script and wait for it to fully exit before starting a second phase
+// against the *same* deviceState — reusing the same DeviceState pointer
+// across two phases is what makes a two-phase test a genuine restart:
+// Script.storage isn't reset between phases, only whatever the running
+// script itself wrote to it, exactly like Script.Stop/Script.Start on a
+// real device reusing the same on-flash storage.
+func runPoolPumpPhase(t *testing.T, buf []byte, deviceState *script.DeviceState) (stop func()) {
+	t.Helper()
 	ctx, cancel := poolPumpRunContext(t)
-	defer cancel()
-
 	done := make(chan error, 1)
 	go func() {
 		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
 	}()
-
 	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
 		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
 		return exists
@@ -718,53 +701,269 @@ func TestPoolPump_RuntimeAccounting_ContinuesAfterReboot(t *testing.T) {
 		<-done
 		t.Fatalf("init timeout")
 	}
+	return func() {
+		cancel()
+		<-done
+	}
+}
 
-	// Short real wait, then stop, to confirm accumulation continues from the
-	// restored baseline rather than resetting to 0.
-	time.Sleep(1 * time.Second)
+// runtimeStorageState mirrors the JSON object pool-pump.js persists at
+// Script.storage["runtime"] (see STORAGE_KEYS.runtime, #469): {sec, ts}.
+type runtimeStorageState struct {
+	Sec float64 `json:"sec"`
+	Ts  float64 `json:"ts"`
+}
 
+// readRuntimeStorage reads and JSON-decodes Script.storage["runtime"],
+// failing the test if it is absent, not a string (Script.storage only ever
+// holds strings — Web Storage semantics), or not valid JSON. This is the
+// "assert the value and type come back intact" check #469 asked for: unlike
+// the pre-#469 loose scalars, a malformed round trip fails loudly here
+// instead of silently coercing to 0/null.
+func readRuntimeStorage(t *testing.T, d *script.DeviceState) runtimeStorageState {
+	t.Helper()
+	raw, ok := d.StorageValue("runtime")
+	if !ok {
+		t.Fatalf(`Script.storage["runtime"] not present`)
+	}
+	s, ok := raw.(string)
+	if !ok {
+		t.Fatalf(`Script.storage["runtime"] = %v (%T), want a string (Web Storage semantics)`, raw, raw)
+	}
+	var out runtimeStorageState
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		t.Fatalf(`Script.storage["runtime"] = %q is not valid JSON: %v`, s, err)
+	}
+	return out
+}
+
+// seedRuntimeStorage directly overwrites Script.storage["runtime"] between
+// two runPoolPumpPhase phases, to force a scenario a real clock can't
+// produce inside a unit test (a specific past day, or corruption).
+func seedRuntimeStorage(d *script.DeviceState, sec float64, ts int64) {
+	raw, _ := json.Marshal(runtimeStorageState{Sec: sec, Ts: float64(ts)})
+	d.SetStorageValue("runtime", string(raw))
+}
+
+// localDayNumber mirrors pool-pump.js's localDayNumber(epochSec): a
+// comparable YYYYMMDD integer in local time, so Go-side assertions about
+// "which day" a persisted ts belongs to use the same representation as the
+// script itself, rather than a separately-formatted date string.
+func localDayNumber(epochSec int64) int64 {
+	tm := time.Unix(epochSec, 0)
+	return int64(tm.Year())*10000 + int64(tm.Month())*100 + int64(tm.Day())
+}
+
+// TestPoolPump_RuntimeAccounting_ContinuesAfterReboot is the storage
+// round-trip test #469 asked for, and a rewrite of the pre-#469 test of the
+// same name: that version seeded Script.storage directly with Go-string
+// values, bypassing the script's own storeStorageValue()/loadStorageValue()
+// write-read path entirely — which is exactly why it kept passing while the
+// bug was live, and why #469 asked for it to be fixed, not just supplemented.
+// This version does NOT seed Script.storage directly: phase 1 runs the pump
+// for real and lets its own stop-event handler persist a nonzero runtime
+// through the actual storeStorageValue()/JSON.stringify code path; phase 2
+// is a genuine second script instance (new goja VM, same DeviceState) that
+// must restore that exact value through loadStorageObject()/JSON.parse —
+// proving the round trip is intact end to end, and that a same-day restart
+// carries the count forward instead of resetting it.
+func TestPoolPump_RuntimeAccounting_ContinuesAfterReboot(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	injector := make(chan []byte, 4)
+	cs := pro3ComponentStatus()
+	cs["switch:2"] = map[string]interface{}{"id": 2, "output": true} // pump on at boot
+
+	deviceState := &script.DeviceState{
+		KVS:             controllerKVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: cs,
+		Schedules:       poolPumpSchedules(),
+		EventInjector:   injector,
+	}
+
+	// --- Phase 1: pump runs briefly, then a real water-supply-ON event
+	// stops it, which calls stopRuntimeAccounting() -> persistRuntimeState()
+	// -> the script's own storeStorageValue() write. ---
+	stop1 := runPoolPumpPhase(t, buf, deviceState)
+	time.Sleep(1200 * time.Millisecond)
 	injector <- shellyInputEvent(0, true)
 	stopped := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
 		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
 		return ok && v == "-1"
 	})
-	cancel()
-	<-done
-
+	stop1()
 	if !stopped {
-		t.Fatalf("pump did not stop after water supply ON; active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
+		t.Fatalf("pump did not stop after water supply ON in phase 1; active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
 	}
 
-	runtimeSec := parseKVSInt(t, deviceState, "script/pool-pump/runtime-sec")
-	if runtimeSec <= baselineSec {
-		t.Fatalf("runtime-sec %d did not increase past persisted baseline %d — accounting reset instead of continuing",
-			runtimeSec, baselineSec)
+	phase1Sec := parseKVSInt(t, deviceState, "script/pool-pump/runtime-sec")
+	if phase1Sec <= 0 {
+		t.Fatalf("phase 1 KVS runtime-sec = %d, want > 0 (the real write path never ran)", phase1Sec)
+	}
+	phase1Storage := readRuntimeStorage(t, deviceState)
+	if phase1Storage.Sec <= 0 {
+		t.Fatalf(`phase 1 Script.storage["runtime"].sec = %v, want > 0`, phase1Storage.Sec)
 	}
 
-	turnoverToday := parseKVSFloat(t, deviceState, "script/pool-pump/turnover-today")
-	wantTurnover := expectedTurnover(float64(runtimeSec))
-	if math.Abs(turnoverToday-wantTurnover) > 0.01 {
-		t.Errorf("turnover-today = %v, want ~%v (runtime_sec=%d)", turnoverToday, wantTurnover, runtimeSec)
+	// --- Phase 2: a fresh script instance (new VM) against the SAME
+	// DeviceState. Water supply is still "on" so the pump stays off; this
+	// isolates the restore itself from any further accumulation. ---
+	cs2 := pro3ComponentStatus()
+	cs2["input:0"] = map[string]interface{}{"id": 0, "state": true}
+	deviceState.ComponentStatus = cs2
+
+	stop2 := runPoolPumpPhase(t, buf, deviceState)
+	defer stop2()
+
+	restoredSec := parseKVSInt(t, deviceState, "script/pool-pump/runtime-sec")
+	if restoredSec < phase1Sec {
+		t.Fatalf("phase 2 KVS runtime-sec = %d, want >= phase 1's %d (round trip lost data, #469)", restoredSec, phase1Sec)
+	}
+
+	restoredStorage := readRuntimeStorage(t, deviceState)
+	if restoredStorage.Sec < phase1Storage.Sec {
+		t.Fatalf(`phase 2 Script.storage["runtime"].sec = %v, want >= phase 1's %v (#469)`, restoredStorage.Sec, phase1Storage.Sec)
+	}
+	if localDayNumber(int64(restoredStorage.Ts)) != localDayNumber(time.Now().Unix()) {
+		t.Fatalf(`phase 2 Script.storage["runtime"].ts = %v, want today`, restoredStorage.Ts)
 	}
 }
 
-// TestPoolPump_RuntimeAccounting_StaleDateResetsOnBoot verifies
-// ensureRuntimeDay()'s day-rollover reset: Script.storage is pre-seeded with
-// a runtime-date from "yesterday" plus a large leftover runtime-sec — as if
-// the device was left running overnight and only rebooted the next day (or
-// the daemon never stopped it before midnight). At boot, loadState() must
-// discard the stale total (reset to 0) rather than carry it into today,
-// which is the same reset path exercised — for an in-progress run instead of
-// at boot — by the flushRuntimeCheckpoint()/handleNightStop() mid-run
-// rollover fix (ensureRuntimeDay() pulling STATE.runStartTs forward to
-// Date.now() so a still-open run doesn't re-credit its pre-midnight time to
-// the new day). That exact mid-run interleaving isn't independently
+// TestPoolPump_RuntimeAccounting_PreviousDayRestartResets verifies the
+// day-rollover reset using the current {sec, ts} format end to end across a
+// genuine two-phase restart (unlike TestPoolPump_RuntimeAccounting_
+// LegacyMigrationDiscardsStaleDate below, which single-run-seeds the
+// pre-#469 legacy pair). Phase 1 persists a real baseline; between phases
+// the test backdates Script.storage["runtime"].ts to yesterday — standing in
+// for a device that sat idle overnight, since this Go harness can't fast-
+// forward goja's Date() past a real midnight. Phase 2 must reset the count
+// to 0 rather than carrying yesterday's total into today.
+func TestPoolPump_RuntimeAccounting_PreviousDayRestartResets(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	deviceState := &script.DeviceState{
+		KVS:             controllerKVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: pro3ComponentStatus(), // pump off throughout
+		Schedules:       poolPumpSchedules(),
+	}
+
+	stop1 := runPoolPumpPhase(t, buf, deviceState)
+	stop1()
+
+	yesterday := time.Now().AddDate(0, 0, -1)
+	seedRuntimeStorage(deviceState, 43200, yesterday.Unix()) // 12h — clearly stale if carried over
+
+	stop2 := runPoolPumpPhase(t, buf, deviceState)
+	defer stop2()
+
+	got := readRuntimeStorage(t, deviceState)
+	if got.Sec != 0 {
+		t.Errorf(`Script.storage["runtime"].sec after cross-day restart = %v, want 0 (stale total must not carry over, #469)`, got.Sec)
+	}
+	if localDayNumber(int64(got.Ts)) != localDayNumber(time.Now().Unix()) {
+		t.Errorf(`Script.storage["runtime"].ts after cross-day restart = %v, want today`, got.Ts)
+	}
+}
+
+// TestPoolPump_RuntimeAccounting_CorruptStorageFallsBackToKVS exercises the
+// KVS recovery path (#469 design point 5): phase 1 persists a real baseline
+// to both Script.storage and its KVS mirrors (runtime-sec, runtime-ts).
+// Between phases, Script.storage["runtime"] is corrupted (not valid JSON) —
+// standing in for a script reinstall wiping Script.storage while KVS,
+// external to the script package, survives. Phase 2 must recover the KVS
+// baseline instead of resetting to 0, exercising the async loadValueAsync/
+// loadRuntimeStateFromKVS path that loadStorageObject() alone cannot reach.
+func TestPoolPump_RuntimeAccounting_CorruptStorageFallsBackToKVS(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	injector := make(chan []byte, 4)
+	cs := pro3ComponentStatus()
+	cs["switch:2"] = map[string]interface{}{"id": 2, "output": true}
+
+	deviceState := &script.DeviceState{
+		KVS:             controllerKVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: cs,
+		Schedules:       poolPumpSchedules(),
+		EventInjector:   injector,
+	}
+
+	stop1 := runPoolPumpPhase(t, buf, deviceState)
+	time.Sleep(1200 * time.Millisecond)
+	injector <- shellyInputEvent(0, true)
+	stopped := waitFor(eventTimeout, 50*time.Millisecond, func() bool {
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
+		return ok && v == "-1"
+	})
+	stop1()
+	if !stopped {
+		t.Fatalf("pump did not stop after water supply ON in phase 1")
+	}
+
+	kvsSecBefore := parseKVSInt(t, deviceState, "script/pool-pump/runtime-sec")
+	if kvsSecBefore <= 0 {
+		t.Fatalf("phase 1 KVS runtime-sec = %d, want > 0", kvsSecBefore)
+	}
+	if _, ok := deviceState.KVSValue("script/pool-pump/runtime-ts"); !ok {
+		t.Fatalf("phase 1 did not write KVS runtime-ts")
+	}
+
+	deviceState.SetStorageValue("runtime", "not valid json")
+
+	cs2 := pro3ComponentStatus()
+	cs2["input:0"] = map[string]interface{}{"id": 0, "state": true}
+	deviceState.ComponentStatus = cs2
+
+	stop2 := runPoolPumpPhase(t, buf, deviceState)
+	defer stop2()
+
+	// applyRuntimeState() re-persists to Script.storage synchronously as
+	// part of the same init chain runPoolPumpPhase already waited for
+	// (finishLoadState/onDone only fires after the KVS fallback resolves),
+	// so this is safe to read immediately.
+	recovered := readRuntimeStorage(t, deviceState)
+	if recovered.Sec < float64(kvsSecBefore) {
+		t.Fatalf(`after corrupt Script.storage, recovered Script.storage["runtime"].sec = %v, want >= phase 1's KVS baseline %d (KVS fallback must carry forward, not reset, #469)`, recovered.Sec, kvsSecBefore)
+	}
+}
+
+// TestPoolPump_RuntimeAccounting_LegacyMigrationDiscardsStaleDate verifies
+// migrateLegacyRuntimeState()'s one-time upgrade path for a pre-#469 device
+// that only has the old loose-scalar pair (runtime-sec + runtime-date), in
+// the specific case where that legacy date is stale: as if the device was
+// left running overnight and only rebooted the next day (or the daemon
+// never stopped it before midnight). At boot, the migrated total must be
+// discarded (reset to 0) rather than carried into today.
+//
+// This is a single-run, directly-seeded test (unlike the two-phase tests
+// above) because it is specifically about migrating a value the *test*
+// plants in the legacy format, not about round-tripping through the
+// script's own write path — migrateLegacyRuntimeState() only ever reads
+// runtime-sec/runtime-date, it never writes them again once migrated.
+//
+// The exact mid-run rollover interleaving (ensureRuntimeDay() pulling
+// STATE.runStartTs forward to Date.now() so a still-open run doesn't
+// re-credit its pre-midnight time to the new day) isn't independently
 // reproducible from this Go harness: Date.now()/Timer.set are tied to the
 // real system clock with no injectable virtual clock, so there's no
-// deterministic way to force STATE.runtimeDate stale while STATE.runStartTs
-// is non-null without a real device restart in between (which always goes
+// deterministic way to force a stale restored ts while STATE.runStartTs is
+// non-null without a real device restart in between (which always goes
 // through this same boot-time reset path).
-func TestPoolPump_RuntimeAccounting_StaleDateResetsOnBoot(t *testing.T) {
+func TestPoolPump_RuntimeAccounting_LegacyMigrationDiscardsStaleDate(t *testing.T) {
 	buf := readPoolPumpScript(t)
 
 	mqtt.ResetClient()
@@ -781,30 +980,15 @@ func TestPoolPump_RuntimeAccounting_StaleDateResetsOnBoot(t *testing.T) {
 		Schedules:       poolPumpSchedules(),
 	}
 
-	ctx, cancel := poolPumpRunContext(t)
-	defer cancel()
+	stop := runPoolPumpPhase(t, buf, deviceState)
+	stop()
 
-	done := make(chan error, 1)
-	go func() {
-		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
-	}()
-
-	initDone := waitFor(initTimeout, 200*time.Millisecond, func() bool {
-		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
-		return exists
-	})
-	cancel()
-	<-done
-
-	if !initDone {
-		t.Fatalf("init timeout")
+	got := readRuntimeStorage(t, deviceState)
+	if got.Sec != 0 {
+		t.Errorf(`Script.storage["runtime"].sec after migrating a stale legacy date = %v, want 0 (stale total must not carry over)`, got.Sec)
 	}
-
-	if got := storageValue(deviceState, "runtime-date"); got != dateString(time.Now()) {
-		t.Errorf("Storage runtime-date = %v, want today (%s)", got, dateString(time.Now()))
-	}
-	if got := storageValue(deviceState, "runtime-sec"); got != "0" {
-		t.Errorf("Storage runtime-sec = %v, want \"0\" (stale total must not carry over)", got)
+	if localDayNumber(int64(got.Ts)) != localDayNumber(time.Now().Unix()) {
+		t.Errorf(`Script.storage["runtime"].ts after migrating a stale legacy date = %v, want today`, got.Ts)
 	}
 }
 

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -687,6 +687,15 @@ func TestPoolPump_RuntimeAccounting_TracksElapsedRunAndTurnover(t *testing.T) {
 // real device reusing the same on-flash storage.
 func runPoolPumpPhase(t *testing.T, buf []byte, deviceState *script.DeviceState) (stop func()) {
 	t.Helper()
+	// KVS (unlike Storage) is deliberately NOT reset between phases either —
+	// but that means "schedule-mode" is already present in deviceState.KVS
+	// the instant a second phase starts, left over from the previous phase's
+	// own saveState() write. Left alone, the waitFor below would return
+	// immediately on a stale key instead of waiting for *this* run's init to
+	// reach the same point, racing the very state restore under test. Clear
+	// it first so the predicate can only be satisfied by a fresh write.
+	deviceState.DeleteKVSValue("script/pool-pump/schedule-mode")
+
 	ctx, cancel := poolPumpRunContext(t)
 	done := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
## Problem

`pool-pump.js` lost the day's accumulated runtime **on every script restart**, not just after a crash. Measured on `filtration-hiver` on 2026-08-11 — six restarts, every one of them:

```
06:34  Restored runtime today: 0 s
06:45  Restored runtime today: 0 s
06:46  Restored runtime today: 0 s
09:54  Restored runtime today: 0 s
18:28  Restored runtime today: 0 s
19:33  Restored runtime today: 0 s
```

Three also logged a spurious `Runtime day rollover: null -> 2026-8-11`.

Real cost that day: the pump ran **9h09m (~6.2 turnovers)** and afterwards believed it had done **0.54**. Both turnover ceilings (`solar-min-turnover` 5, `solar-max-turnover` 7) became unreachable, so neither the soft stop nor the hard ceiling could fire — the pump would have kept filtering all evening.

## Root cause

State was persisted as **two loose `Script.storage` scalars** (`runtime-sec`, `runtime-date`) and restored through a type-guessing `loadStorageValue()` (`Number()` → `JSON.parse()` → raw string). The restore was silently type-gated:

```js
STATE.runtimeDate     = (typeof savedRuntimeDate === "string") ? savedRuntimeDate : null;
STATE.runtimeTodaySec = (typeof savedRuntimeSec  === "number") ? savedRuntimeSec  : 0;
```

Anything not exactly the expected type became `null`/`0` **with no logging**, and a `null` date then triggered the rollover branch that zeroes the counter.

Note on the suspected mechanism: `JSON.parse("2026-8-11")` was checked against goja and **throws** there (spec-compliant), so the emulator cannot reproduce the Espruino leniency originally suspected. That remains unverified on real firmware — and is now moot, because the fix never stores or parses a date string again.

## Fix

- **One JSON object**: `Script.storage["runtime"] = {sec, ts}`, both numbers. A serialised object cannot be silently misparsed as a number.
- **Day derived from an epoch timestamp**, compared as a `YYYYMMDD` integer. No date string is stored or parsed, which removes the entire failure class.
- **Typed accessors** — `loadStorageNumber` / `loadStorageString` / `loadStorageObject` replace the guess-chain, each logging a `WARNING:` on fallback. All six resets above were silent.
- **KVS `runtime-ts` as a recovery path**, used when `Script.storage` yields nothing valid. KVS survives script reinstalls and is repairable by hand — which is what I wrongly assumed it already did.
- **Reconcile, not reset**: `reconcileRuntimeState()` zeroes only on a demonstrably *earlier* calendar day. Missing timestamp, or even a future one, carries the count forward with a loud warning. An over-counted day wastes energy; a zeroed day drives real over-filtration, which is the harm actually observed.
- **One-time migration** of the legacy scalar pair, so a running device's counter is not stranded.
- `ensureRuntimeDay()` additionally handles a rollover **mid-run**: it pulls `runStartTs` forward to now, so a run spanning midnight does not re-credit its pre-midnight portion to the new day.

## Why the existing test missed it

`TestPoolPump_RuntimeAccounting_ContinuesAfterReboot` seeded `Script.storage` directly with Go-string values, **bypassing the script's own write path**. It never exercised a write-then-read round trip, so it passed while the bug was live.

Rewritten as a genuine two-phase restart — the same `*script.DeviceState` reused across two `RunWithDeviceState` calls, i.e. two goja VMs. Added `PreviousDayRestartResets`, `CorruptStorageFallsBackToKVS` (exercises the new async KVS recovery), and `LegacyMigrationDiscardsStaleDate`.

A test-harness bug surfaced doing this: the "init complete" signal (`schedule-mode` present in KVS) was a stale leftover from phase 1, since KVS is deliberately not reset between phases. Fixed by clearing that key before each phase.

## Verification

```
go test -count=1 -run 'TestPoolPump_RuntimeAccounting' ./internal/shelly/scripts/...
ok  github.com/asnowfix/home-automation/internal/shelly/scripts  48.565s
```

Agent's full `-race` run of the package: green, 268.96s. No emulator change was needed — `Script.storage` already round-trips faithfully.

Shelly JS constraints checked on the diff: no `let`/`const`, no empty catch blocks, no `!== undefined` property checks, no `shift`/`unshift`. New KVS key `runtime-ts` follows the lowercase-hyphen convention.

Closes #469.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): persist daily runtime as a single {sec,ts} object (#469) ([02c1d5d](https://github.com/asnowfix/home-automation/commit/02c1d5d8bb325d8fc3eaaca15467ccf83b5f3aad))
- test(pool-pump): storage round-trip test through the script's real write path (#469) ([0538fd3](https://github.com/asnowfix/home-automation/commit/0538fd329dbb6f6f77206e9f4d7d65dba119a64b))
- test(pool-pump): fix stale KVS schedule-mode racing the phase-2 init signal ([cbdafd0](https://github.com/asnowfix/home-automation/commit/cbdafd06b66d718f6c564c06d19361e921c21266))
<!-- END-AUTO-GENERATED-COMMITS -->