### PR TITLE
safety(scripts): wrap task-queue, script.eval and handler entry points so a throw stops killing the script (#480)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,17 @@ So there is no case where skipping the wrapper is justified, including a "quick"
   in a throwaway diagnostic expression is exactly as fatal as a bug in production code. Wrap every
   probe the same way: `(function(){ try { return <expr> } catch(e) { return "ERR:"+e } })()`.
 
+- **Every `Shelly.addEventHandler`/`Shelly.addStatusHandler`/`MQTT.subscribe` callback must be
+  wrapped too** — verified empirically on `mezzanine` (#480): an uncaught throw inside any of these
+  kills the whole script exactly like the unwrapped `queueTask`/`script.eval` cases above. Wrap the
+  callback's body **in place** — `try { ...existing body... } catch (e) { log(...) }` inside the
+  same function — rather than via a wrapping higher-order function. A HOF that returns a new
+  `function(x){ try{fn(x)}catch(e){...} }` adds one call frame to *every* dispatch through it, and
+  the main event dispatcher is typically the busiest handler in a script; on a device already close
+  to its stack ceiling (see the Callback Depth Limits section above), that extra frame can matter.
+  In-place wrapping adds zero call-stack depth. If the callback is a named function rather than an
+  inline one, wrap that function's own body directly.
+
 ### Script Lifecycle Logging
 
 Always add startup and stop logging to Shelly scripts:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,6 +491,60 @@ Rules:
 - After any `Script.Eval` against a production device, re-check `Script.GetStatus` — an eval that
   killed the script leaves it `running: false` and the pump uncontrolled.
 
+#### MANDATORY: never register a bare `script.eval` payload, never send an unwrapped `Script.Eval`
+
+This is the general form of the rule above, and issue #480 made it non-optional after measuring the
+same failure mode in two more places on `mezzanine`:
+
+```
+queueTask(function(){ null.x })            -> script DEAD
+Script.Eval with a bad expression          -> script DEAD ("FACTS" is not defined)
+```
+
+Wrapping loses nothing — the return value survives:
+
+```
+(function(){ try { return String(2+2) } catch(e) { return "ERR:"+e } })()  ->  "4"
+```
+
+So there is no case where skipping the wrapper is justified, including a "quick" ad-hoc probe.
+
+- **Every `Schedule.Create`/`Schedule.Update` job's `code` field must be built by a shared per-script
+  wrapper**, e.g. `pool-pump.js` and `garden.js`'s `wrapScheduleCall(handlerCall)`:
+
+  ```javascript
+  function wrapScheduleCall(handlerCall) {
+    return "(function(){try{" + handlerCall + "}catch(e){log('schedule handler error:',e)}})()";
+  }
+  // ...
+  code: wrapScheduleCall('handleMorningStart()')
+  ```
+
+  Route every registration through that one helper — never build a `code` string by hand at the call
+  site — so a schedule job added later can't slip through unwrapped. If code elsewhere reads the
+  `code` field back off a live `Schedule.List` (to identify which job is which), match by
+  **substring containment** (`code.indexOf('handleX()') !== -1`), not exact equality or prefix —
+  the wrapped field no longer equals the bare handler call.
+
+- **Every queued-task dispatcher must wrap the call it invokes.** Any script defining a `queueTask`/
+  `processTaskQueue` pair (`pool-pump.js`, `garden.js`, `blu-listener.js`) must wrap the single
+  `task()` invocation inside `processTaskQueue`, not each call site — this protects every
+  `queueTask()` caller at once:
+
+  ```javascript
+  var task = TASK_QUEUE[TASK_INDEX];
+  TASK_INDEX++;
+  try {
+    task();
+  } catch (e) {
+    log("queued task error:", e);
+  }
+  ```
+
+- **Never send an unwrapped ad-hoc `Script.Eval` to a live device, including for debugging.** A typo
+  in a throwaway diagnostic expression is exactly as fatal as a bug in production code. Wrap every
+  probe the same way: `(function(){ try { return <expr> } catch(e) { return "ERR:"+e } })()`.
+
 ### Script Lifecycle Logging
 
 Always add startup and stop logging to Shelly scripts:

--- a/internal/shelly/scripts/blu-listener.js
+++ b/internal/shelly/scripts/blu-listener.js
@@ -354,8 +354,15 @@ function onSwitchSetOnResponse(idx, follow, mac, resp, err) {
   else log("Turned on", follow.switchIdStr, "for", mac, "auto_off=", follow.autoOff, "s");
 }
 
+// #480 part 4: an uncaught throw inside an MQTT.subscribe callback kills the
+// whole script (verified live on mezzanine). Wrapped in place -- same
+// function, no new call frame.
 function onMqttMessage(t, m, r) {
-  handleBluEvent(t, m);
+  try {
+    handleBluEvent(t, m);
+  } catch (e) {
+    log("mqtt handler error:", e);
+  }
 }
 
 function subscribeMqtt() {

--- a/internal/shelly/scripts/blu-listener.js
+++ b/internal/shelly/scripts/blu-listener.js
@@ -71,9 +71,15 @@ function processTaskQueue() {
     TASK_INDEX = 0;
     return;
   }
+  // #480: an uncaught throw inside a queued task used to kill the whole
+  // script. Wrapping this single call site protects every queueTask() call.
   var task = TASK_QUEUE[TASK_INDEX];
   TASK_INDEX++;
-  task();
+  try {
+    task();
+  } catch (e) {
+    log("queued task error:", e);
+  }
 }
 
 function queueTask(task) {

--- a/internal/shelly/scripts/garden.js
+++ b/internal/shelly/scripts/garden.js
@@ -1363,19 +1363,25 @@ function init() {
 }
 
 // === EVENT SUBSCRIPTION ===
+// #480 part 4: an uncaught throw inside this handler kills the whole script
+// (verified live on mezzanine). Wrapped in place -- no new call frame added.
 Shelly.addEventHandler(function(event) {
-  if (!event || !event.info) return;
-  var info = event.info;
-  if (info.event === "script_stop") {
-    log("Script stopping");
-    return;
-  }
-  if (typeof info.component === "string") {
-    if (info.component.indexOf("switch:") === 0 && typeof info.state === "boolean") {
-      handleSwitchEvent(info);
-    } else if (info.component === "sys" && info.event === "sys_btn_push") {
-      cycleOutputs();
+  try {
+    if (!event || !event.info) return;
+    var info = event.info;
+    if (info.event === "script_stop") {
+      log("Script stopping");
+      return;
     }
+    if (typeof info.component === "string") {
+      if (info.component.indexOf("switch:") === 0 && typeof info.state === "boolean") {
+        handleSwitchEvent(info);
+      } else if (info.component === "sys" && info.event === "sys_btn_push") {
+        cycleOutputs();
+      }
+    }
+  } catch (e) {
+    log("event handler error:", e);
   }
 });
 

--- a/internal/shelly/scripts/garden.js
+++ b/internal/shelly/scripts/garden.js
@@ -192,9 +192,15 @@ function processTaskQueue() {
     TASK_INDEX = 0;
     return;
   }
+  // #480: an uncaught throw inside a queued task used to kill the whole
+  // script. Wrapping this single call site protects every queueTask() call.
   var task = TASK_QUEUE[TASK_INDEX];
   TASK_INDEX++;
-  task();
+  try {
+    task();
+  } catch (e) {
+    log("queued task error:", e);
+  }
 }
 
 function queueTask(task) {
@@ -739,6 +745,18 @@ function loadWateringQueue() {
 }
 
 // === SCHEDULE MANAGEMENT ===
+
+// #480: every script.eval payload a schedule job carries must be wrapped —
+// an uncaught throw inside an unwrapped handler kills the whole script.
+// Route every registration through this one helper so a future schedule job
+// can never be added unwrapped. The wrapped source always contains
+// handlerCall verbatim, so code that later reads the `code` field back off a
+// live Schedule.List (updatePlanSchedule, verifySchedules below) matches on
+// substring containment rather than exact equality.
+function wrapScheduleCall(handlerCall) {
+  return "(function(){try{" + handlerCall + "}catch(e){log('schedule handler error:',e)}})()";
+}
+
 function updatePlanSchedule(startH) {
   var ts = makeTimespec(startH);
   log("Updating watering schedule to " + ts);
@@ -754,7 +772,9 @@ function updatePlanSchedule(startH) {
       var job = result.jobs[i];
       if (job.calls && job.calls.length > 0) {
         var code = job.calls[0].params && job.calls[0].params.code;
-        if (code === "handleWateringStart()") {
+        // #480: code is wrapScheduleCall()'s wrapped source, not the bare
+        // handler call, so match by containment rather than exact equality.
+        if (code && code.indexOf("handleWateringStart()") !== -1) {
           jobId = job.id;
           break;
         }
@@ -827,12 +847,12 @@ function createSchedules(callback) {
     {
       enable: true,
       timespec: "0 30 0 * * SUN,MON,TUE,WED,THU,FRI,SAT",
-      calls: [{method: "script.eval", params: {id: scriptId, code: "handlePlan()"}}]
+      calls: [{method: "script.eval", params: {id: scriptId, code: wrapScheduleCall("handlePlan()")}}]
     },
     {
       enable: true,
       timespec: fallbackTs,
-      calls: [{method: "script.eval", params: {id: scriptId, code: "handleWateringStart()"}}]
+      calls: [{method: "script.eval", params: {id: scriptId, code: wrapScheduleCall("handleWateringStart()")}}]
     }
   ];
   var sIdx = 0;
@@ -868,8 +888,10 @@ function verifySchedules(cb) {
         var job = result.jobs[i];
         if (job.calls && job.calls.length > 0) {
           var code = job.calls[0].params && job.calls[0].params.code;
-          if (code === "handlePlan()") hasPlan = true;
-          if (code === "handleWateringStart()") hasWater = true;
+          // #480: code is wrapScheduleCall()'s wrapped source, not the bare
+          // handler call, so match by containment rather than exact equality.
+          if (code && code.indexOf("handlePlan()") !== -1) hasPlan = true;
+          if (code && code.indexOf("handleWateringStart()") !== -1) hasWater = true;
         }
       }
     }

--- a/internal/shelly/scripts/garden_test.go
+++ b/internal/shelly/scripts/garden_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -64,6 +65,169 @@ func gardenVM(t *testing.T) *goja.Runtime {
 	}
 
 	return vm
+}
+
+// gardenVMWithScheduleList extends gardenVM's stub set with a Shelly.call
+// that answers "Schedule.List" from a caller-supplied job list and records
+// every "Schedule.Update" call, a Timer stub that runs queueTask()'s
+// deferred callback synchronously (updatePlanSchedule() and verifySchedules()
+// both finish through the task queue, and there is no real event loop here),
+// and a print() stub that captures log lines so a test can distinguish
+// "Garden schedules verified" from "FATAL: Garden schedules missing" without
+// a live device.
+//
+// Used by the #480 regression tests below to prove updatePlanSchedule() and
+// verifySchedules() still find their jobs once the `code` field carries
+// wrapScheduleCall()'s wrapped source instead of the bare handler call.
+func gardenVMWithScheduleList(t *testing.T) (vm *goja.Runtime, setJobs func([]map[string]interface{}), updates *[]map[string]interface{}, logLines *[]string) {
+	t.Helper()
+
+	buf, err := os.ReadFile(gardenScriptPath)
+	if err != nil {
+		t.Fatalf("failed to read garden.js: %v", err)
+	}
+
+	vm = goja.New()
+	var jobs []map[string]interface{}
+	var updatesSlice []map[string]interface{}
+	var lines []string
+
+	shellyObj := vm.NewObject()
+	shellyObj.Set("call", func(call goja.FunctionCall) goja.Value {
+		method := call.Argument(0).String()
+		cb, _ := goja.AssertFunction(call.Argument(2))
+		switch method {
+		case "Schedule.List":
+			result := map[string]interface{}{"jobs": jobs}
+			if cb != nil {
+				if _, err := cb(goja.Undefined(), vm.ToValue(result), goja.Undefined()); err != nil {
+					t.Fatalf("Schedule.List callback: %v", err)
+				}
+			}
+		case "Schedule.Update":
+			params, _ := call.Argument(1).Export().(map[string]interface{})
+			updatesSlice = append(updatesSlice, params)
+			if cb != nil {
+				if _, err := cb(goja.Undefined(), goja.Undefined(), goja.Undefined()); err != nil {
+					t.Fatalf("Schedule.Update callback: %v", err)
+				}
+			}
+		}
+		return goja.Undefined()
+	})
+	shellyObj.Set("addEventHandler", func(call goja.FunctionCall) goja.Value { return goja.Undefined() })
+	shellyObj.Set("getCurrentScriptId", func(call goja.FunctionCall) goja.Value { return vm.ToValue(1) })
+	vm.Set("Shelly", shellyObj)
+
+	vm.Set("print", func(call goja.FunctionCall) goja.Value {
+		lines = append(lines, call.Argument(0).String())
+		return goja.Undefined()
+	})
+
+	timerObj := vm.NewObject()
+	timerObj.Set("set", func(call goja.FunctionCall) goja.Value {
+		fn, _ := goja.AssertFunction(call.Argument(2))
+		if fn != nil {
+			if _, err := fn(goja.Undefined()); err != nil {
+				t.Fatalf("Timer.set callback: %v", err)
+			}
+		}
+		return vm.ToValue(1)
+	})
+	timerObj.Set("clear", func(call goja.FunctionCall) goja.Value { return goja.Undefined() })
+	vm.Set("Timer", timerObj)
+
+	storage := make(map[string]string)
+	storageObj := vm.NewObject()
+	storageObj.Set("getItem", func(call goja.FunctionCall) goja.Value {
+		if v, ok := storage[call.Argument(0).String()]; ok {
+			return vm.ToValue(v)
+		}
+		return goja.Null()
+	})
+	storageObj.Set("setItem", func(call goja.FunctionCall) goja.Value {
+		storage[call.Argument(0).String()] = call.Argument(1).String()
+		return goja.Undefined()
+	})
+	scriptObj := vm.NewObject()
+	scriptObj.Set("storage", storageObj)
+	vm.Set("Script", scriptObj)
+
+	if _, err := vm.RunString(string(buf)); err != nil {
+		t.Fatalf("garden.js failed to load: %v", err)
+	}
+
+	return vm, func(j []map[string]interface{}) { jobs = j }, &updatesSlice, &lines
+}
+
+// gardenWrappedJob builds a Schedule.List job entry whose script.eval code is
+// wrapScheduleCall(handlerCall)'d, mirroring what a live device carries after
+// #480's createSchedules() change.
+func gardenWrappedJob(id int, handlerCall, timespec string) map[string]interface{} {
+	wrapped := "(function(){try{" + handlerCall + "}catch(e){log('schedule handler error:',e)}})()"
+	return map[string]interface{}{
+		"id": id, "enable": true, "timespec": timespec,
+		"calls": []interface{}{map[string]interface{}{
+			"method": "script.eval",
+			"params": map[string]interface{}{"id": 1, "code": wrapped},
+		}},
+	}
+}
+
+// TestGarden_UpdatePlanSchedule_MatchesWrappedCode is the #480 regression
+// guard for updatePlanSchedule(): with the handleWateringStart() job's code
+// field wrapped (as garden.js's own createSchedules() now writes it), the
+// job must still be found by id and rewritten. Before the substring-match
+// fix this silently no-ops (jobId stays -1, "WARNING: handleWateringStart()
+// schedule not found", no Schedule.Update call) instead of erroring loudly.
+func TestGarden_UpdatePlanSchedule_MatchesWrappedCode(t *testing.T) {
+	vm, setJobs, updates, logLines := gardenVMWithScheduleList(t)
+
+	setJobs([]map[string]interface{}{
+		gardenWrappedJob(1, "handlePlan()", "0 30 0 * * SUN,MON,TUE,WED,THU,FRI,SAT"),
+		gardenWrappedJob(7, "handleWateringStart()", "0 0 5 * * SUN,MON,TUE,WED,THU,FRI,SAT"),
+	})
+
+	mustEval(t, vm, `updatePlanSchedule(6)`)
+
+	if len(*updates) != 1 {
+		t.Fatalf("expected exactly 1 Schedule.Update call, got %d (log: %v)", len(*updates), *logLines)
+	}
+	got := (*updates)[0]
+	if id, _ := got["id"].(int64); id != 7 {
+		t.Errorf("expected Schedule.Update on job id 7 (the wrapped handleWateringStart() job), got id=%v", got["id"])
+	}
+	wantTs := "0 0 6 * * SUN,MON,TUE,WED,THU,FRI,SAT"
+	if ts, _ := got["timespec"].(string); ts != wantTs {
+		t.Errorf("expected timespec %q, got %q", wantTs, ts)
+	}
+}
+
+// TestGarden_VerifySchedules_MatchesWrappedCode is the #480 regression guard
+// for verifySchedules(): with both jobs' code fields wrapped, it must log
+// success ("Garden schedules verified"), not the FATAL missing-schedules
+// message, and cb must still run.
+func TestGarden_VerifySchedules_MatchesWrappedCode(t *testing.T) {
+	vm, setJobs, _, logLines := gardenVMWithScheduleList(t)
+
+	setJobs([]map[string]interface{}{
+		gardenWrappedJob(1, "handlePlan()", "0 30 0 * * SUN,MON,TUE,WED,THU,FRI,SAT"),
+		gardenWrappedJob(2, "handleWateringStart()", "0 0 5 * * SUN,MON,TUE,WED,THU,FRI,SAT"),
+	})
+
+	mustEval(t, vm, `var __cbRan = false; verifySchedules(function() { __cbRan = true; });`)
+
+	if ran := mustEval(t, vm, `__cbRan`).ToBoolean(); !ran {
+		t.Fatalf("verifySchedules() callback never ran (log: %v)", *logLines)
+	}
+
+	joined := strings.Join(*logLines, "\n")
+	if strings.Contains(joined, "FATAL") {
+		t.Errorf("verifySchedules() reported schedules missing with wrapped code (log: %v)", *logLines)
+	}
+	if !strings.Contains(joined, "Garden schedules verified") {
+		t.Errorf("expected \"Garden schedules verified\" in log, got: %v", *logLines)
+	}
 }
 
 func mustEval(t *testing.T, vm *goja.Runtime, code string) goja.Value {

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -630,9 +630,17 @@ function processTaskQueue() {
 
   // Execute next task; new tasks queued by the task itself extend TASK_QUEUE
   // and will be picked up on subsequent timer ticks.
+  // #480: an uncaught throw inside a queued task used to kill the whole
+  // script (verified live on mezzanine: queueTask(function(){ null.x })
+  // stopped the script). Wrapping this single call site protects every
+  // queueTask() call in the script.
   var task = TASK_QUEUE[TASK_INDEX];
   TASK_INDEX++;
-  task();
+  try {
+    task();
+  } catch (e) {
+    log("queued task error:", e);
+  }
 }
 
 function queueTask(task) {
@@ -2056,6 +2064,19 @@ function clearNonUpdateSchedules(callback) {
   });
 }
 
+// #480: every script.eval payload a schedule job carries must be wrapped —
+// an uncaught throw inside an unwrapped handler kills the whole script
+// (verified live on mezzanine: an ad-hoc bad Script.Eval killed the running
+// script with a ReferenceError). Route every registration through this one
+// helper so a future schedule job can never be added unwrapped. The wrapped
+// source always contains handlerCall verbatim, so code that later reads the
+// `code` field back off a live Schedule.List (isWithinRunWindow,
+// updateScheduleMode, verifySchedules below) matches on substring
+// containment rather than exact/prefix equality.
+function wrapScheduleCall(handlerCall) {
+  return "(function(){try{" + handlerCall + "}catch(e){log('schedule handler error:',e)}})()";
+}
+
 function createSchedules(callback) {
   log('Creating pool pump schedules...');
 
@@ -2069,7 +2090,7 @@ function createSchedules(callback) {
         method: 'script.eval',
         params: {
           id: scriptId,
-          code: 'handleDailyCheck()'
+          code: wrapScheduleCall('handleDailyCheck()')
         }
       }]
     },
@@ -2080,7 +2101,7 @@ function createSchedules(callback) {
         method: 'script.eval',
         params: {
           id: scriptId,
-          code: 'handleMorningStart()'
+          code: wrapScheduleCall('handleMorningStart()')
         }
       }]
     },
@@ -2091,7 +2112,7 @@ function createSchedules(callback) {
         method: 'script.eval',
         params: {
           id: scriptId,
-          code: 'handleEveningStop()'
+          code: wrapScheduleCall('handleEveningStop()')
         }
       }]
     },
@@ -2102,7 +2123,7 @@ function createSchedules(callback) {
         method: 'script.eval',
         params: {
           id: scriptId,
-          code: 'handleNightStart()'
+          code: wrapScheduleCall('handleNightStart()')
         }
       }]
     },
