### PR TITLE
fix(pool-pump): log before MQTT.subscribe, not after — script would not start with solar enabled (#474)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,32 @@ Shelly devices run a **modified version of Espruino** JavaScript interpreter. Es
    - ⚠️ `let`/`const` - Supported in Espruino v2.14+, but `var` is safer for compatibility
    - **Recommendation**: Use `var` for maximum compatibility
 
+3. **Never call anything on the line after `MQTT.subscribe()` - CRITICAL**
+   - ⚠️ Calling a function immediately after `MQTT.subscribe()` returns reliably kills the script
+     with `Too much recursion - the stack is about to overflow`, **even with ~23 KB of heap free**
+   - The failing call is only ever the innermost frame in the trace, not the cause. It is simply
+     the first thing to touch the stack on return from the subscribe
+   - Measured on a Pro1 (`mezzanine`, 2026-08-12, issue #474), three controlled arms on
+     byte-verified code:
+
+   ```javascript
+   // BROKEN - crashes init every time, with solar-enabled=true
+   MQTT.subscribe("myhome/energy/solar/available", onSolarAvailable);
+   log("Subscribed to myhome/energy/solar/available");
+
+   // WORKS - the same log call, one line earlier
+   log("Subscribing to myhome/energy/solar/available");
+   MQTT.subscribe("myhome/energy/solar/available", onSolarAvailable);
+
+   // ALSO WORKS - no call after the subscribe at all
+   MQTT.subscribe("myhome/energy/solar/available", onSolarAvailable);
+   ```
+
+   - This cost a full day of production filtration: the pump ran with solar disabled because the
+     script would not start. The emulator cannot catch it - goja has no such stack limit
+   - **Rule**: put any logging *before* the subscribe, and make `MQTT.subscribe()` the last
+     statement in its function
+
 3. **Function Definition Order - CRITICAL**
    - ⚠️ **No hoisting**: Functions must be defined BEFORE they are used
    - This applies to ALL function references, including those passed to callbacks

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1890,8 +1890,16 @@ function onSolarAvailable(topic, message) {
 
 function subscribeSolarAvailable() {
   if (!CONFIG.solarEnabled) return;
+  // Log BEFORE the subscribe, never after. Calling log() on the line
+  // immediately following MQTT.subscribe() reliably kills the script with
+  // "Too much recursion - the stack is about to overflow" on a Pro1, even
+  // with ~23 KB of heap free (#474). Measured on `mezzanine` 2026-08-12:
+  // this exact call after the subscribe crashes init every time; the same
+  // call one line earlier runs fine. log() is only ever the innermost
+  // frame, not the cause -- it is simply the first thing to touch the
+  // stack on return from the subscribe.
+  log("Subscribing to myhome/energy/solar/available");
   MQTT.subscribe("myhome/energy/solar/available", onSolarAvailable);
-  log("Subscribed to myhome/energy/solar/available");
 }
 
 // Hard ceiling (pool volumes/day): pump always stops (and won't solar-start)


### PR DESCRIPTION
## Impact

`pool-pump.js` **would not start at all** with `solar-enabled = true`. The pool pump ran a full day with solar disabled because of this.

```
Uncaught Error: Too much recursion - the stack is about to overflow
 at ...t"?e+=JSON.stringify(n):e+=String(n)}catch(n){e+=String(argu...
in function "log"                     called from ...ome/energy/solar/available")
in function "subscribeSolarAvailable" called from ..."),subscribeSolarAvailable()
in function "setupMQTT"               called from ...enforceOutputState(),setupMQTT(),CONFIG.solarEnabled&&(...
```

## Cause

Calling **anything** on the line immediately after `MQTT.subscribe()` returns kills the script, even with ~23 KB of heap free. `log()` is only ever the innermost frame because it is the first thing to touch the stack on return from the subscribe — it is not the cause.

Measured on `mezzanine` (Shelly Pro1) 2026-08-12. Each arm's bytes were fetched back off the device and hashed, so what was tested is what was running:

| arm | device sha256 | solar | result |
|---|---|---|---|
| unmodified | `ff3826fe…` | on | **crash**, `mem_free 23044` |
| `log()` after subscribe removed | `8da0ddbe…` | on | **runs**, `peak 20440 / free 7392` |
| same `log()` moved **before** subscribe | — | on | **runs**, `peak 20636 / free 5264` |

The middle and last arms isolate it: the identical log call one line earlier is harmless.

## Two earlier diagnoses were wrong

- **Not** the heap growth from #450/#469. The control arm crashes on code containing both, and the +1470 B growth (measured separately on `mezzanine`) is real but unrelated.
- **Not** the retained MQTT message re-entering the handler during subscribe. Arms with the retained value at 0 W, faked at 800 W, and deleted outright all crashed identically.

Both incorrect diagnoses are retracted on #474.

## Fix

Move the log above the subscribe, with a comment recording why, and put the trap in `AGENTS.md` beside the other Shelly JS hazards — **the emulator cannot catch this**, since goja has no equivalent stack limit.

This is deliberately minimal: it removes the sharp edge at the one place we hit it. The general problem — that init does work inline where a re-entrant or stack-hostile context can break it — is the subject of the state-machine study in #475/#476.

## Verification

```
go test -count=1 -run 'TestPoolPump|TestSmokeAllScripts' ./internal/shelly/scripts/...
ok  github.com/asnowfix/home-automation/internal/shelly/scripts  282.685s
```

Plus the on-device arms above. `mezzanine` is currently running the fixed ordering with `solar-enabled = true`.

Closes #474.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- fix(pool-pump): log before MQTT.subscribe, not after (#474) ([f0de5c8](https://github.com/asnowfix/home-automation/commit/f0de5c85734859844e00e5bd8bc61d90b552c0bc))
<!-- END-AUTO-GENERATED-COMMITS -->