### PR TITLE
fix(pool-pump): make handleWaterSupply re-entrancy safe, ending the recursion crash (#450)

### DIFF
--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1665,7 +1665,42 @@ function cycleOutputs() {
 }
 
 // === WATER SUPPLY PROTECTION ===
-var WATER_SUPPLY_ACTIVE = false;  // debounce guard
+var WATER_SUPPLY_ACTIVE = false;  // debounce guard, and latest observed input:0 state
+
+// #450: re-entrancy guards for handleWaterSupply. input:0 can flap faster
+// than a Switch.Set round-trip (protect -> restore -> protect, or the
+// reverse, within milliseconds). handleWaterSupply used to call
+// activateOutput()/setOutput() unconditionally on every event; a second
+// event arriving before the first transition's Shelly.call callback had
+// fired called activateOutput() again while the first call was still in
+// flight. On real hardware that nests a fresh Shelly.call inside the native
+// completion handler of the one before it -- invisible to CALL_DEPTH, which
+// only bounds the RPC *completion* path (sharedCallDone), not this *event*
+// entry point -- and the nesting grows until acquireCallSlot's plain for
+// loop runs out of interpreter stack:
+//
+//   Uncaught Error: Too much recursion - the stack is about to overflow
+//    in function "acquireCallSlot" ... "setOutput" ... "activateOutput"
+//    ... "handleWaterSupply" ... "handleInputEvent" ... called from system
+//
+// That crashed the production pump (#450), leaving it running with
+// protection "active" and no script left to enforce it.
+//
+// WATER_SUPPLY_TRANSITION_PENDING is true from the moment a transition
+// starts until its activateOutput() callback has run. While true, a new
+// event does not call activateOutput() again -- it only records that a
+// newer input state exists (WATER_SUPPLY_PENDING_APPLY) and returns
+// immediately, so no second Shelly.call chain is ever nested inside the
+// first. WATER_SUPPLY_ACTIVE already holds the latest observed state (set
+// synchronously below, before the pending check), so nothing is lost: once
+// the in-flight transition's callback runs, finishWaterSupplyTransition()
+// applies that latest state via queueTask -- never inline -- so the
+// follow-up transition runs from a fresh stack, not nested inside the
+// callback that discovered it. A flap that ends "protection active" leaves
+// the pump off; one that ends "clear" leaves it restored -- matching the
+// LAST observed input, never the first.
+var WATER_SUPPLY_TRANSITION_PENDING = false;
+var WATER_SUPPLY_PENDING_APPLY = false;
 
 function handleWaterSupply(waterSupplyActive) {
   log("Water supply active signal:", waterSupplyActive);
@@ -1677,6 +1712,25 @@ function handleWaterSupply(waterSupplyActive) {
   }
   WATER_SUPPLY_ACTIVE = waterSupplyActive;
 
+  if (WATER_SUPPLY_TRANSITION_PENDING) {
+    // A previous transition's Shelly.call has not completed yet. Do NOT
+    // call activateOutput() here -- see the block comment above. Record
+    // that a newer state must be applied once the in-flight transition
+    // settles.
+    log("Water supply transition in flight, deferring to latest state:", waterSupplyActive);
+    WATER_SUPPLY_PENDING_APPLY = true;
+    return;
+  }
+
+  startWaterSupplyTransition(waterSupplyActive);
+}
+
+// Applies one water-supply transition (protect or restore) and, on
+// completion, hands off to finishWaterSupplyTransition to check whether a
+// newer input state arrived while it was running.
+function startWaterSupplyTransition(waterSupplyActive) {
+  WATER_SUPPLY_TRANSITION_PENDING = true;
+
   if (waterSupplyActive) {
     // Water supply is ON (signal is HIGH after invert) - save current state and turn off all pumps
     STATE.savedOutput = STATE.activeOutput;
@@ -1685,6 +1739,7 @@ function handleWaterSupply(waterSupplyActive) {
     Shelly.emitEvent("pool.water_supply_protected", {saved_output: STATE.savedOutput});
     activateOutput(-1, function() {
       log("All pumps turned off for water supply protection");
+      finishWaterSupplyTransition();
     });
   } else {
     // Water supply is OFF (signal is LOW after invert) - restore previous state
@@ -1693,8 +1748,28 @@ function handleWaterSupply(waterSupplyActive) {
     Shelly.emitEvent("pool.water_supply_restored", {restored_output: STATE.savedOutput});
     activateOutput(STATE.savedOutput, function() {
       log("Pump restored after water supply turned off");
+      finishWaterSupplyTransition();
     });
   }
+}
+
+// Runs when a water-supply transition's activateOutput() callback fires. If
+// a newer input state arrived while that transition was in flight (see
+// handleWaterSupply), applies it next -- via queueTask, so the follow-up
+// transition runs on a fresh stack instead of nesting inside this callback,
+// which would just move the #450 recursion one level deeper. Otherwise
+// clears the in-flight flag so the next event is handled immediately.
+function finishWaterSupplyTransition() {
+  if (!WATER_SUPPLY_PENDING_APPLY) {
+    WATER_SUPPLY_TRANSITION_PENDING = false;
+    return;
+  }
+  WATER_SUPPLY_PENDING_APPLY = false;
+  // Stay "pending" across the queueTask hop: a flap arriving before the
+  // queued transition actually starts must defer again (coalescing into
+  // this same follow-up), not race it.
+  var latest = WATER_SUPPLY_ACTIVE;
+  queueTask(function() { startWaterSupplyTransition(latest); });
 }
 
 // === EVENT HANDLERS ===
@@ -2446,12 +2521,23 @@ function doStop(reason) {
 function handleDailyCheck() {
   log('Daily check event');
 
-  var input0 = Shelly.getComponentStatus('input:0');
-  if (input0 && input0.state) {
-    log('Water supply protection active, ignoring event');
-    return;
-  }
-
+  // #450: this used to skip performDailyModeCheck() entirely while
+  // water-supply protection was active. That silently skipped the
+  // summer/winter MODE decision too, not just pump actuation -- observed
+  // live on 2026-08-11: the script crashed and restarted with protection
+  // still active, the next daily check hit this guard and left the device
+  // on 'winter' scheduling on an August evening, and it only self-corrected
+  // on a LATER restart/daily-check once protection had cleared.
+  //
+  // performDailyModeCheck() -> updateScheduleMode() only reads the forecast
+  // and rewrites Schedule.List jobs; it does not touch the physical output
+  // directly. The one place it can indirectly move the pump --
+  // reconcileRunState(), called only if the window actually changed --
+  // already goes through doStart()/doStop(), and BOTH already re-check
+  // live water-supply state themselves: doStart() refuses to start while
+  // protected, doStop() always proceeds. So running the daily check during
+  // protection is safe; skipping it just delayed a correct decision for no
+  // safety benefit.
   performDailyModeCheck();
 }
 

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -1878,6 +1878,75 @@ func TestPoolPump_ScheduleRewriteOutsideWindowDoesNotStartPump(t *testing.T) {
 	}
 }
 
+// TestPoolPump_DailyCheckRunsDuringWaterSupplyProtection is the aftermath
+// defect noted alongside the #450 crash: after the live crash-restart on
+// 2026-08-11, the script logged 'Current mode: winter', then 'Daily check
+// event' -> 'Water supply protection active, ignoring event' — the daily
+// check that would have restored 'summer' mode was skipped outright because
+// handleDailyCheck() bailed out whenever input:0 was active, leaving the
+// device on a winter schedule on an August evening until a LATER restart
+// happened to find protection cleared.
+//
+// handleDailyCheck() runs automatically once, at the very end of init()
+// (continueInit()'s queueTask(handleDailyCheck)), so booting this device
+// with water-supply protection ALREADY active (input:0.state=true in the
+// very first ComponentStatus read) reproduces exactly that shape without
+// needing a live crash: if the guard removed by this fix were still in
+// place, performDailyModeCheck() would never run and schedule-mode would
+// stay 'winter' forever despite a forecast hot enough for 'summer'.
+func TestPoolPump_DailyCheckRunsDuringWaterSupplyProtection(t *testing.T) {
+	srv := poolPumpForecastServer(t, poolPumpWidePeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	cs := pro1ComponentStatus()
+	cs["input:0"] = map[string]interface{}{"id": 0, "state": true} // protected from boot
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpWideRunHours),
+		Storage: map[string]interface{}{
+			// No schedule-mode seeded: loadState() defaults to "winter",
+			// matching the live device's post-crash state.
+			"forecast-url": srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: cs,
+		Schedules:       poolPumpSummerSchedules(now.Add(2*time.Hour), now.Add(4*time.Hour)),
+	}
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	ctx, cancel := poolPumpRunContext(t)
+	defer cancel()
+
+	buf := readPoolPumpScript(t)
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	ok := waitFor(initTimeout, 200*time.Millisecond, func() bool {
+		v, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
+		return exists && v == "summer"
+	})
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatalf("schedule-mode never became 'summer' while water-supply protection was active at boot "+
+			"(hot forecast, threshold exceeded); got %v — handleDailyCheck() is (again) silently skipping "+
+			"performDailyModeCheck() during protection instead of only refusing pump actuation",
+			kvsValue(deviceState, "script/pool-pump/schedule-mode"))
+	}
+
+	// Protection must still be respected: with input:0 active throughout,
+	// the pump itself must never have been started by the mode change.
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "-1" {
+		t.Errorf("pump was started (active-output=%v) while water-supply protection was active — "+
+			"doStart()'s own live input:0 check should have refused this regardless of the daily-check fix", v)
+	}
+}
+
 // Locked read helpers for DeviceState (#451).
 //
 // The emulator mutates DeviceState's maps from the goroutine running the

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -520,6 +520,259 @@ func TestPoolPump_Pro1ToggleAndWaterSupply(t *testing.T) {
 	<-done
 }
 
+// === Water-supply flap re-entrancy regression (#450) ===
+//
+// The live crash trace (issue #450, 2026-08-11 18:42 CEST comment) showed
+// input:0 flapping faster than a Switch.Set round-trip: handleWaterSupply
+// was re-entered from a fresh handleInputEvent while the PREVIOUS
+// transition's Shelly.call callback had not yet fired, nesting a second
+// activateOutput()/setOutput() chain inside the first and eventually
+// overflowing the interpreter stack on real hardware ("Too much recursion
+// ... in function acquireCallSlot").
+//
+// The emulator's default event loop (a Go `select` over EventInjector, see
+// run.go) cannot reproduce that interleaving on its own: it always runs one
+// event's JS handler fully to completion — including every synchronous
+// nested Shelly.call/callback chain — before dequeuing the next, so two
+// events sent back-to-back on the injector are processed strictly in
+// sequence, never nested. That is a real emulator fidelity gap: without a
+// change here, no test could ever exercise this race (matching the
+// class of gap already on record for this file — missing Schedule.Update,
+// Switch.Set emitting no events, KVS.List's signature, unsynchronised state
+// maps).
+//
+// DeviceState.SetPendingNestedEvent (pkg/shelly/script/device_state.go)
+// closes that gap: it arms the emulator's Switch.Set emulation to deliver
+// one more raw device event to the script's event handlers SYNCHRONOUSLY,
+// nested inside the very Switch.Set call the script issued — exactly where
+// the live crash trace shows the second event landing.
+//
+// Before the #450 fix, handleWaterSupply called activateOutput()
+// unconditionally on every event. With the nested event landing inside the
+// first Switch.Set, this reproduces the documented symptom
+// without needing a literal stack overflow (goja's Go-native call stack
+// does not overflow at this shallow a nesting depth the way Espruino's
+// interpreter stack does): the two nested completions race to write
+// STATE.activeOutput/KVS active-output, and whichever happens to unwind
+// LAST wins — which is not necessarily the one matching the physical
+// Switch.Set applied last, so the script's own bookkeeping ends up out of
+// sync with the hardware it just set. After the fix, the second event is
+// deferred instead of acted on immediately (no nested activateOutput() call
+// happens at all), and the coalesced follow-up transition — dispatched via
+// queueTask once the first settles — leaves output in the state matching
+// the LAST observed input, with bookkeeping and hardware agreeing.
+
+// poolPumpWaterSupplyFlapDeviceState returns a Pro1 DeviceState (single
+// output, the device type on which #450 was observed live) wired up for
+// event injection.
+func poolPumpWaterSupplyFlapDeviceState(injector chan []byte) *script.DeviceState {
+	return &script.DeviceState{
+		KVS:             pro1KVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: pro1ComponentStatus(),
+		Schedules:       pro1Schedules(),
+		EventInjector:   injector,
+	}
+}
+
+// assertSwitchOutput fails the test if switch:0's physical output does not
+// match want. Used to check the #450 symptom directly: the script's own
+// active-output bookkeeping diverging from the hardware state it just set.
+func assertSwitchOutput(t *testing.T, deviceState *script.DeviceState, want bool, context string) {
+	t.Helper()
+	entry, ok := componentStatusValue(deviceState, "switch:0")
+	if !ok {
+		t.Errorf("%s: switch:0 component status missing", context)
+		return
+	}
+	m, ok := entry.(map[string]interface{})
+	if !ok {
+		t.Errorf("%s: switch:0 component status not a map: %#v", context, entry)
+		return
+	}
+	on, _ := m["output"].(bool)
+	if on != want {
+		t.Errorf("%s: switch:0 physically %v, want %v — script bookkeeping diverged from hardware state (the #450 race)", context, on, want)
+	}
+}
+
+// TestPoolPump_WaterSupplyFlapFalseThenTrue drives input:0 false -> true
+// (restore starts, then protection re-engages before the restore's
+// Switch.Set completes) and asserts the pump ends OFF, matching the LAST
+// observed input (true = protected) — not the first (false = clear), and
+// not some interleaved mix of the two.
+func TestPoolPump_WaterSupplyFlapFalseThenTrue(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	injector := make(chan []byte, 8)
+	deviceState := poolPumpWaterSupplyFlapDeviceState(injector)
+
+	ctx, cancel := poolPumpRunContext(t)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	if !waitPoolPumpInit(t, deviceState) {
+		cancel()
+		<-done
+		t.Fatalf("init timeout")
+	}
+
+	// Get the pump running so there is something to protect and restore.
+	injector <- shellyButtonEvent()
+	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
+		return ok && v == "0"
+	}) {
+		cancel()
+		<-done
+		t.Fatalf("setup: pump did not start, active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
+	}
+
+	// Enter protection normally (no flap yet) so there is a saved_output to
+	// restore from.
+	injector <- shellyInputEvent(0, true)
+	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
+		return ok && v == "-1"
+	}) {
+		cancel()
+		<-done
+		t.Fatalf("setup: pump did not stop for protection, active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
+	}
+
+	// Arm the nested event: while the upcoming restore's Switch.Set is in
+	// flight, deliver a SECOND input:0 event (back to true / protect)
+	// nested inside it, before the restore's own callback fires. This is
+	// the live crash's exact shape: a restore in flight, protection
+	// re-arriving before it completes.
+	deviceState.SetPendingNestedEvent(shellyInputEvent(0, true))
+
+	// Fire the flap: input:0 -> false (restore starts; the armed nested
+	// event above fires the second leg from inside the restore's own
+	// Switch.Set call).
+	injector <- shellyInputEvent(0, false)
+
+	// This flap starts AND ends "protected" (active-output=-1 both before
+	// and after), matching the live incident exactly: input:0 dipped low
+	// and came straight back high. That means a plain waitFor() for
+	// active-output==-1 would return on its very FIRST poll — matching the
+	// stale pre-flap value — without ever giving the queued follow-up
+	// transition (dispatched via queueTask once the in-flight one settles)
+	// a chance to run, so it would pass unconditionally regardless of
+	// whether the fix works. Settle explicitly instead: several task-queue
+	// ticks (200ms each) is enough for the synchronous nested chain plus
+	// every queued follow-up to fully drain in both the fixed and the
+	// unfixed script.
+	settlePoolPumpTaskQueue(t)
+
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "-1" {
+		cancel()
+		<-done
+		t.Fatalf("false->true flap: expected active-output=-1 (matching last input=protected) after settling, got %v — "+
+			"without the #450 fix this settles on the WRONG value because the nested transition's completion "+
+			"races the outer one instead of being deferred",
+			v)
+	}
+
+	assertSwitchOutput(t, deviceState, false, "false->true flap")
+
+	cancel()
+	<-done
+}
+
+// TestPoolPump_WaterSupplyFlapTrueThenFalse drives input:0 true -> false
+// (protection starts, then clears before the protect's Switch.Set
+// completes) and asserts the pump ends restored, matching the LAST observed
+// input (false = clear) — not the first (true = protected).
+func TestPoolPump_WaterSupplyFlapTrueThenFalse(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	injector := make(chan []byte, 8)
+	deviceState := poolPumpWaterSupplyFlapDeviceState(injector)
+
+	ctx, cancel := poolPumpRunContext(t)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	if !waitPoolPumpInit(t, deviceState) {
+		cancel()
+		<-done
+		t.Fatalf("init timeout")
+	}
+
+	// Get the pump running: this becomes savedOutput once protection
+	// engages below, and must be what gets restored at the end.
+	injector <- shellyButtonEvent()
+	if !waitFor(eventTimeout, 50*time.Millisecond, func() bool {
+		v, ok := deviceState.KVSValue("script/pool-pump/active-output")
+		return ok && v == "0"
+	}) {
+		cancel()
+		<-done
+		t.Fatalf("setup: pump did not start, active-output = %v", kvsValue(deviceState, "script/pool-pump/active-output"))
+	}
+
+	// Arm the nested event: while the upcoming protect's Switch.Set is in
+	// flight, deliver a SECOND input:0 event (back to false / clear) nested
+	// inside it, before the protect's own callback fires.
+	deviceState.SetPendingNestedEvent(shellyInputEvent(0, false))
+
+	// Fire the flap: input:0 -> true (protection starts; the armed nested
+	// event above fires the second leg from inside the protect's own
+	// Switch.Set call).
+	injector <- shellyInputEvent(0, true)
+
+	// As in the false->true test above, this flap starts AND ends
+	// "restored" (active-output=0 both before and after) — a plain
+	// waitFor() for active-output==0 would match the stale pre-flap value
+	// on its first poll and never observe whether the queued follow-up
+	// transition actually ran (or ran correctly). Settle explicitly first.
+	settlePoolPumpTaskQueue(t)
+
+	if v := kvsValue(deviceState, "script/pool-pump/active-output"); v != "0" {
+		cancel()
+		<-done
+		t.Fatalf("true->false flap: expected active-output=0 (matching last input=clear) after settling, got %v — "+
+			"without the #450 fix this settles on the WRONG value because the nested transition's completion "+
+			"races the outer one instead of being deferred",
+			v)
+	}
+
+	assertSwitchOutput(t, deviceState, true, "true->false flap")
+
+	cancel()
+	<-done
+}
+
+// settlePoolPumpTaskQueue waits long enough for pool-pump.js's TASK_QUEUE
+// (a single 200ms-period Timer, see queueTask() in pool-pump.js) to fully
+// drain a multi-step follow-up chain: the deferred transition itself, plus
+// its own saveState() write, is at most a handful of queued tasks deep.
+// Generous rather than tight, like initTimeout/eventTimeout elsewhere in
+// this file — the point of the flap tests below is to observe the SETTLED
+// final state, not the first state a poll happens to see, so a fixed wait
+// is used instead of waitFor().
+func settlePoolPumpTaskQueue(t *testing.T) {
+	t.Helper()
+	time.Sleep(2 * time.Second)
+}
+
 // === Runtime/turnover tracking (#402) ===
 //
 // controllerKVS() sets preferred speed "eco" and doesn't override