@@ -2113,7 +2134,7 @@ function createSchedules(callback) {
         method: 'script.eval',
         params: {
           id: scriptId,
-          code: 'handleNightStop()'
+          code: wrapScheduleCall('handleNightStop()')
         }
       }]
     }
@@ -2160,7 +2181,10 @@ function verifySchedules(cb) {
         var job = result.jobs[i];
         if (job.calls && job.calls.length > 0 && job.calls[0].method === 'script.eval') {
           var code = job.calls[0].params && job.calls[0].params.code;
-          if (code && (code.indexOf('handleNight') === 0 || code.indexOf('handleDaily') === 0 || code.indexOf('handleMorning') === 0 || code.indexOf('handleEvening') === 0)) {
+          // #480: code carries wrapScheduleCall()'s wrapper boilerplate, not
+          // just the bare handler call, so match by containment rather than
+          // by prefix.
+          if (code && (code.indexOf('handleNight') !== -1 || code.indexOf('handleDaily') !== -1 || code.indexOf('handleMorning') !== -1 || code.indexOf('handleEvening') !== -1)) {
             hasPoolSchedules = true;
             break;
           }
@@ -2281,8 +2305,10 @@ function isWithinRunWindow(cb) {
       var job = result.jobs[i];
       if (!job.enable || !job.calls || job.calls.length === 0) continue;
       var code = job.calls[0].params && job.calls[0].params.code;
-      if (code === sc) a = parseHM(job.timespec);
-      else if (code === ec) b = parseHM(job.timespec);
+      // #480: code is wrapScheduleCall()'s wrapped source, not the bare
+      // handler call, so match by containment rather than exact equality.
+      if (code && code.indexOf(sc) !== -1) a = parseHM(job.timespec);
+      else if (code && code.indexOf(ec) !== -1) b = parseHM(job.timespec);
     }
 
     if (a === null || b === null) { cb(null); return; }
@@ -2343,22 +2369,26 @@ function updateScheduleMode(newMode, morningStartHours, eveningStopHours) {
       var job = result.jobs[i];
       if (job.calls && job.calls.length > 0) {
         var code = job.calls[0].params && job.calls[0].params.code;
-        if (code === 'handleMorningStart()') {
-          var updM = {id: job.id, enable: newMode === 'summer', name: code};
+        // #480: code is wrapScheduleCall()'s wrapped source, not the bare
+        // handler call, so match by containment. `name` is set to the short
+        // handler literal (not the matched `code`) so log lines stay
+        // readable instead of printing the whole wrapper.
+        if (code && code.indexOf('handleMorningStart()') !== -1) {
+          var updM = {id: job.id, enable: newMode === 'summer', name: 'handleMorningStart()'};
           if (hasTimings && newMode === 'summer') {
             updM.timespec = makeTimespec(morningStartHours);
           }
           if (moves(job, updM)) windowChanged = true;
           schedulesToUpdate.push(updM);
-        } else if (code === 'handleEveningStop()') {
-          var updE = {id: job.id, enable: newMode === 'summer', name: code};
+        } else if (code && code.indexOf('handleEveningStop()') !== -1) {
+          var updE = {id: job.id, enable: newMode === 'summer', name: 'handleEveningStop()'};
           if (hasTimings && newMode === 'summer') {
             updE.timespec = makeTimespec(eveningStopHours);
           }
           if (moves(job, updE)) windowChanged = true;
           schedulesToUpdate.push(updE);
-        } else if (code === 'handleNightStart()' || code === 'handleNightStop()') {
-          var updN = {id: job.id, enable: newMode === 'winter', name: code};
+        } else if (code && (code.indexOf('handleNightStart()') !== -1 || code.indexOf('handleNightStop()') !== -1)) {
+          var updN = {id: job.id, enable: newMode === 'winter', name: code.indexOf('handleNightStart()') !== -1 ? 'handleNightStart()' : 'handleNightStop()'};
           if (moves(job, updN)) windowChanged = true;
           schedulesToUpdate.push(updN);
         }

--- a/internal/shelly/scripts/pool-pump.js
+++ b/internal/shelly/scripts/pool-pump.js
@@ -1875,25 +1875,33 @@ var SOLAR = {
   tickTimer: null
 };
 
+// #480 part 4: an uncaught throw inside an MQTT.subscribe callback kills the
+// whole script (verified live on mezzanine with a real publish to a test
+// topic). Wrapped in place -- same function, no new call frame, so dispatch
+// isn't deeper than before.
 function onSolarAvailable(topic, message) {
-  var data = null;
   try {
-    data = JSON.parse(message);
+    var data = null;
+    try {
+      data = JSON.parse(message);
+    } catch (e) {
+      if (e && false) {}
+      return;
+    }
+    if (!data || typeof data.available_w !== "number") return;
+
+    SOLAR.availableW = data.available_w;
+    SOLAR.lastMsgTs = Date.now();
+    // ts is unix-epoch-seconds; convert to ms to compare against Date.now().
+    // This is the field staleness decisions are based on — see comment above.
+    if (typeof data.ts === "number") {
+      SOLAR.publishedTs = data.ts * 1000;
+    }
+
+    checkSolarHysteresis();
   } catch (e) {
-    if (e && false) {}
-    return;
+    log("mqtt handler error:", e);
   }
-  if (!data || typeof data.available_w !== "number") return;
-
-  SOLAR.availableW = data.available_w;
-  SOLAR.lastMsgTs = Date.now();
-  // ts is unix-epoch-seconds; convert to ms to compare against Date.now().
-  // This is the field staleness decisions are based on — see comment above.
-  if (typeof data.ts === "number") {
-    SOLAR.publishedTs = data.ts * 1000;
-  }
-
-  checkSolarHysteresis();
 }
 
 function subscribeSolarAvailable() {
@@ -2781,30 +2789,41 @@ function finishContinueInit() {
 }
 
 // === EVENT SUBSCRIPTION ===
+// #480 part 4: an uncaught throw inside this handler kills the whole script
+// (verified live on mezzanine: a throwing addEventHandler callback, triggered
+// by a real Switch.Set, crashed the script identically to the unwrapped
+// queueTask/script.eval cases). Wrapped in place -- no extra function layer
+// around the callback, so dispatch adds no new call frame; every event still
+// goes through exactly the frames it did before, just with a try/catch
+// around the existing body.
 Shelly.addEventHandler(function(event) {
-  if (!event || !event.info) return;
-  
-  var info = event.info;
-  
-  // Handle script stop event
-  if (info.event === "script_stop") {
-    log("Script stopping");
-    return;
-  }
-  
-  // Handle component events
-  if (typeof info.component === "string") {
-    if (info.component.indexOf("switch:") === 0 && typeof info.state === "boolean") {
-      handleSwitchEvent(info);
-    } else if (info.component.indexOf("input:") === 0 && typeof info.state === "boolean") {
-      handleInputEvent(info);
-    } else if (info.component === "sys" && info.event === "sys_btn_push") {
-      handleButtonEvent(info);
-    } else {
-      log("Unhandled component event:", JSON.stringify(info));
+  try {
+    if (!event || !event.info) return;
+
+    var info = event.info;
+
+    // Handle script stop event
+    if (info.event === "script_stop") {
+      log("Script stopping");
+      return;
     }
-  } else {
-    log("Unhandled event:", JSON.stringify(info));
+
+    // Handle component events
+    if (typeof info.component === "string") {
+      if (info.component.indexOf("switch:") === 0 && typeof info.state === "boolean") {
+        handleSwitchEvent(info);
+      } else if (info.component.indexOf("input:") === 0 && typeof info.state === "boolean") {
+        handleInputEvent(info);
+      } else if (info.component === "sys" && info.event === "sys_btn_push") {
+        handleButtonEvent(info);
+      } else {
+        log("Unhandled component event:", JSON.stringify(info));
+      }
+    } else {
+      log("Unhandled event:", JSON.stringify(info));
+    }
+  } catch (e) {
+    log("event handler error:", e);
   }
 });
 

--- a/internal/shelly/scripts/pool_pump_test.go
+++ b/internal/shelly/scripts/pool_pump_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -247,6 +248,96 @@ func TestPoolPump_InitVerifiesSchedules(t *testing.T) {
 
 	if !ok {
 		t.Fatalf("timed out waiting for init to complete")
+	}
+}
+
+// poolPumpSchedulesWrapped is poolPumpSchedules with every job's code field
+// passed through poolPumpWrapScheduleCall — the shape a real device carries
+// once createSchedules() has registered #480-wrapped jobs.
+func poolPumpSchedulesWrapped() []map[string]interface{} {
+	scriptID := 1
+	wrap := func(code string) string { return poolPumpWrapScheduleCall(code) }
+	return []map[string]interface{}{
+		{
+			"id": 1, "enable": true,
+			"timespec": "@sunrise * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": scriptID, "code": wrap("handleDailyCheck()")},
+			}},
+		},
+		{
+			"id": 2, "enable": true,
+			"timespec": "@sunrise+3h * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": scriptID, "code": wrap("handleMorningStart()")},
+			}},
+		},
+		{
+			"id": 3, "enable": true,
+			"timespec": "@sunset * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": scriptID, "code": wrap("handleEveningStop()")},
+			}},
+		},
+		{
+			"id": 4, "enable": true,
+			"timespec": "0 15 23 * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": scriptID, "code": wrap("handleNightStart()")},
+			}},
+		},
+		{
+			"id": 5, "enable": true,
+			"timespec": "0 15 0 * * SUN,MON,TUE,WED,THU,FRI,SAT",
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": scriptID, "code": wrap("handleNightStop()")},
+			}},
+		},
+	}
+}
+
+// TestPoolPump_InitVerifiesWrappedSchedules is TestPoolPump_InitVerifiesSchedules
+// with #480-wrapped schedule code. verifySchedules() is the last of init's four
+// steps (finishContinueInit()'s initSteps) and init stalls forever if it fails
+// to recognize the wrapped jobs, so this fails by timeout if the substring
+// match in verifySchedules() regresses back to the old prefix-equality check.
+func TestPoolPump_InitVerifiesWrappedSchedules(t *testing.T) {
+	buf := readPoolPumpScript(t)
+
+	mqtt.ResetClient()
+	mqtt.SetClient(mqtt.NewMockClient())
+	t.Cleanup(mqtt.ResetClient)
+
+	ctx, cancel := poolPumpRunContext(t)
+	defer cancel()
+
+	deviceState := &script.DeviceState{
+		KVS:             controllerKVS(),
+		Storage:         make(map[string]interface{}),
+		ComponentStatus: pro3ComponentStatus(),
+		Schedules:       poolPumpSchedulesWrapped(),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- script.RunWithDeviceState(ctx, "pool-pump.js", buf, false, deviceState)
+	}()
+
+	ok := waitFor(initTimeout, 200*time.Millisecond, func() bool {
+		_, exists := deviceState.KVSValue("script/pool-pump/schedule-mode")
+		return exists
+	})
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatalf("timed out waiting for init to complete with wrapped schedule code -- " +
+			"verifySchedules() likely regressed from substring match back to exact/prefix match")
 	}
 }
 
@@ -1644,9 +1735,15 @@ func poolPumpSummerSchedules(start, stop time.Time) []map[string]interface{} {
 }
 
 // poolPumpScheduleTimespec reads back the timespec currently on the job whose
-// script.eval code matches, so a test can prove the rewrite actually landed
-// before asserting on what the rewrite should have caused.
-func poolPumpScheduleTimespec(schedules []map[string]interface{}, code string) string {
+// script.eval code contains handlerCall, so a test can prove the rewrite
+// actually landed before asserting on what the rewrite should have caused.
+//
+// Matches by substring, not equality: #480 wraps every registered code field
+// in wrapScheduleCall()'s try/catch boilerplate, so a live (or
+// wrapped-fixture) job's code is never exactly "handleMorningStart()" — it
+// contains it. Plain unwrapped fixtures used elsewhere still match, since a
+// string trivially contains itself.
+func poolPumpScheduleTimespec(schedules []map[string]interface{}, handlerCall string) string {
 	for _, job := range schedules {
 		calls, ok := job["calls"].([]interface{})
 		if !ok || len(calls) == 0 {
@@ -1657,7 +1754,11 @@ func poolPumpScheduleTimespec(schedules []map[string]interface{}, code string) s
 			continue
 		}
 		params, ok := call["params"].(map[string]interface{})
-		if !ok || params["code"] != code {
+		if !ok {
+			continue
+		}
+		code, ok := params["code"].(string)
+		if !ok || !strings.Contains(code, handlerCall) {
 			continue
 		}
 		if ts, ok := job["timespec"].(string); ok {
@@ -1665,6 +1766,37 @@ func poolPumpScheduleTimespec(schedules []map[string]interface{}, code string) s
 		}
 	}
 	return ""
+}
+
+// poolPumpWrapScheduleCall mirrors pool-pump.js's wrapScheduleCall() exactly,
+// so Go fixtures can seed Schedule.List with the same wrapped source a live
+// device carries after #480 — proving isWithinRunWindow(),
+// updateScheduleMode() and verifySchedules() still recognize handler jobs by
+// substring once the code field is no longer the bare handler call.
+func poolPumpWrapScheduleCall(handlerCall string) string {
+	return "(function(){try{" + handlerCall + "}catch(e){log('schedule handler error:',e)}})()"
+}
+
+// poolPumpSummerSchedulesWrapped is poolPumpSummerSchedules with every job's
+// code field passed through poolPumpWrapScheduleCall — the shape a real
+// device carries once createSchedules() has registered #480-wrapped jobs.
+func poolPumpSummerSchedulesWrapped(start, stop time.Time) []map[string]interface{} {
+	job := func(id int, code, timespec string, enable bool) map[string]interface{} {
+		return map[string]interface{}{
+			"id": id, "enable": enable, "timespec": timespec,
+			"calls": []interface{}{map[string]interface{}{
+				"method": "script.eval",
+				"params": map[string]interface{}{"id": 1, "code": poolPumpWrapScheduleCall(code)},
+			}},
+		}
+	}
+	return []map[string]interface{}{
+		job(1, "handleDailyCheck()", "@sunrise * * SUN,MON,TUE,WED,THU,FRI,SAT", true),
+		job(2, "handleMorningStart()", poolPumpTimespec(start.Hour(), start.Minute()), true),
+		job(3, "handleEveningStop()", poolPumpTimespec(stop.Hour(), stop.Minute()), true),
+		job(4, "handleNightStart()", poolPumpTimespec(23, 15), false),
+		job(5, "handleNightStop()", poolPumpTimespec(0, 15), false),
+	}
 }
 
 // poolPumpRewriteResult runs the script against the given fixture, waits for
@@ -1875,6 +2007,80 @@ func TestPoolPump_ScheduleRewriteOutsideWindowDoesNotStartPump(t *testing.T) {
 	if got != "-1" {
 		t.Fatalf("now is outside the rewritten window: "+
 			"expected the pump to stay off (active-output=-1), got %q", got)
+	}
+}
+
+// #480 regression guards: everything above this point seeds Schedule.List
+// with bare handler-name code strings. A live device running the wrapped
+// createSchedules() never has that — every code field is
+// wrapScheduleCall()'s try/catch boilerplate around the handler call. These
+// two tests are TestPoolPump_ScheduleRewriteIntoPastStartsPump and
+// TestPoolPump_ScheduleRewriteAwayStopsPump verbatim, except the fixture is
+// poolPumpSummerSchedulesWrapped instead of poolPumpSummerSchedules — proving
+// isWithinRunWindow() (the #441 predicate) and updateScheduleMode()'s job
+// matching both still resolve a real answer, not null, once matching moved
+// from exact/prefix equality to substring containment. If either regresses
+// back to exact-match, isWithinRunWindow() silently returns null ("don't
+// know") for every job and these tests fail by leaving the pump in the wrong
+// state instead of erroring loudly — exactly the #441 failure shape.
+func TestPoolPump_WrappedScheduleCode_IsWithinRunWindowStartsPump(t *testing.T) {
+	skipUnlessNowInside(t, poolPumpWideStartMin, poolPumpWideStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpWidePeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpWideRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: pro1ComponentStatus(), // pump off
+		// Old window: the start is still ahead of us, so nothing was due yet.
+		Schedules: poolPumpSummerSchedulesWrapped(now.Add(2*time.Hour), now.Add(4*time.Hour)),
+	}
+
+	got, schedules := poolPumpRewriteResult(t, deviceState, "0")
+
+	if ts := poolPumpScheduleTimespec(schedules, "handleMorningStart()"); ts != poolPumpTimespec(1, 0) {
+		t.Fatalf("updateScheduleMode() failed to find/rewrite the wrapped morning-start job: "+
+			"expected 01:00, got %q", ts)
+	}
+	if got != "0" {
+		t.Fatalf("isWithinRunWindow() failed to resolve a wrapped-code schedule: "+
+			"expected the pump to start (active-output=0), got %q", got)
+	}
+}
+
+func TestPoolPump_WrappedScheduleCode_IsWithinRunWindowStopsPump(t *testing.T) {
+	skipIfNowInside(t, poolPumpNarrowStartMin, poolPumpNarrowStopMin)
+
+	srv := poolPumpForecastServer(t, poolPumpNarrowPeakHour, "00:00", "23:59")
+	now := time.Now()
+
+	cs := pro1ComponentStatus()
+	cs["switch:0"] = map[string]interface{}{"id": 0, "output": true} // running
+
+	deviceState := &script.DeviceState{
+		KVS: poolPumpWindowKVS(poolPumpNarrowRunHours),
+		Storage: map[string]interface{}{
+			"schedule-mode": "summer",
+			"forecast-url":  srv.URL + "?daily=sunrise,sunset",
+		},
+		ComponentStatus: cs,
+		// Old window contains "now", which is why the pump is running.
+		Schedules: poolPumpSummerSchedulesWrapped(now.Add(-1*time.Hour), now.Add(1*time.Hour)),
+	}
+
+	got, schedules := poolPumpRewriteResult(t, deviceState, "-1")
+
+	if ts := poolPumpScheduleTimespec(schedules, "handleMorningStart()"); ts != poolPumpTimespec(1, 57) {
+		t.Fatalf("updateScheduleMode() failed to find/rewrite the wrapped morning-start job: "+
+			"expected 01:57, got %q", ts)
+	}
+	if got != "-1" {
+		t.Fatalf("isWithinRunWindow() failed to resolve a wrapped-code schedule: "+
+			"expected the running pump to stop (active-output=-1), got %q", got)
 	}
 }
 

--- a/internal/shelly/scripts/schedule_wrap_test.go
+++ b/internal/shelly/scripts/schedule_wrap_test.go
@@ -1,0 +1,135 @@
+package scripts
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// wrapScheduleCallCallRe extracts the handlerCall argument from every
+// wrapScheduleCall('...') / wrapScheduleCall("...") call site in a script's
+// source, so this test tracks whatever handler names are actually registered
+// instead of a hand-maintained list that can silently go stale.
+var wrapScheduleCallCallRe = regexp.MustCompile(`wrapScheduleCall\(\s*['"]([^'"]+)['"]\s*\)`)
+
+// registeredHandlerCalls reads path and returns every handlerCall string
+// passed to wrapScheduleCall() in it, in source order. Fails the test if the
+// script doesn't call wrapScheduleCall at all -- that would mean either the
+// script no longer registers any schedule.eval jobs (fine, caller should
+// only invoke this for scripts known to use the pattern) or #480's wrapper
+// silently stopped being used.
+func registeredHandlerCalls(t *testing.T, path string) []string {
+	t.Helper()
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	matches := wrapScheduleCallCallRe.FindAllStringSubmatch(string(buf), -1)
+	if len(matches) == 0 {
+		t.Fatalf("no wrapScheduleCall(...) call sites found in %s", path)
+	}
+	calls := make([]string, len(matches))
+	for i, m := range matches {
+		calls[i] = m[1]
+	}
+	return calls
+}
+
+// scheduleWrapBoilerplate is wrapScheduleCall()'s fixed template with the
+// handlerCall placeholder removed -- i.e. everything that surrounds every
+// registered handler call verbatim, in both pool-pump.js and garden.js. It is
+// asserted equal to the live source in TestScheduleWrap_BoilerplateMatchesSource
+// below so this constant cannot silently drift from the two scripts.
+const scheduleWrapBoilerplate = "(function(){try{" + "}catch(e){log('schedule handler error:',e)}})()"
+
+// assertNoHandlerNameCollisions is the #480 invariant the substring-match
+// fix in isWithinRunWindow()/updateScheduleMode()/verifySchedules()
+// (pool-pump.js) and updatePlanSchedule()/verifySchedules() (garden.js)
+// depends on: reading a wrapped `code` field back and matching it against a
+// handler name by containment only identifies the right job if no handler
+// name is ever a substring of another, and if the wrapper's own boilerplate
+// text never happens to contain a handler name. Both are true today only
+// because every handler call ends in "()" and the names themselves don't
+// nest -- exactly the kind of fact that quietly breaks when someone adds
+// e.g. handleMorningStartDelayed() next to handleMorningStart(). This turns
+// that invariant into something CI enforces instead of a comment.
+func assertNoHandlerNameCollisions(t *testing.T, scriptName string, handlerCalls []string) {
+	t.Helper()
+
+	seen := map[string]bool{}
+	for _, h := range handlerCalls {
+		seen[h] = true
+	}
+
+	unique := make([]string, 0, len(seen))
+	for h := range seen {
+		unique = append(unique, h)
+	}
+
+	for i, a := range unique {
+		for j, b := range unique {
+			if i == j {
+				continue
+			}
+			if strings.Contains(a, b) {
+				t.Errorf("%s: handler name %q contains %q as a substring -- "+
+					"substring-based Schedule.List matching (see wrapScheduleCall callers) "+
+					"cannot tell these two handlers' jobs apart", scriptName, a, b)
+			}
+		}
+		if strings.Contains(scheduleWrapBoilerplate, a) {
+			t.Errorf("%s: wrapper boilerplate itself contains handler name %q -- "+
+				"every job's code field would match this handler regardless of which "+
+				"handler it actually calls", scriptName, a)
+		}
+	}
+
+	if len(unique) < 2 {
+		t.Fatalf("%s: expected at least 2 distinct registered handler names to make this check "+
+			"meaningful, got %d (%v) -- did extraction break?", scriptName, len(unique), unique)
+	}
+}
+
+// TestScheduleWrap_PoolPumpHandlerNamesDontCollide is the #480 no-collision
+// guard for pool-pump.js's five schedule.eval jobs (handleDailyCheck,
+// handleMorningStart, handleEveningStop, handleNightStart, handleNightStop).
+func TestScheduleWrap_PoolPumpHandlerNamesDontCollide(t *testing.T) {
+	handlers := registeredHandlerCalls(t, poolPumpScriptPath)
+	assertNoHandlerNameCollisions(t, "pool-pump.js", handlers)
+}
+
+// TestScheduleWrap_GardenHandlerNamesDontCollide is the same guard for
+// garden.js's two schedule.eval jobs (handlePlan, handleWateringStart).
+func TestScheduleWrap_GardenHandlerNamesDontCollide(t *testing.T) {
+	handlers := registeredHandlerCalls(t, gardenScriptPath)
+	assertNoHandlerNameCollisions(t, "garden.js", handlers)
+}
+
+// TestScheduleWrap_BoilerplateMatchesSource keeps scheduleWrapBoilerplate
+// (used above to check the wrapper template itself doesn't accidentally
+// contain a handler name) from silently drifting away from what
+// wrapScheduleCall() actually emits in either script. If a script's wrapper
+// changes, this fails until the Go constant -- and the collision check it
+// backs -- is updated to match.
+func TestScheduleWrap_BoilerplateMatchesSource(t *testing.T) {
+	for _, path := range []string{poolPumpScriptPath, gardenScriptPath} {
+		buf, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", path, err)
+		}
+		src := string(buf)
+		re := regexp.MustCompile(`function wrapScheduleCall\(handlerCall\) \{\s*return "([^"]*)" \+ handlerCall \+ "([^"]*)";`)
+		m := re.FindStringSubmatch(src)
+		if m == nil {
+			t.Fatalf("%s: could not locate wrapScheduleCall()'s return statement -- "+
+				"update this test's regex if the implementation changed shape", path)
+		}
+		gotBoilerplate := m[1] + m[2]
+		if gotBoilerplate != scheduleWrapBoilerplate {
+			t.Errorf("%s: wrapScheduleCall() boilerplate is %q, test constant scheduleWrapBoilerplate is %q -- "+
+				"update the constant (and re-check for handler-name collisions against the new text)",
+				path, gotBoilerplate, scheduleWrapBoilerplate)
+		}
+	}
+}


### PR DESCRIPTION
## Why

An uncaught throw anywhere in a device script's task queue, scheduled handlers, or event/MQTT callbacks **kills the whole script** — silently, unattended, on a production pool pump. Everything it does stops with it: filtration, runtime accounting, water-supply protection.

Measured on `mezzanine` (Shelly Pro1) on 2026-08-12, all reproducible:

```
queueTask(function(){ null.x })                      -> script DEAD
Script.Eval with a bad expression                    -> script DEAD
Shelly.addEventHandler(fn that throws)  + switch toggle  -> script DEAD
Shelly.addStatusHandler(fn that throws) + switch toggle  -> script DEAD
MQTT.subscribe(topic, fn that throws)   + real publish   -> script DEAD
```

`pool-pump.js` alone has ~37 `queueTask()` call sites and registers all five of its scheduled actions as bare `script.eval` payloads. Any one of them could take the pump down.

## What changed

1. **Task-queue dispatch** — `processTaskQueue()`'s single `task()` call wrapped in `pool-pump.js`, `garden.js`, `blu-listener.js`. One change covering every queued task.
2. **`script.eval` payloads** — every schedule registration routed through a shared `wrapScheduleCall()` helper, so a future job cannot be added unwrapped.
3. **Event / status / MQTT callbacks** — wrapped **in place, adding no call frame at dispatch time**. This script is demonstrably at its interpreter stack ceiling (#474, #481), so a higher-order wrapper that added a frame per event was rejected deliberately.
4. **`AGENTS.md`** carries both rules, including the ad-hoc `Script.Eval` case — an unwrapped debug probe killed a device twice during this work.

## The design snag, and why there are 8 new tests

Wrapping the `code` field broke code that reads it back from a live `Schedule.List` and matches it **verbatim** — including `isWithinRunWindow()`, which is the predicate behind **#441**, where the pump did not start and the pool went unfiltered for two days. Its failure mode is returning `null` ("don't know"), which looks like nothing is wrong until you notice the pump never ran.

Fixed with substring containment, guarded by:
- tests seeding `Schedule.List` with **wrapped** code and asserting real booleans from `isWithinRunWindow()`, `updateScheduleMode()`, `verifySchedules()`, `updatePlanSchedule()`
- a **revert-and-confirm-fail** check, so the guard is proven to catch a regression to `===`
- a **no-collision invariant** test that extracts handler names from source by regex rather than hardcoding them, so it keeps holding when a handler is added

## Device verification (`mezzanine`, hash-verified)

Both headline criteria confirmed via device-side debug-UDP capture — the script logs the full error and `Script.GetStatus` reports `running: true` immediately after:

- `queueTask(function(){ null.x })` — previously fatal, now logged and survived
- a scheduled handler that throws — previously fatal, now logged and survived

**Heap cost: +14 bytes** `mem_peak` (origin/main vs this branch) at a reboot-clean, hash-verified checkpoint — inside the ~180 B reboot-to-reboot noise band measured on byte-identical code the same day. Full table with four configurations and sha256 hashes is on #480.

## Tests

```
make test  ->  47 packages ok, zero FAIL, 5m37s
```

Run by the coordinator on a quiesced machine. An earlier run showed one failure in `TestPoolPump_WaterSupplyFlapTrueThenFalse`; that was CPU contention (three concurrent test processes) — it passes 3/3 in isolation at 7.5 s and the clean full run is green. Same #393 timing sensitivity seen elsewhere this week.

## Filed, not fixed here

- **#481** — `pool-pump.js` crashes deterministically ~7–11 s into every boot on `mezzanine`, inside `setupMQTT()`'s own `log()` call. Reproduces on **unmodified `origin/main`** and across a full `Shelly.Reboot`, so it is pre-existing and not introduced here. Same failure class as #474 at a *different* call site. `filtration-hiver` (running `main`, solar disabled) is unaffected, so it appears config-dependent.
- **#482** — ~12 further scripts register the same handler APIs unwrapped. Deliberately out of this PR to keep it reviewable.

## Note

During device testing `myhome ctl`'s MQTT channel was unavailable for the whole session, while the device's own `mqtt.connected` stayed true and other clients reached it fine. Work continued over direct HTTP RPC with every upload hash-verified via `Script.GetCode` read-back, so no result depends on the CLI having worked. Root cause not chased; may deserve its own issue.

Closes #480.<!-- AUTO-GENERATED-COMMITS -->

## Commits

- safety(scripts): wrap task-queue dispatch and script.eval payloads (#480) ([83fcb2e](https://github.com/asnowfix/home-automation/commit/83fcb2e079aa052ce5bc0883ba9722746dc0e4b4))
- test(scripts): regression-guard the #480 substring-match fix ([73540f4](https://github.com/asnowfix/home-automation/commit/73540f4d6d9b37d979929d9e247d07037ab372e3))
- safety(scripts): wrap addEventHandler/addStatusHandler/MQTT.subscribe callbacks (#480 part 4) ([4ea03b7](https://github.com/asnowfix/home-automation/commit/4ea03b71ce32ad3ff8879773c4d5fe1c12486eea))
- docs(agents): record the handler-wrapping rule for addEventHandler/addStatusHandler/MQTT.subscribe ([09fcef1](https://github.com/asnowfix/home-automation/commit/09fcef15866c91a39cb05b3b240882cf20f6fe93))
<!-- END-AUTO-GENERATED-COMMITS -->