--- a/pkg/shelly/script/device_state.go
+++ b/pkg/shelly/script/device_state.go
@@ -34,6 +34,28 @@ type DeviceState struct {
 	// This allows automatic persistence of state changes during script execution
 	OnModified func() `json:"-"`
 
+	// pendingNestedEvent, when set via SetPendingNestedEvent, is delivered to
+	// the script's own event handlers synchronously from INSIDE the next
+	// Switch.Set() call, immediately before that call's completion callback
+	// fires — i.e. nested inside the Shelly.call the script itself issued.
+	//
+	// This exists to reproduce a real Shelly device's event interleaving,
+	// which the default emulator event loop (a Go `select` over
+	// EventInjector and friends in run.go) cannot: that loop only dequeues
+	// the next event after the previous one's handler has fully returned, so
+	// two events sent back-to-back on EventInjector are always processed
+	// strictly in sequence, never nested. On real firmware, a fresh system
+	// event (e.g. input:0 flapping) CAN be dispatched while a previous RPC's
+	// native completion handler is still executing on the interpreter stack
+	// — that is the exact mechanism behind the #450 crash ("Too much
+	// recursion" in pool-pump.js's water-supply handling, triggered by
+	// input:0 flapping faster than a Switch.Set round-trip). Without this
+	// hook, no emulator test can reproduce that interleaving at all.
+	//
+	// Consumed exactly once per Switch.Set call (cleared by
+	// TakePendingNestedEvent) so it targets a single call, not every one.
+	pendingNestedEvent []byte
+
 	nextScheduleID int
 
 	// mu guards every map and slice above. The emulator mutates them from the
@@ -236,6 +258,31 @@ func (d *DeviceState) UpdateSchedule(id int, updates map[string]interface{}) (ma
 // GetKVS returns a snapshot of the KVS map. It is a copy: see KVSSnapshot.
 func (d *DeviceState) GetKVS() map[string]interface{} {
 	return d.KVSSnapshot()
+}
+
+// SetPendingNestedEvent arms the next Switch.Set() call to deliver this raw
+// JSON device event to the script's own event handlers synchronously, nested
+// inside that call — see pendingNestedEvent's doc comment for why this
+// exists (#450). Tests only; nil (the zero value) in normal operation.
+func (d *DeviceState) SetPendingNestedEvent(event []byte) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.pendingNestedEvent = event
+}
+
+// TakePendingNestedEvent returns and clears the pending nested event, if any.
+// Called by the Switch.Set emulation in run.go; consuming it here (rather
+// than leaving it for the caller to clear) guarantees it fires at most once
+// even if TakePendingNestedEvent is called from more than one nested call.
+func (d *DeviceState) TakePendingNestedEvent() ([]byte, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.pendingNestedEvent == nil {
+		return nil, false
+	}
+	event := d.pendingNestedEvent
+	d.pendingNestedEvent = nil
+	return event, true
 }
 
 // GetStorage returns a snapshot of the Script.storage map.

--- a/pkg/shelly/script/run.go
+++ b/pkg/shelly/script/run.go
@@ -171,8 +171,11 @@ func createShellyRuntime(ctx context.Context, mc mqtt.Client, handlers *[]handle
 	// Shelly event handler system
 	eh := NewEventsHandler(ctx, vm)
 
-	// Define methods map with access to deviceState
-	methods := createMethodsMap(deviceState)
+	// Define methods map with access to deviceState. ctx/vm/eh let Switch.Set
+	// deliver a test-armed nested event (see DeviceState.pendingNestedEvent
+	// and #450) synchronously from inside the call, before invoking the
+	// script's own callback.
+	methods := createMethodsMap(ctx, eh, deviceState)
 
 	// Shelly object with all APIs from https://shelly-api-docs.shelly.cloud/gen2/Scripts/ShellyScriptLanguageFeatures#shelly-apis
 	shellyObj := vm.NewObject()
@@ -774,7 +777,8 @@ func scheduleID(v interface{}) int {
 	return -1
 }
 
-func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
+func createMethodsMap(ctx context.Context, eh *eventsHandler, deviceState *DeviceState) map[string]methodFunc {
+	log, _ := logr.FromContext(ctx)
 	return map[string]methodFunc{
 		"shelly.detectlocation": func(vm *goja.Runtime, method string, params goja.Value, callback goja.Value, userdata goja.Value) (interface{}, error) {
 			// emulate https://shelly-api-docs.shelly.cloud/gen2/ComponentsAndServices/Shelly#shellydetectlocation
@@ -1057,6 +1061,22 @@ func createMethodsMap(deviceState *DeviceState) map[string]methodFunc {
 			// Trigger auto-save if callback is set
 			if deviceState.OnModified != nil {
 				deviceState.OnModified()
+			}
+
+			// #450: if a test armed a nested event (DeviceState.pendingNestedEvent),
+			// deliver it to the script's event handlers now — synchronously,
+			// nested inside this very Switch.Set call and BEFORE its own
+			// callback fires. This reproduces a real device's ability to
+			// dispatch a fresh system event while a previous RPC's native
+			// completion handler is still on the stack, which the ordinary
+			// event loop (a Go `select` over EventInjector) cannot: that loop
+			// only ever dequeues the next event after the previous handler has
+			// fully returned. See DeviceState.pendingNestedEvent for the full
+			// rationale.
+			if nested, ok := deviceState.TakePendingNestedEvent(); ok {
+				if err := eh.Handle(ctx, vm, nested); err != nil {
+					log.Error(err, "Nested event dispatch failed (#450 test hook)")
+				}
 			}
 
 			if !goja.IsUndefined(callback) && !goja.IsNull(callback) {


### PR DESCRIPTION
## The crash

Five crashes on real hardware. `pool-pump.js` died with `Too much recursion - the stack is about to overflow`, **leaving the pump running**. The 2026-08-11 18:26:32 crash on `filtration-hiver` was captured over UDP with the full chain, including — for the first time — the originating event:

```
in function "acquireCallSlot"   called from ...allDone,acquireCallSlot(n,s))
in function "call"              called from ...("Switch.Set",{id:e,on:t},n)
in function "setOutput"         called from ...tput=-1,saveState(),t&&t()});return}setOutput(0,!0,function(...
in function "activateOutput"    called from ... water supply protection")})):(log("Water supply OFF - resto...
in function "handleWaterSupply" called from log("Input event:",e),e.id===0&&handleWaterSupply(e.state)
in function "handleInputEvent"  called from ...
```

`JS Error [9] ... used=1067 peak=1553 total=1222` — an **interpreter stack** overflow, not heap exhaustion. ~8.6 KB of heap was free; this is unrelated to #433.

**Mechanism — a rapid water-supply flap:** `input:0` goes false, the restore path fires an async `Switch.Set`, then `input:0` goes true again before it completes; the second event's `setOutput` re-enters *inside the first one's callback* and nests until the stack is gone. `acquireCallSlot` is the victim, not the cause — merely the deepest frame when the budget runs out, which is what sent earlier attempts in the wrong direction.

## Why the existing guard never caught it

`MAX_CALL_DEPTH = 3` (#460, retained via #461) bounds nesting through `sharedCallDone`, the RPC **completion** path. This recursion arrives through the **event** path, which never consults `CALL_DEPTH`. #460 shipped, was verified live, and the crash continued.

## Fix

`handleWaterSupply` is now re-entrancy safe, using an in-flight transition marker plus a `queueTask` hop — **not** a deeper depth cap:

- `WATER_SUPPLY_TRANSITION_PENDING` / `WATER_SUPPLY_PENDING_APPLY` track a transition in progress.
- An event arriving mid-transition no longer calls `activateOutput()` again — the actual recursion trigger. It records the latest state and returns.
- The work moved into `startWaterSupplyTransition()`; `finishWaterSupplyTransition()` runs from the in-flight transition's own callback and applies any newer state via `queueTask(...)`, **never inline**, so the follow-up runs on a fresh stack.

The final output therefore matches the **last observed** input state — a flap ending "protection active" leaves the pump off, one ending "clear" leaves it restored. The second event is coalesced, not dropped.

## Emulator fidelity gap — found and fixed

The emulator could not reproduce this at all: its event loop ran each event's JS handler **to completion** before dequeuing the next, so nesting was impossible by construction. Added `DeviceState.SetPendingNestedEvent` / `TakePendingNestedEvent` and wired `Switch.Set` to deliver an armed nested event *synchronously, inside the call, before invoking the script's callback* — reproducing exactly where the live trace shows the second event landing.

This is the fifth emulator-vs-hardware gap found in this campaign, after `Schedule.Update` missing, `Switch.Set` emitting no events, `KVS.List`'s wrong signature, and unsynchronised state maps.

## Tests

- `TestPoolPump_WaterSupplyFlapFalseThenTrue` and `...TrueThenFalse` — both orderings. **Verified to fail without the JS fix** (stashed): they settle on the wrong `active-output` (`0` instead of `-1`, and `-1` instead of `0`), the predicted bookkeeping/hardware divergence.
  One caveat worth recording: the first version of these tests was a **false positive** — it asserted against a value equal to the stale pre-flap state, so `waitFor` matched immediately without giving the queued follow-up a chance to run. Fixed by settling before asserting.
- `TestPoolPump_DailyCheckRunsDuringWaterSupplyProtection` — covers the aftermath defect from #450: after the crash-restart, `Daily check event` → `Water supply protection active, ignoring event` left the device on a **winter schedule in August**. Verdict: fixed here rather than filed separately, because `handleDailyCheck()`'s guard was redundant — `doStart()`/`doStop()` already re-check live water-supply state. Verified by reinstating the old guard: the test times out with `schedule-mode` stuck on `"winter"`.

Full `-race` run of `internal/shelly/scripts` + `pkg/shelly/script`: green, 262.5s.

Shelly JS constraints checked on the diff: no `let`/`const`, no empty catch blocks, no `!== undefined` property checks.

## Merge order

**Conflicts with #472 (issue #469)** — both change `pool-pump.js`. #472 should merge first; this branch will be rebased onto it.

Closes #450.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): make handleWaterSupply re-entrancy safe (#450) ([7fed42b](https://github.com/asnowfix/home-automation/commit/7fed42becb5c49839f5d921659722d5624f18515))
- test(pool-pump): regression-test the #450 daily-check aftermath fix ([bf1c5f1](https://github.com/asnowfix/home-automation/commit/bf1c5f15f719ede118c1c3eff576c49ba529bc65))
<!-- END-AUTO-GENERATED-COMMITS -->